### PR TITLE
Allow typenum to be built without the standard library.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,6 @@
 
 [lib]
   name = "typenum"
+
+[features]
+  no_std = []

--- a/src/__private/mod.rs
+++ b/src/__private/mod.rs
@@ -19,6 +19,7 @@ compelling case, it may be moved out of __private.
 
 #![doc(hidden)]
 
+#[cfg(not(feature="no_std"))]
 pub mod build;
 
 use std::marker::PhantomData;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,11 @@ assert_eq!(<X as Integer>::to_i32(), 7);
 
 Documented in each module is the full list of type operators implemented.
 */
+#![cfg_attr(feature="no_std", feature(core, no_std))]
+#![cfg_attr(feature="no_std", no_std)]
+#[cfg(feature="no_std")]
+extern crate core as std;
+
 use std::cmp::{Ordering};
 
 pub mod consts;

--- a/tests/builder/mod.rs
+++ b/tests/builder/mod.rs
@@ -1,1 +1,0 @@
-../../src/__private/build.rs

--- a/tests/builder/mod.rs
+++ b/tests/builder/mod.rs
@@ -1,0 +1,1 @@
+../../src/__private/build.rs

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -7,6 +7,7 @@ use std::process::Command;
 
 use builder::{gen_int, gen_uint};
 
+#[path="../src/__private/build.rs"]
 mod builder;
 
 fn sign(i: i64) -> char {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,5 +1,3 @@
-extern crate typenum;
-
 use std::env;
 use std::fs::File;
 use std::io::{Write, BufWriter};
@@ -7,7 +5,9 @@ use std::path::Path;
 use std::fmt;
 use std::process::Command;
 
-use typenum::__private::build::{gen_int, gen_uint};
+use builder::{gen_int, gen_uint};
+
+mod builder;
 
 fn sign(i: i64) -> char {
     if i > 0 { 'P' } else if i < 0 { 'N' } else { '_' }


### PR DESCRIPTION
The build.rs stuff is hacky, but should work.