### PR TITLE
hide __private from docs

### DIFF
--- a/src/__private/mod.rs
+++ b/src/__private/mod.rs
@@ -13,6 +13,8 @@ Just look away.
 Loooooooooooooooooooooooooooooooooook awaaaaaaaaaaaayyyyyyyyyyyyyyyyyyyyyyyyyyyyy...
  */
 
+#![doc(hidden)]
+
 pub mod build;
 
 use std::marker::PhantomData;


### PR DESCRIPTION
I think actually hiding the module is better than asking people to look away.