### PR TITLE
Added comparison.

### DIFF
--- a/src/__private.rs
+++ b/src/__private.rs
@@ -169,3 +169,7 @@ impl<U: Unsigned> Trim for U
 }
 
 // Note: Trimming is tested when we do subtraction.
+
+pub trait PrivateCmp<Rhs, SoFar> {
+    type Output;
+}

--- a/src/bit.rs
+++ b/src/bit.rs
@@ -1,4 +1,4 @@
-use ::{Not, And, Or, Xor, Same};
+use ::{Not, And, Or, Xor, Same, Cmp, Greater, Less, Equal};
 
 /// The compile time bit 0
 pub struct B0;
@@ -109,4 +109,20 @@ fn bit_operations() {
     test_bit_op!(B0 Xor B1 = B1);
     test_bit_op!(B1 Xor B0 = B1);
     test_bit_op!(B1 Xor B1 = B0);
+}
+
+impl Cmp<B0> for B0 {
+    type Output = Equal;
+}
+
+impl Cmp<B1> for B0 {
+    type Output = Less;
+}
+
+impl Cmp<B0> for B1 {
+    type Output = Greater;
+}
+
+impl Cmp<B1> for B1 {
+    type Output = Equal;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+use std::cmp::{Ordering};
 
 pub mod bit;
 
@@ -49,5 +50,28 @@ pub trait Div<Rhs = Self> {
     type Output;
 }
 pub trait Rem<Rhs = Self> {
+    type Output;
+}
+
+pub trait Ord {
+    fn to_ordering() -> Ordering;
+}
+
+pub struct Greater;
+pub struct Less;
+pub struct Equal;
+
+impl Ord for Greater {
+    fn to_ordering() -> Ordering { Ordering::Greater }
+}
+impl Ord for Less {
+    fn to_ordering() -> Ordering { Ordering::Less }
+}
+impl Ord for Equal {
+    fn to_ordering() -> Ordering { Ordering::Equal }
+}
+
+/// Compares `Self` and `Rhs`. Should only ever return one of `Greater`, `Less`, or `Equal`.
+pub trait Cmp<Rhs = Self> {
     type Output;
 }


### PR DESCRIPTION
This adds the empty structs `Greater`, `Less`, and `Equal`, as well as the trait `Ord` that they all implement, which includes the function `to_ordering()` that returns the appropriate enum variant from [std::cmp::Ordering](https://doc.rust-lang.org/std/cmp/enum.Ordering.html).

In addition, it adds the trait `Cmp<Rhs>` as a type operator with associated type `Output` that should always be one of `Greater`, `Less`, or `Equal`.

Finally, `Cmp` is implemented for both bits and uints.