### PR TITLE
Division!

### DIFF
--- a/src/__private.rs
+++ b/src/__private.rs
@@ -68,6 +68,30 @@ pub trait PrivateXor<Rhs = Self> {
 pub trait PrivateSub<Rhs = Self> {
     type Output;
 }
+
+pub trait PrivatePow<Y, N> {
+    type Output;
+}
+
+pub trait PrivateDiv<C, I, Q, Divisor> {
+    type Output;
+}
+
+pub trait PrivateDivFirstStep<C, Divisor> {
+    type Output;
+}
+
+/// Performs Shl on Lhs so that SizeOf(Lhs) = SizeOf(Rhs)
+/// Fails if SizeOf(Lhs) > SizeOf(Rhs)
+pub trait ShiftDiff<Rhs> {
+    type Output;
+}
+
+/// Gives SizeOf(Lhs) - SizeOf(Rhs)
+pub trait BitDiff<Rhs> {
+    type Output;
+}
+
 /// Inverted unsigned numbers
 pub trait InvertedUnsigned {
     fn to_int() -> u64;
@@ -175,24 +199,5 @@ impl<U: Unsigned> Trim for U
 // Note: Trimming is tested when we do subtraction.
 
 pub trait PrivateCmp<Rhs, SoFar> {
-    type Output;
-}
-
-/// Performs long division.
-/// RvsD is the result of comparing the remainder with the divisor (Rhs)
-/// I is the counter; it should start at N-1 and go to 0. N is the number of bits of the numberator.
-/// Q is the quotient so far
-/// R is the Remainder so far
-// pub trait PrivateDiv<RvsD, I, Quotient, Remainder, Rhs> {
-//     type Output;
-// }
-
-/// Gives the least significant bit
-pub trait LSB {
-    type Output;
-}
-
-/// Gives the bit at `Rhs`
-pub trait BitAt<Rhs> {
     type Output;
 }

--- a/src/__private.rs
+++ b/src/__private.rs
@@ -178,7 +178,21 @@ pub trait PrivateCmp<Rhs, SoFar> {
     type Output;
 }
 
-pub trait PrivateDiv<Rhs> {
-    type Quotient;
-    type Remainder;
+/// Performs long division.
+/// RvsD is the result of comparing the remainder with the divisor (Rhs)
+/// I is the counter; it should start at N-1 and go to 0. N is the number of bits of the numberator.
+/// Q is the quotient so far
+/// R is the Remainder so far
+// pub trait PrivateDiv<RvsD, I, Quotient, Remainder, Rhs> {
+//     type Output;
+// }
+
+/// Gives the least significant bit
+pub trait LSB {
+    type Output;
+}
+
+/// Gives the bit at `Rhs`
+pub trait BitAt<Rhs> {
+    type Output;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,9 @@ pub trait Div<Rhs = Self> {
 pub trait Rem<Rhs = Self> {
     type Output;
 }
+pub trait Pow<Rhs = Self> {
+    type Output;
+}
 
 
 pub trait Ord {

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -1011,7 +1011,7 @@ fn pow_uints() {
 //   # I > 0
 //   if C == Less: # Divisor is too big
 //     Call PrivateDiv with Divisor >> 1, I - 1
-//   if C == Equal: # Sweet, we're done eary with no remainder
+//   if C == Equal: # Sweet, we're done early with no remainder
 //     return Q + 2^I
 //   if C == Greater: # Do a step and keep going
 //     Q += 2^I

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -1217,6 +1217,9 @@ fn div_uints() {
     test_uint_op!(U27 Div U27 = U1);
 
     test_uint_op!(U81 Div U9 = U9);
+
+    test_uint_op!(U7 Div U3 = U2);
+    test_uint_op!(U7 Div U2 = U3);
 }
 
 // ---------------------------------------------------------------------------------------


### PR DESCRIPTION
Division is implemented for UInts.

While it does long division, it scales worse than it should. This is probably due to the very many where clauses required; hopefully Rust fixes will speed it up eventually.

We may also want to go over it again and try a different algorithm.

If it makes `cargo test` too slow, we can reduce the number of tests done.