### PR TITLE
Use empty enums instead of zero-sized structs

### DIFF
--- a/src/__private/mod.rs
+++ b/src/__private/mod.rs
@@ -61,7 +61,7 @@ pub trait PrivateSizeOf {
 }
 
 /// Terminating character for `InvertedUInt`s
-pub struct InvertedUTerm;
+pub enum InvertedUTerm {}
 
 /// Inverted UInt (has most significant digit on the outside)
 pub struct InvertedUInt<IU: InvertedUnsigned, B: Bit> {

--- a/src/bit.rs
+++ b/src/bit.rs
@@ -14,10 +14,10 @@ use std::ops::{BitAnd, BitOr, BitXor, Not};
 use {NonZero, Cmp, Greater, Less, Equal};
 
 /// The type-level bit 0.
-pub struct B0;
+pub enum B0 {}
 
 /// The type-level bit 1.
-pub struct B1;
+pub enum B1 {}
 
 /**
 The **marker trait** for compile time bits.

--- a/src/int.rs
+++ b/src/int.rs
@@ -57,7 +57,7 @@ pub struct NInt<U: Unsigned + NonZero> {
 /**
 The type-level signed integer 0.
 */
-pub struct Z0;
+pub enum Z0 {}
 
 /**
 The **marker trait** for compile time signed integers.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,13 +113,13 @@ pub trait Ord {
 
 /// A potential output from `Cmp`, this is the type equivalent to the enum variant
 /// `std::cmp::Ordering::Greater`.
-pub struct Greater;
+pub enum Greater {}
 /// A potential output from `Cmp`, this is the type equivalent to the enum variant
 /// `std::cmp::Ordering::Less`.
-pub struct Less;
+pub enum Less {}
 /// A potential output from `Cmp`, this is the type equivalent to the enum variant
 /// `std::cmp::Ordering::Equal`.
-pub struct Equal;
+pub enum Equal {}
 
 /// Returns `std::cmp::Ordering::Greater`
 impl Ord for Greater {

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -70,7 +70,7 @@ pub trait Unsigned {
 The terminating type for `UInt`; it always comes after the most significant bit. `UTerm`
  by itself represents zero, which is aliased to `U0`.
 */
-pub struct UTerm;
+pub enum UTerm {}
 
 impl Unsigned for UTerm {
     #[inline] fn to_u8() -> u8 { 0 }


### PR DESCRIPTION
This implements james-darkfox' suggestion to use empty enums for atom-structs.