### PR TITLE
generically impl same

### DIFF
--- a/src/bit.rs
+++ b/src/bit.rs
@@ -11,7 +11,7 @@ other number types in this crate.
 
 */
 use std::ops::{BitAnd, BitOr, BitXor, Not};
-use { NonZero, Same, Cmp, Greater, Less, Equal };
+use {NonZero, Cmp, Greater, Less, Equal};
 
 /// The type-level bit 0.
 pub struct B0;
@@ -45,23 +45,16 @@ impl NonZero for B1 {}
 macro_rules! test_bit_op {
     ($op:ident $Lhs:ident = $Answer:ident) => (
         {
-            type Test = <<$Lhs as $op>::Output as Same<$Answer>>::Output;
+            type Test = <<$Lhs as $op>::Output as ::Same<$Answer>>::Output;
             assert_eq!(<$Answer as Bit>::to_u8(), <Test as Bit>::to_u8());
         }
         );
     ($Lhs:ident $op:ident $Rhs:ident = $Answer:ident) => (
         {
-            type Test = <<$Lhs as $op<$Rhs>>::Output as Same<$Answer>>::Output;
+            type Test = <<$Lhs as $op<$Rhs>>::Output as ::Same<$Answer>>::Output;
             assert_eq!(<$Answer as Bit>::to_u8(), <Test as Bit>::to_u8());
         }
         );
-}
-
-impl Same<B0> for B0 {
-    type Output = B0;
-}
-impl Same<B1> for B1 {
-    type Output = B1;
 }
 
 /// Not of 0 (!0 = 1)

--- a/src/int.rs
+++ b/src/int.rs
@@ -34,7 +34,7 @@ use std::marker::PhantomData;
 
 use std::ops::{Neg, Add, Sub, Mul, Div, Rem};
 
-use {NonZero, Same, Pow, Cmp, Greater, Equal, Less};
+use {NonZero, Pow, Cmp, Greater, Equal, Less};
 use uint::{Unsigned, UInt};
 use bit::{Bit, B0, B1};
 use __private::{PrivateIntegerAdd, PrivateDivInt, PrivateRem};
@@ -107,30 +107,18 @@ impl<U: Unsigned + NonZero> Integer for NInt<U> {
     #[inline] fn to_isize() -> isize { -<U as Unsigned>::to_isize() }
 }
 
-impl Same<Z0> for Z0 {
-    type Output = Z0;
-}
-
-impl<U: Unsigned + NonZero> Same<PInt<U>> for PInt<U> {
-    type Output = PInt<U>;
-}
-
-impl<U: Unsigned + NonZero> Same<NInt<U>> for NInt<U> {
-    type Output = NInt<U>;
-}
-
 // macro for testing operation results. Uses `Same` to ensure the types are equal and
 // not just the values they evaluate to.
 macro_rules! test_int_op {
     ($op:ident $Lhs:ident = $Answer:ident) => (
         {
-            type Test = <<$Lhs as $op>::Output as Same<$Answer>>::Output;
+            type Test = <<$Lhs as $op>::Output as ::Same<$Answer>>::Output;
             assert_eq!(<$Answer as Integer>::to_i64(), <Test as Integer>::to_i64());
         }
         );
     ($Lhs:ident $op:ident $Rhs:ident = $Answer:ident) => (
         {
-            type Test = <<$Lhs as $op<$Rhs>>::Output as Same<$Answer>>::Output;
+            type Test = <<$Lhs as $op<$Rhs>>::Output as ::Same<$Answer>>::Output;
             assert_eq!(<$Answer as Integer>::to_i64(), <Test as Integer>::to_i64());
         }
         );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,9 @@ pub trait NonZero {}
 A **type operator** that ensures that `Rhs` is the same as `Self`, it is mainly useful
 for writing macros that can take arbitrary binary or unary operators.
 
+`Same` is implemented generically for all types; it should never need to be implemented
+for anything else.
+
 Note that Rust lazily evaluates types, so this will only fail for two different types if
 the `Output` is used.
 
@@ -70,6 +73,10 @@ type Undefined = <U5 as Same<U4>>::Output;
 pub trait Same<Rhs = Self> {
     /// Should always be `Self`
     type Output;
+}
+
+impl<T> Same<T> for T {
+    type Output = T;
 }
 
 /**

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -33,7 +33,7 @@ assert_eq!(<U3 as Rem<U2>>::Output::to_u32(), 1);
 use std::marker::PhantomData;
 
 use std::ops::{BitAnd, BitOr, BitXor, Shl, Shr, Add, Sub, Mul, Div, Rem};
-use {NonZero, Same, Ord, Greater, Equal, Less, Cmp, Pow};
+use {NonZero, Ord, Greater, Equal, Less, Cmp, Pow};
 use bit::{Bit, B0, B1};
 use __private::{Trim, SizeOf, PrivateAnd, PrivateXor, PrivateSub, PrivateCmp, PrivateSizeOf,
                   ShiftDiff, PrivateDiv, PrivateDivFirstStep, PrivatePow, BitDiff};
@@ -124,22 +124,18 @@ impl<U: Unsigned, B: Bit> Unsigned for UInt<U, B> {
 
 impl<U: Unsigned, B: Bit> NonZero for UInt<U, B> {}
 
-impl<U: Unsigned> Same<U> for U {
-    type Output = U;
-}
-
 // macro for testing operation results. Uses `Same` to ensure the types are equal and
 // not just the values they evaluate to.
 macro_rules! test_uint_op {
     ($op:ident $Lhs:ident = $Answer:ident) => (
         {
-            type Test = <<$Lhs as $op>::Output as Same<$Answer>>::Output;
+            type Test = <<$Lhs as $op>::Output as ::Same<$Answer>>::Output;
             assert_eq!(<$Answer as Unsigned>::to_u64(), <Test as Unsigned>::to_u64());
         }
         );
     ($Lhs:ident $op:ident $Rhs:ident = $Answer:ident) => (
         {
-            type Test = <<$Lhs as $op<$Rhs>>::Output as Same<$Answer>>::Output;
+            type Test = <<$Lhs as $op<$Rhs>>::Output as ::Same<$Answer>>::Output;
             assert_eq!(<$Answer as Unsigned>::to_u64(), <Test as Unsigned>::to_u64());
         }
         );


### PR DESCRIPTION
This implements `Same` for all types everywhere, rather than just the ones in this crate.