### PR TITLE
Type operator aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,4 @@ This project follows semantic versioning.
 
 ### Unpublished
 - `[added]` This change log!
-- `[added]` Convenience type aliases for operators. ([Issues #48](https://github.com/paholg/typenum/issues/48))
+- `[added]` Convenience type aliases for operators. ([Issues #48](https://github.com/paholg/typenum/issues/48), [PR #50](https://github.com/paholg/typenum/pull/50))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+This project follows semantic versioning.
+
+### Unpublished
+- `[added]` This change log!
+- `[added]` Convenience type aliases for operators. ([Issues #48](https://github.com/paholg/typenum/issues/48))

--- a/src/__private/build.rs
+++ b/src/__private/build.rs
@@ -7,25 +7,21 @@ use std::fmt;
 pub enum UIntCode {
     Term,
     Zero(Box<UIntCode>),
-    One(Box<UIntCode>)
+    One(Box<UIntCode>),
 }
 
 pub enum IntCode {
     Zero,
     Pos(Box<UIntCode>),
-    Neg(Box<UIntCode>)
+    Neg(Box<UIntCode>),
 }
 
 impl fmt::Display for UIntCode {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             UIntCode::Term => write!(f, "UTerm"),
-            UIntCode::Zero(ref inner) => {
-                write!(f, "UInt<{}, B0>", inner)
-            },
-            UIntCode::One(ref inner) => {
-                write!(f, "UInt<{}, B1>", inner)
-            }
+            UIntCode::Zero(ref inner) => write!(f, "UInt<{}, B0>", inner),
+            UIntCode::One(ref inner) => write!(f, "UInt<{}, B1>", inner),
         }
     }
 }
@@ -34,22 +30,24 @@ impl fmt::Display for IntCode {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             IntCode::Zero => write!(f, "Z0"),
-            IntCode::Pos(ref inner) => {
-                write!(f, "PInt<{}>", inner)
-            },
-            IntCode::Neg(ref inner) => {
-                write!(f, "NInt<{}>", inner)
-            }
+            IntCode::Pos(ref inner) => write!(f, "PInt<{}>", inner),
+            IntCode::Neg(ref inner) => write!(f, "NInt<{}>", inner),
         }
     }
 }
 
-pub fn gen_uint(u: u64)  -> UIntCode {
+pub fn gen_uint(u: u64) -> UIntCode {
     let mut result = UIntCode::Term;
     let mut x = 1u64 << 63;
-    while x > u { x = x >> 1 }
+    while x > u {
+        x = x >> 1
+    }
     while x > 0 {
-        result = if x & u > 0 { UIntCode::One(Box::new(result)) } else { UIntCode::Zero(Box::new(result)) };
+        result = if x & u > 0 {
+            UIntCode::One(Box::new(result))
+        } else {
+            UIntCode::Zero(Box::new(result))
+        };
         x = x >> 1;
     }
     result
@@ -58,11 +56,9 @@ pub fn gen_uint(u: u64)  -> UIntCode {
 pub fn gen_int(i: i64) -> IntCode {
     if i > 0 {
         IntCode::Pos(Box::new(gen_uint(i as u64)))
-    }
-    else if i < 0 {
+    } else if i < 0 {
         IntCode::Neg(Box::new(gen_uint(i.abs() as u64)))
-    }
-    else {
+    } else {
         IntCode::Zero
     }
 }
@@ -76,10 +72,9 @@ fn main() {
 
     let first2: u32 = (highest as f64).log(2.0) as u32 + 1;
     let first10: u32 = (highest as f64).log(10.0) as u32 + 1;
-    let uints = (0..(highest+1))
-        .chain((first2..64).map(|i| 2u64.pow(i))) // powers of 2
-        .chain((first10..20).map(|i| 10u64.pow(i))) // powers of 10
-        ;
+    let uints = (0..(highest + 1))
+                    .chain((first2..64).map(|i| 2u64.pow(i)))
+                    .chain((first10..20).map(|i| 10u64.pow(i)));
 
 
     let out_dir = env::var("OUT_DIR").unwrap();
@@ -94,7 +89,8 @@ use uint::{UInt, UTerm};
 use int::{PInt, NInt};
 
 pub use int::Z0; // re-export for convenience.
-").unwrap();
+")
+     .unwrap();
 
     for u in uints {
         write!(f, "pub type U{} = {};\n", u, gen_uint(u)).unwrap();

--- a/src/__private/mod.rs
+++ b/src/__private/mod.rs
@@ -1,21 +1,24 @@
-/*!
-**Ignore me!** This module is for things that are conceptually private but that must be made public for
-typenum to work correctly.
-
-Unless you are working on typenum itself, **there is no need to view anything here**.
-
-Certainly don't implement any of the traits here for anything.
-
-
-Just look away.
-
-
-Loooooooooooooooooooooooooooooooooook awaaaaaaaaaaaayyyyyyyyyyyyyyyyyyyyyyyyyyyyy...
-
-
-If you do manage to find something of use in here, please let me know. If you can make a
-compelling case, it may be moved out of __private.
- */
+// !
+// *Ignore me!** This module is for things that are conceptually private but that must be made public for
+// typenum to work correctly.
+//
+// Unless you are working on typenum itself, **there is no need to view anything here**.
+//
+// Certainly don't implement any of the traits here for anything.
+//
+//
+// Just look away.
+//
+//
+// Loooooooooooooooooooooooooooooooooook awaaaaaaaaaaaayyyyyyyyyyyyyyyyyyyyyyyyyyyyy...
+//
+//
+// If you do manage to find something of use in here, please let me know. If you can make a
+// compelling case, it may be moved out of __private.
+//
+// Note: Aliases for private type operators will all be named simply that operator followed
+// by an abbreviated name of its associated type.
+//
 
 #![doc(hidden)]
 
@@ -32,11 +35,13 @@ use uint::{Unsigned, UInt, UTerm};
 pub trait SizeOf {
     type Output;
 }
+pub type SizeOfOut<A> = <A as SizeOf>::Output;
 
 /// Convenience trait. Calls Invert -> TrimTrailingZeros -> Invert
 pub trait Trim {
     type Output;
 }
+pub type TrimOut<A> = <A as Trim>::Output;
 
 /// Gets rid of all zeros until it hits a one.
 
@@ -44,44 +49,52 @@ pub trait Trim {
 pub trait TrimTrailingZeros {
     type Output;
 }
+pub type TrimTrailingZerosOut<A> = <A as TrimTrailingZeros>::Output;
 
 /// Converts between standard numbers and inverted ones that have the most significant
 /// digit on the outside.
 pub trait Invert {
     type Output;
 }
+pub type InvertOut<A> = <A as Invert>::Output;
+
 /// Doubly private! Called by invert to make the magic happen once its done the first step.
 /// The Rhs is what we've got so far.
 pub trait PrivateInvert<Rhs> {
     type Output;
 }
+pub type PrivateInvertOut<A, Rhs> = <A as PrivateInvert<Rhs>>::Output;
 
 pub trait PrivateSizeOf {
     type Output;
 }
+pub type PrivateSizeOfOut<A> = <A as PrivateSizeOf>::Output;
 
 /// Terminating character for `InvertedUInt`s
 pub enum InvertedUTerm {}
 
 /// Inverted UInt (has most significant digit on the outside)
 pub struct InvertedUInt<IU: InvertedUnsigned, B: Bit> {
-    _marker: PhantomData<(IU, B)>
+    _marker: PhantomData<(IU, B)>,
 }
 
 /// Does the real anding for `UInt`s; `And` just calls this and then `Trim`.
 pub trait PrivateAnd<Rhs = Self> {
     type Output;
 }
+pub type PrivateAndOut<A, Rhs> = <A as PrivateAnd<Rhs>>::Output;
 
 /// Does the real xoring for `UInt`s; `Xor` just calls this and then `Trim`.
 pub trait PrivateXor<Rhs = Self> {
     type Output;
 }
+pub type PrivateXorOut<A, Rhs> = <A as PrivateXor<Rhs>>::Output;
 
 /// Does the real subtraction for `UInt`s; `Sub` just calls this and then `Trim`.
 pub trait PrivateSub<Rhs = Self> {
     type Output;
 }
+pub type PrivateSubOut<A, Rhs> = <A as PrivateSub<Rhs>>::Output;
 
 /// Used for addition of signed integers; C = P.cmp(N)
 /// Assumes P = Self is positive and N is negative
@@ -89,39 +102,56 @@ pub trait PrivateSub<Rhs = Self> {
 pub trait PrivateIntegerAdd<C, N> {
     type Output;
 }
+pub type PrivateIntegerAddOut<P, C, N> =
+    <P as PrivateIntegerAdd<C, N>>::Output;
 
 pub trait PrivatePow<Y, N> {
     type Output;
 }
+pub type PrivatePowOut<A, Y, N> = <A as PrivatePow<Y, N>>::Output;
 
 pub trait PrivateDiv<C, I, Q, Divisor> {
     type Quotient;
     type Remainder;
 }
+pub type PrivateDivQuot<R, C, I, Q, Divisor> =
+    <R as PrivateDiv<C, I, Q, Divisor>>::Quotient;
+pub type PrivateDivRem<R, C, I, Q, Divisor> =
+    <R as PrivateDiv<C, I, Q, Divisor>>::Remainder;
 
 pub trait PrivateDivFirstStep<C, Divisor> {
     type Quotient;
     type Remainder;
 }
+pub type PrivateDivFirstStepQuot<R, C, Divisor> =
+    <R as PrivateDivFirstStep<C, Divisor>>::Quotient;
+pub type PrivateDivFirstStepRem<R, C, Divisor> =
+    <R as PrivateDivFirstStep<C, Divisor>>::Remainder;
 
 pub trait PrivateDivInt<C, Divisor> {
     type Output;
 }
+pub type PrivateDivIntOut<A, C, Divisor> =
+    <A as PrivateDivInt<C, Divisor>>::Output;
 
 pub trait PrivateRem<URem, Divisor> {
     type Output;
 }
+pub type PrivateRemOut<A, URem, Divisor> =
+    <A as PrivateRem<URem, Divisor>>::Output;
 
 /// Performs Shl on Lhs so that SizeOf(Lhs) = SizeOf(Rhs)
 /// Fails if SizeOf(Lhs) > SizeOf(Rhs)
 pub trait ShiftDiff<Rhs> {
     type Output;
 }
+pub type ShiftDiffOut<A, Rhs> = <A as ShiftDiff<Rhs>>::Output;
 
 /// Gives SizeOf(Lhs) - SizeOf(Rhs)
 pub trait BitDiff<Rhs> {
     type Output;
 }
+pub type BitDiffOut<A, Rhs> = <A as BitDiff<Rhs>>::Output;
 
 /// Inverted unsigned numbers
 pub trait InvertedUnsigned {
@@ -129,7 +159,9 @@ pub trait InvertedUnsigned {
 }
 
 impl InvertedUnsigned for InvertedUTerm {
-    fn to_u64() -> u64 { 0 }
+    fn to_u64() -> u64 {
+        0
+    }
 }
 
 impl<IU: InvertedUnsigned, B: Bit> InvertedUnsigned for InvertedUInt<IU, B> {
@@ -145,7 +177,7 @@ impl Invert for UTerm {
 impl<U: Unsigned, B: Bit> Invert for UInt<U, B>
     where U: PrivateInvert<InvertedUInt<InvertedUTerm, B>>
 {
-    type Output = <U as PrivateInvert<InvertedUInt<InvertedUTerm, B>>>::Output;
+    type Output = PrivateInvertOut<U, InvertedUInt<InvertedUTerm, B>>;
 }
 
 
@@ -156,7 +188,7 @@ impl<IU: InvertedUnsigned> PrivateInvert<IU> for UTerm {
 impl<IU: InvertedUnsigned, U: Unsigned, B: Bit> PrivateInvert<IU> for UInt<U, B>
     where U: PrivateInvert<InvertedUInt<IU, B>>
 {
-    type Output = <U as PrivateInvert<InvertedUInt<IU, B>>>::Output;
+    type Output = PrivateInvertOut<U, InvertedUInt<IU, B>>;
 }
 
 #[test]
@@ -213,8 +245,7 @@ impl<IU: InvertedUnsigned> TrimTrailingZeros for InvertedUInt<IU, B1> {
     type Output = Self;
 }
 
-impl<IU: InvertedUnsigned> TrimTrailingZeros for InvertedUInt<IU, B0>
-    where IU: TrimTrailingZeros
+impl<IU: InvertedUnsigned> TrimTrailingZeros for InvertedUInt<IU, B0> where IU: TrimTrailingZeros
 {
     type Output = <IU as TrimTrailingZeros>::Output;
 }
@@ -232,3 +263,4 @@ impl<U: Unsigned> Trim for U
 pub trait PrivateCmp<Rhs, SoFar> {
     type Output;
 }
+pub type PrivateCmpOut<A, Rhs, SoFar> = <A as PrivateCmp<Rhs, SoFar>>::Output;

--- a/src/bit.rs
+++ b/src/bit.rs
@@ -4,12 +4,12 @@ Type-level bits. These are rather simple and are used as the building blocks of 
 other number types in this crate.
 
 
-**Type operators** implemented:
+*Type operators** implemented:
 
-* From std::ops: `BitAnd`, `BitOr`, `BitXor`, and `Not`.
-* From typenum: `Same` and `Cmp`.
-
+From std::ops: `BitAnd`, `BitOr`, `BitXor`, and `Not`.
+From typenum: `Same` and `Cmp`.
 */
+
 use std::ops::{BitAnd, BitOr, BitXor, Not};
 use {NonZero, Cmp, Greater, Less, Equal};
 
@@ -30,12 +30,24 @@ pub trait Bit {
 }
 
 impl Bit for B0 {
-    #[inline] fn to_u8() -> u8 { 0 }
-    #[inline] fn to_bool() -> bool { false }
+    #[inline]
+    fn to_u8() -> u8 {
+        0
+    }
+    #[inline]
+    fn to_bool() -> bool {
+        false
+    }
 }
 impl Bit for B1 {
-    #[inline] fn to_u8() -> u8 { 1 }
-    #[inline] fn to_bool() -> bool { true }
+    #[inline]
+    fn to_u8() -> u8 {
+        1
+    }
+    #[inline]
+    fn to_bool() -> bool {
+        true
+    }
 }
 
 impl NonZero for B1 {}
@@ -60,55 +72,75 @@ macro_rules! test_bit_op {
 /// Not of 0 (!0 = 1)
 impl Not for B0 {
     type Output = B1;
-    fn not(self) -> Self::Output { unreachable!() }
+    fn not(self) -> Self::Output {
+        unreachable!()
+    }
 }
 /// Not of 1 (!1 = 0)
 impl Not for B1 {
     type Output = B0;
-    fn not(self) -> Self::Output { unreachable!() }
+    fn not(self) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// And with 0 ( 0 & B = 0)
 impl<Rhs: Bit> BitAnd<Rhs> for B0 {
     type Output = B0;
-    fn bitand(self, _: Rhs) -> Self::Output { unreachable!() }
+    fn bitand(self, _: Rhs) -> Self::Output {
+        unreachable!()
+    }
 }
 /// And with 1 ( 1 & B = B)
 impl<Rhs: Bit> BitAnd<Rhs> for B1 {
     type Output = Rhs;
-    fn bitand(self, _: Rhs) -> Self::Output { unreachable!() }
+    fn bitand(self, _: Rhs) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// Or with 0 ( 0 | B = B)
 impl<Rhs: Bit> BitOr<Rhs> for B0 {
     type Output = Rhs;
-    fn bitor(self, _: Rhs) -> Self::Output { unreachable!() }
+    fn bitor(self, _: Rhs) -> Self::Output {
+        unreachable!()
+    }
 }
 /// Or with 1 ( 1 | B = 1)
 impl<Rhs: Bit> BitOr<Rhs> for B1 {
     type Output = B1;
-    fn bitor(self, _: Rhs) -> Self::Output { unreachable!() }
+    fn bitor(self, _: Rhs) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// Xor between 0 and 0 ( 0 ^ 0 = 0)
 impl BitXor<B0> for B0 {
     type Output = B0;
-    fn bitxor(self, _: B0) -> Self::Output { unreachable!() }
+    fn bitxor(self, _: B0) -> Self::Output {
+        unreachable!()
+    }
 }
 /// Xor between 1 and 0 ( 1 ^ 0 = 1)
 impl BitXor<B0> for B1 {
     type Output = B1;
-    fn bitxor(self, _: B0) -> Self::Output { unreachable!() }
+    fn bitxor(self, _: B0) -> Self::Output {
+        unreachable!()
+    }
 }
 /// Xor between 0 and 1 ( 0 ^ 1 = 1)
 impl BitXor<B1> for B0 {
     type Output = B1;
-    fn bitxor(self, _: B1) -> Self::Output { unreachable!() }
+    fn bitxor(self, _: B1) -> Self::Output {
+        unreachable!()
+    }
 }
 /// Xor between 1 and 1 ( 1 ^ 1 = 0)
 impl BitXor<B1> for B1 {
     type Output = B0;
-    fn bitxor(self, _: B1) -> Self::Output { unreachable!() }
+    fn bitxor(self, _: B1) -> Self::Output {
+        unreachable!()
+    }
 }
 
 #[test]

--- a/src/int.rs
+++ b/src/int.rs
@@ -3,10 +3,10 @@
 Type-level signed integers.
 
 
-**Type operators** implemented:
+*Type operators** implemented:
 
-* From std::ops: `Add`, `Sub`, `Mul`, `Div`, and `Rem`.
-* From typenum: `Same`, `Cmp`, and `Pow`.
+From std::ops: `Add`, `Sub`, `Mul`, `Div`, and `Rem`.
+From typenum: `Same`, `Cmp`, and `Pow`.
 
 Rather than directly using the structs defined in this module, it is recommended that
 you import and use the relevant aliases from the [consts](../consts/index.html) module.
@@ -44,14 +44,14 @@ use consts::{U0, U1, P1, N1};
 Type-level signed integers with positive sign.
 */
 pub struct PInt<U: Unsigned + NonZero> {
-    _marker: PhantomData<U>
+    _marker: PhantomData<U>,
 }
 
 /**
 Type-level signed integers with negative sign.
 */
 pub struct NInt<U: Unsigned + NonZero> {
-    _marker: PhantomData<U>
+    _marker: PhantomData<U>,
 }
 
 /**
@@ -84,27 +84,72 @@ impl<U: Unsigned + NonZero> NonZero for PInt<U> {}
 impl<U: Unsigned + NonZero> NonZero for NInt<U> {}
 
 impl Integer for Z0 {
-    #[inline] fn to_i8() -> i8 { 0 }
-    #[inline] fn to_i16() -> i16 { 0 }
-    #[inline] fn to_i32() -> i32 { 0 }
-    #[inline] fn to_i64() -> i64 { 0 }
-    #[inline] fn to_isize() -> isize { 0 }
+    #[inline]
+    fn to_i8() -> i8 {
+        0
+    }
+    #[inline]
+    fn to_i16() -> i16 {
+        0
+    }
+    #[inline]
+    fn to_i32() -> i32 {
+        0
+    }
+    #[inline]
+    fn to_i64() -> i64 {
+        0
+    }
+    #[inline]
+    fn to_isize() -> isize {
+        0
+    }
 }
 
 impl<U: Unsigned + NonZero> Integer for PInt<U> {
-    #[inline] fn to_i8() -> i8 { <U as Unsigned>::to_i8() }
-    #[inline] fn to_i16() -> i16 { <U as Unsigned>::to_i16() }
-    #[inline] fn to_i32() -> i32 { <U as Unsigned>::to_i32() }
-    #[inline] fn to_i64() -> i64 { <U as Unsigned>::to_i64() }
-    #[inline] fn to_isize() -> isize { <U as Unsigned>::to_isize() }
+    #[inline]
+    fn to_i8() -> i8 {
+        <U as Unsigned>::to_i8()
+    }
+    #[inline]
+    fn to_i16() -> i16 {
+        <U as Unsigned>::to_i16()
+    }
+    #[inline]
+    fn to_i32() -> i32 {
+        <U as Unsigned>::to_i32()
+    }
+    #[inline]
+    fn to_i64() -> i64 {
+        <U as Unsigned>::to_i64()
+    }
+    #[inline]
+    fn to_isize() -> isize {
+        <U as Unsigned>::to_isize()
+    }
 }
 
 impl<U: Unsigned + NonZero> Integer for NInt<U> {
-    #[inline] fn to_i8() -> i8 { -<U as Unsigned>::to_i8() }
-    #[inline] fn to_i16() -> i16 { -<U as Unsigned>::to_i16() }
-    #[inline] fn to_i32() -> i32 { -<U as Unsigned>::to_i32() }
-    #[inline] fn to_i64() -> i64 { -<U as Unsigned>::to_i64() }
-    #[inline] fn to_isize() -> isize { -<U as Unsigned>::to_isize() }
+    #[inline]
+    fn to_i8() -> i8 {
+        -<U as Unsigned>::to_i8()
+    }
+    #[inline]
+    fn to_i16() -> i16 {
+        -<U as Unsigned>::to_i16()
+    }
+    #[inline]
+    fn to_i32() -> i32 {
+        -<U as Unsigned>::to_i32()
+    }
+    #[inline]
+    fn to_i64() -> i64 {
+        -<U as Unsigned>::to_i64()
+    }
+    #[inline]
+    fn to_isize() -> isize {
+        -<U as Unsigned>::to_isize()
+    }
 }
 
 // macro for testing operation results. Uses `Same` to ensure the types are equal and
@@ -130,19 +175,25 @@ macro_rules! test_int_op {
 /// `-Z0 = Z0`
 impl Neg for Z0 {
     type Output = Z0;
-    fn neg(self) -> Self::Output { unreachable!() }
+    fn neg(self) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// `-PInt = NInt`
 impl<U: Unsigned + NonZero> Neg for PInt<U> {
     type Output = NInt<U>;
-    fn neg(self) -> Self::Output { unreachable!() }
+    fn neg(self) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// `-NInt = PInt`
 impl<U: Unsigned + NonZero> Neg for NInt<U> {
     type Output = PInt<U>;
-    fn neg(self) -> Self::Output { unreachable!() }
+    fn neg(self) -> Self::Output {
+        unreachable!()
+    }
 }
 
 // ---------------------------------------------------------------------------------------
@@ -151,19 +202,25 @@ impl<U: Unsigned + NonZero> Neg for NInt<U> {
 /// `Z0 + I = I`
 impl<I: Integer> Add<I> for Z0 {
     type Output = I;
-    fn add(self, _: I) -> Self::Output { unreachable!() }
+    fn add(self, _: I) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// `PInt + Z0 = PInt`
 impl<U: Unsigned + NonZero> Add<Z0> for PInt<U> {
     type Output = PInt<U>;
-    fn add(self, _: Z0) -> Self::Output { unreachable!() }
+    fn add(self, _: Z0) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// `NInt + Z0 = NInt`
 impl<U: Unsigned + NonZero> Add<Z0> for NInt<U> {
     type Output = NInt<U>;
-    fn add(self, _: Z0) -> Self::Output { unreachable!() }
+    fn add(self, _: Z0) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// `P(Ul) + P(Ur) = P(Ul + Ur)`
@@ -172,7 +229,9 @@ impl<Ul: Unsigned + NonZero, Ur: Unsigned + NonZero> Add<PInt<Ur>> for PInt<Ul>
           <Ul as Add<Ur>>::Output: Unsigned + NonZero
 {
     type Output = PInt<<Ul as Add<Ur>>::Output>;
-    fn add(self, _: PInt<Ur>) -> Self::Output { unreachable!() }
+    fn add(self, _: PInt<Ur>) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// `N(Ul) + N(Ur) = N(Ul + Ur)`
@@ -181,7 +240,9 @@ impl<Ul: Unsigned + NonZero, Ur: Unsigned + NonZero> Add<NInt<Ur>> for NInt<Ul>
           <Ul as Add<Ur>>::Output: Unsigned + NonZero
 {
     type Output = NInt<<Ul as Add<Ur>>::Output>;
-    fn add(self, _: NInt<Ur>) -> Self::Output { unreachable!() }
+    fn add(self, _: NInt<Ur>) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// `P(Ul) + N(Ur)`: We resolve this with our `PrivateAdd`
@@ -191,7 +252,9 @@ impl<Ul: Unsigned + NonZero, Ur: Unsigned + NonZero> Add<NInt<Ur>> for PInt<Ul>
     type Output = <Ul as PrivateIntegerAdd<
         <Ul as Cmp<Ur>>::Output, Ur
         >>::Output;
-    fn add(self, _: NInt<Ur>) -> Self::Output { unreachable!() }
+    fn add(self, _: NInt<Ur>) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// `P(Ul) + P(Ur)`: We resolve this with our `PrivateAdd`
@@ -202,7 +265,9 @@ impl<Ul: Unsigned + NonZero, Ur: Unsigned + NonZero> Add<PInt<Ur>> for NInt<Ul>
     type Output = <Ur as PrivateIntegerAdd<
         <Ur as Cmp<Ul>>::Output, Ul
         >>::Output;
-    fn add(self, _: PInt<Ur>) -> Self::Output { unreachable!() }
+    fn add(self, _: PInt<Ur>) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// `P + N = 0` where `P == N`
@@ -232,31 +297,41 @@ impl<N: Unsigned, P: Unsigned> PrivateIntegerAdd<Less, N> for P
 /// `Z0 - Z0 = Z0`
 impl Sub<Z0> for Z0 {
     type Output = Z0;
-    fn sub(self, _: Z0) -> Self::Output { unreachable!() }
+    fn sub(self, _: Z0) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// `Z0 - P = N`
 impl<U: Unsigned + NonZero> Sub<PInt<U>> for Z0 {
     type Output = NInt<U>;
-    fn sub(self, _: PInt<U>) -> Self::Output { unreachable!() }
+    fn sub(self, _: PInt<U>) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// `Z0 - N = P`
 impl<U: Unsigned + NonZero> Sub<NInt<U>> for Z0 {
     type Output = PInt<U>;
-    fn sub(self, _: NInt<U>) -> Self::Output { unreachable!() }
+    fn sub(self, _: NInt<U>) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// `PInt - Z0 = PInt`
 impl<U: Unsigned + NonZero> Sub<Z0> for PInt<U> {
     type Output = PInt<U>;
-    fn sub(self, _: Z0) -> Self::Output { unreachable!() }
+    fn sub(self, _: Z0) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// `NInt - Z0 = NInt`
 impl<U: Unsigned + NonZero> Sub<Z0> for NInt<U> {
     type Output = NInt<U>;
-    fn sub(self, _: Z0) -> Self::Output { unreachable!() }
+    fn sub(self, _: Z0) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// `P(Ul) - N(Ur) = P(Ul + Ur)`
@@ -265,7 +340,9 @@ impl<Ul: Unsigned + NonZero, Ur: Unsigned + NonZero> Sub<NInt<Ur>> for PInt<Ul>
           <Ul as Add<Ur>>::Output: Unsigned + NonZero
 {
     type Output = PInt<<Ul as Add<Ur>>::Output>;
-    fn sub(self, _: NInt<Ur>) -> Self::Output { unreachable!() }
+    fn sub(self, _: NInt<Ur>) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// `N(Ul) - P(Ur) = N(Ul + Ur)`
@@ -274,7 +351,9 @@ impl<Ul: Unsigned + NonZero, Ur: Unsigned + NonZero> Sub<PInt<Ur>> for NInt<Ul>
           <Ul as Add<Ur>>::Output: Unsigned + NonZero
 {
     type Output = NInt<<Ul as Add<Ur>>::Output>;
-    fn sub(self, _: PInt<Ur>) -> Self::Output { unreachable!() }
+    fn sub(self, _: PInt<Ur>) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// `P(Ul) - P(Ur)`: We resolve this with our `PrivateAdd`
@@ -284,7 +363,9 @@ impl<Ul: Unsigned + NonZero, Ur: Unsigned + NonZero> Sub<PInt<Ur>> for PInt<Ul>
     type Output = <Ul as PrivateIntegerAdd<
         <Ul as Cmp<Ur>>::Output, Ur
         >>::Output;
-    fn sub(self, _: PInt<Ur>) -> Self::Output { unreachable!() }
+    fn sub(self, _: PInt<Ur>) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// `N(Ul) - N(Ur)`: We resolve this with our `PrivateAdd`
@@ -295,7 +376,9 @@ impl<Ul: Unsigned + NonZero, Ur: Unsigned + NonZero> Sub<NInt<Ur>> for NInt<Ul>
     type Output = <Ur as PrivateIntegerAdd<
         <Ur as Cmp<Ul>>::Output, Ul
         >>::Output;
-    fn sub(self, _: NInt<Ur>) -> Self::Output { unreachable!() }
+    fn sub(self, _: NInt<Ur>) -> Self::Output {
+        unreachable!()
+    }
 }
 
 // ---------------------------------------------------------------------------------------
@@ -304,19 +387,25 @@ impl<Ul: Unsigned + NonZero, Ur: Unsigned + NonZero> Sub<NInt<Ur>> for NInt<Ul>
 /// `Z0 * I = Z0`
 impl<I: Integer> Mul<I> for Z0 {
     type Output = Z0;
-    fn mul(self, _: I) -> Self::Output { unreachable!() }
+    fn mul(self, _: I) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// `P * Z0 = Z0`
 impl<U: Unsigned + NonZero> Mul<Z0> for PInt<U> {
     type Output = Z0;
-    fn mul(self, _: Z0) -> Self::Output { unreachable!() }
+    fn mul(self, _: Z0) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// `N * Z0 = Z0`
 impl<U: Unsigned + NonZero> Mul<Z0> for NInt<U> {
     type Output = Z0;
-    fn mul(self, _: Z0) -> Self::Output { unreachable!() }
+    fn mul(self, _: Z0) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// P(Ul) * P(Ur) = P(Ul * Ur)
@@ -325,7 +414,9 @@ impl<Ul: Unsigned + NonZero, Ur: Unsigned + NonZero> Mul<PInt<Ur>> for PInt<Ul>
           <Ul as Mul<Ur>>::Output: Unsigned + NonZero
 {
     type Output = PInt<<Ul as Mul<Ur>>::Output>;
-    fn mul(self, _: PInt<Ur>) -> Self::Output { unreachable!() }
+    fn mul(self, _: PInt<Ur>) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// N(Ul) * N(Ur) = P(Ul * Ur)
@@ -334,7 +425,9 @@ impl<Ul: Unsigned + NonZero, Ur: Unsigned + NonZero> Mul<NInt<Ur>> for NInt<Ul>
           <Ul as Mul<Ur>>::Output: Unsigned + NonZero
 {
     type Output = PInt<<Ul as Mul<Ur>>::Output>;
-    fn mul(self, _: NInt<Ur>) -> Self::Output { unreachable!() }
+    fn mul(self, _: NInt<Ur>) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// P(Ul) * N(Ur) = N(Ul * Ur)
@@ -343,7 +436,9 @@ impl<Ul: Unsigned + NonZero, Ur: Unsigned + NonZero> Mul<NInt<Ur>> for PInt<Ul>
           <Ul as Mul<Ur>>::Output: Unsigned + NonZero
 {
     type Output = NInt<<Ul as Mul<Ur>>::Output>;
-    fn mul(self, _: NInt<Ur>) -> Self::Output { unreachable!() }
+    fn mul(self, _: NInt<Ur>) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// N(Ul) * P(Ur) = N(Ul * Ur)
@@ -352,7 +447,9 @@ impl<Ul: Unsigned + NonZero, Ur: Unsigned + NonZero> Mul<PInt<Ur>> for NInt<Ul>
           <Ul as Mul<Ur>>::Output: Unsigned + NonZero
 {
     type Output = NInt<<Ul as Mul<Ur>>::Output>;
-    fn mul(self, _: PInt<Ur>) -> Self::Output { unreachable!() }
+    fn mul(self, _: PInt<Ur>) -> Self::Output {
+        unreachable!()
+    }
 }
 
 // ---------------------------------------------------------------------------------------
@@ -361,7 +458,9 @@ impl<Ul: Unsigned + NonZero, Ur: Unsigned + NonZero> Mul<PInt<Ur>> for NInt<Ul>
 /// `Z0 / I = Z0` where `I != 0`
 impl<I: Integer + NonZero> Div<I> for Z0 {
     type Output = Z0;
-    fn div(self, _: I) -> Self::Output { unreachable!() }
+    fn div(self, _: I) -> Self::Output {
+        unreachable!()
+    }
 }
 
 macro_rules! impl_int_div {
@@ -471,7 +570,9 @@ macro_rules! test_ord {
 /// `Z0 % I = Z0` where `I != 0`
 impl<I: Integer + NonZero> Rem<I> for Z0 {
     type Output = Z0;
-    fn rem(self, _: I) -> Self::Output { unreachable!() }
+    fn rem(self, _: I) -> Self::Output {
+        unreachable!()
+    }
 }
 
 macro_rules! impl_int_rem {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,26 +203,6 @@ pub type Add1<A> = <A as Add<bit::B1>>::Output;
 /// Alias to make it easy to subtract 1: `Sub1<A> = <A as Sub<B1>>::Output`
 pub type Sub1<A> = <A as Sub<bit::B1>>::Output;
 
-/// Alias to make it easy to multiply by `U2`: `MulU2<A> = <A as Mul<U2>>::Output`
-pub type MulU2<A> = <A as Mul<consts::U2>>::Output;
-/// Alias to make it easy to multiply by `U10`: `MulU10<A> = <A as Mul<U10>>::Output`
-pub type MulU10<A> = <A as Mul<consts::U10>>::Output;
-
-/// Alias to make it easy to multiply by `P2`: `MulP2<A> = <A as Mul<P2>>::Output`
-pub type MulP2<A> = <A as Mul<consts::P2>>::Output;
-/// Alias to make it easy to multiply by `P10`: `MulP10<A> = <A as Mul<P10>>::Output`
-pub type MulP10<A> = <A as Mul<consts::P10>>::Output;
-
-/// Alias to make it easy to divide by `U2`: `DivU2<A> = <A as Div<U2>>::Output`
-pub type DivU2<A> = <A as Div<consts::U2>>::Output;
-/// Alias to make it easy to divide by `U10`: `DivU10<A> = <A as Div<U10>>::Output`
-pub type DivU10<A> = <A as Div<consts::U10>>::Output;
-
-/// Alias to make it easy to divide by `P2`: `DivP2<A> = <A as Div<P2>>::Output`
-pub type DivP2<A> = <A as Div<consts::P2>>::Output;
-/// Alias to make it easy to divide by `P10`: `DivP10<A> = <A as Div<P10>>::Output`
-pub type DivP10<A> = <A as Div<consts::P10>>::Output;
-
 /// Alias to make it easy to square. `Square<A> = <A as Mul<A>>::Output`
 pub type Square<A> = <A as Mul>::Output;
 /// Alias to make it easy to square. `Cube<A> = <Square<A> as Mul<A>>::Output`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ debugging. For example,
 assert_eq!(N4::to_i32(), -4);
 ```
 
-**Type operators** are traits that behave as functions at the type level. These are the
+*Type operators** are traits that behave as functions at the type level. These are the
 meat of this library. Where possible, traits defined in the stdlib have been used, but
 their attached functions have not been implemented.
 
@@ -39,7 +39,7 @@ Documented in each module is the full list of type operators implemented.
 #[cfg(feature="no_std")]
 extern crate core as std;
 
-use std::cmp::{Ordering};
+use std::cmp::Ordering;
 
 pub mod consts;
 pub mod bit;
@@ -123,15 +123,24 @@ pub enum Equal {}
 
 /// Returns `std::cmp::Ordering::Greater`
 impl Ord for Greater {
-    #[inline] fn to_ordering() -> Ordering { Ordering::Greater }
+    #[inline]
+    fn to_ordering() -> Ordering {
+        Ordering::Greater
+    }
 }
 /// Returns `std::cmp::Ordering::Less`
 impl Ord for Less {
-    #[inline] fn to_ordering() -> Ordering { Ordering::Less }
+    #[inline]
+    fn to_ordering() -> Ordering {
+        Ordering::Less
+    }
 }
 /// Returns `std::cmp::Ordering::Equal`
 impl Ord for Equal {
-    #[inline] fn to_ordering() -> Ordering { Ordering::Equal }
+    #[inline]
+    fn to_ordering() -> Ordering {
+        Ordering::Equal
+    }
 }
 
 /**
@@ -152,3 +161,62 @@ pub trait Cmp<Rhs = Self> {
     /// The result of the comparison. It should only ever be one of `Greater`, `Less`, or `Equal`.
     type Output;
 }
+
+
+
+// Aliases!!!
+use std::ops::{BitAnd, BitOr, BitXor, Shl, Shr, Add, Sub, Mul, Div, Rem, Neg};
+
+/// Alias for the associated type of `BitAnd`: `And<A, B> = <A as BitAnd<B>>::Output`
+pub type And<A, B> = <A as BitAnd<B>>::Output;
+/// Alias for the associated type of `BitOr`: `Or<A, B> = <A as BitOr<B>>::Output`
+pub type Or<A, B> = <A as BitOr<B>>::Output;
+/// Alias for the associated type of `BitXor`: `Xor<A, B> = <A as BitXor<B>>::Output`
+pub type Xor<A, B> = <A as BitXor<B>>::Output;
+
+/// Alias for the associated type of `Shl`: `Shleft<A, B> = <A as Shl<B>>::Output`
+pub type Shleft<A, B> = <A as Shl<B>>::Output;
+/// Alias for the associated type of `Shr`: `Shright<A, B> = <A as Shr<B>>::Output`
+pub type Shright<A, B> = <A as Shr<B>>::Output;
+
+
+/// Alias for the associated type of `Add`: `Sum<A, B> = <A as Add<B>>::Output`
+pub type Sum<A, B> = <A as Add<B>>::Output;
+/// Alias for the associated type of `Sub`: `Diff<A, B> = <A as Sub<B>>::Output`
+pub type Diff<A, B> = <A as Sub<B>>::Output;
+/// Alias for the associated type of `Mul`: `Prod<A, B> = <A as Mul<B>>::Output`
+pub type Prod<A, B> = <A as Mul<B>>::Output;
+/// Alias for the associated type of `Div`: `Quot<A, B> = <A as Div<B>>::Output`
+pub type Quot<A, B> = <A as Div<B>>::Output;
+/// Alias for the associated type of `Rem`: `Mod<A, B> = <A as Rem<B>>::Output`
+pub type Mod<A, B> = <A as Rem<B>>::Output;
+
+/// Alias for the associated type of `Neg`: `Negate<A> = <A as Neg>::Output`
+pub type Negate<A> = <A as Neg>::Output;
+
+/// Alias for the associated type of `Pow`: `Exp<A, B> = <A as Pow<B>>::Output`
+pub type Exp<A, B> = <A as Pow<B>>::Output;
+
+
+/// Alias to make it easy to add 1: `Add1<A> = <A as Add<B1>>::Output`
+pub type Add1<A> = <A as Add<bit::B1>>::Output;
+/// Alias to make it easy to subtract 1: `Sub1<A> = <A as Sub<B1>>::Output`
+pub type Sub1<A> = <A as Sub<bit::B1>>::Output;
+
+/// Alias to make it easy to multiply by 2: `Mul2<A> = <A as Mul<U2>>::Output`
+pub type Mul2<A> = <A as Mul<consts::U2>>::Output;
+/// Alias to make it easy to multiply by 10: `Mul10<A> = <A as Mul<U10>>::Output`
+pub type Mul10<A> = <A as Mul<consts::U10>>::Output;
+
+/// Alias to make it easy to divide by 2: `Div2<A> = <A as Div<U2>>::Output`
+pub type Div2<A> = <A as Div<consts::U2>>::Output;
+/// Alias to make it easy to divide by 10: `Div10<A> = <A as Div<U10>>::Output`
+pub type Div10<A> = <A as Div<consts::U10>>::Output;
+
+/// Alias to make it easy to square. `Square<A> = <A as Mul<A>>::Output`
+pub type Square<A> = <A as Mul>::Output;
+/// Alias to make it easy to square. `Cube<A> = <Square<A> as Mul<A>>::Output`
+pub type Cube<A> = <Square<A> as Mul<A>>::Output;
+
+/// Alias for the associated type of `Cmp`: `Compare<A, B> = <A as Cmp<B>>::Output`
+pub type Compare<A, B> = <A as Cmp<B>>::Output;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,15 +203,25 @@ pub type Add1<A> = <A as Add<bit::B1>>::Output;
 /// Alias to make it easy to subtract 1: `Sub1<A> = <A as Sub<B1>>::Output`
 pub type Sub1<A> = <A as Sub<bit::B1>>::Output;
 
-/// Alias to make it easy to multiply by 2: `Mul2<A> = <A as Mul<U2>>::Output`
-pub type Mul2<A> = <A as Mul<consts::U2>>::Output;
-/// Alias to make it easy to multiply by 10: `Mul10<A> = <A as Mul<U10>>::Output`
-pub type Mul10<A> = <A as Mul<consts::U10>>::Output;
+/// Alias to make it easy to multiply by `U2`: `MulU2<A> = <A as Mul<U2>>::Output`
+pub type MulU2<A> = <A as Mul<consts::U2>>::Output;
+/// Alias to make it easy to multiply by `U10`: `MulU10<A> = <A as Mul<U10>>::Output`
+pub type MulU10<A> = <A as Mul<consts::U10>>::Output;
 
-/// Alias to make it easy to divide by 2: `Div2<A> = <A as Div<U2>>::Output`
-pub type Div2<A> = <A as Div<consts::U2>>::Output;
-/// Alias to make it easy to divide by 10: `Div10<A> = <A as Div<U10>>::Output`
-pub type Div10<A> = <A as Div<consts::U10>>::Output;
+/// Alias to make it easy to multiply by `P2`: `MulP2<A> = <A as Mul<P2>>::Output`
+pub type MulP2<A> = <A as Mul<consts::P2>>::Output;
+/// Alias to make it easy to multiply by `P10`: `MulP10<A> = <A as Mul<P10>>::Output`
+pub type MulP10<A> = <A as Mul<consts::P10>>::Output;
+
+/// Alias to make it easy to divide by `U2`: `DivU2<A> = <A as Div<U2>>::Output`
+pub type DivU2<A> = <A as Div<consts::U2>>::Output;
+/// Alias to make it easy to divide by `U10`: `DivU10<A> = <A as Div<U10>>::Output`
+pub type DivU10<A> = <A as Div<consts::U10>>::Output;
+
+/// Alias to make it easy to divide by `P2`: `DivP2<A> = <A as Div<P2>>::Output`
+pub type DivP2<A> = <A as Div<consts::P2>>::Output;
+/// Alias to make it easy to divide by `P10`: `DivP10<A> = <A as Div<P10>>::Output`
+pub type DivP10<A> = <A as Div<consts::P10>>::Output;
 
 /// Alias to make it easy to square. `Square<A> = <A as Mul<A>>::Output`
 pub type Square<A> = <A as Mul>::Output;

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -3,10 +3,10 @@
 Type-level unsigned integers.
 
 
-**Type operators** implemented:
+*Type operators** implemented:
 
-* From std::ops: `BitAnd`, `BitOr`, `BitXor`, `Shl`, `Shr`, `Add`, `Sub`, `Mul`, `Div`, and `Rem`.
-* From typenum: `Same`, `Cmp`, and `Pow`.
+From std::ops: `BitAnd`, `BitOr`, `BitXor`, `Shl`, `Shr`, `Add`, `Sub`, `Mul`, `Div`, and `Rem`.
+From typenum: `Same`, `Cmp`, and `Pow`.
 
 Rather than directly using the structs defined in this module, it is recommended that
 you import and use the relevant aliases from the [consts](../consts/index.html) module.
@@ -35,9 +35,15 @@ use std::marker::PhantomData;
 use std::ops::{BitAnd, BitOr, BitXor, Shl, Shr, Add, Sub, Mul, Div, Rem};
 use {NonZero, Ord, Greater, Equal, Less, Cmp, Pow};
 use bit::{Bit, B0, B1};
+
 use __private::{Trim, SizeOf, PrivateAnd, PrivateXor, PrivateSub, PrivateCmp, PrivateSizeOf,
-                  ShiftDiff, PrivateDiv, PrivateDivFirstStep, PrivatePow, BitDiff};
+                ShiftDiff, PrivateDiv, PrivateDivFirstStep, PrivatePow, BitDiff};
+
+use __private::{TrimOut, SizeOfOut, PrivateAndOut, PrivateXorOut, PrivateSubOut, PrivateCmpOut,
+                PrivateSizeOfOut, PrivatePowOut, BitDiffOut};
+
 use consts::{U0, U1};
+use {Or, Shleft, Shright, Sum, Prod, Add1, Sub1, Square};
 
 /**
 The **marker trait** for compile time unsigned integers.
@@ -73,17 +79,47 @@ The terminating type for `UInt`; it always comes after the most significant bit.
 pub enum UTerm {}
 
 impl Unsigned for UTerm {
-    #[inline] fn to_u8() -> u8 { 0 }
-    #[inline] fn to_u16() -> u16 { 0 }
-    #[inline] fn to_u32() -> u32 { 0 }
-    #[inline] fn to_u64() -> u64 { 0 }
-    #[inline] fn to_usize() -> usize { 0 }
+    #[inline]
+    fn to_u8() -> u8 {
+        0
+    }
+    #[inline]
+    fn to_u16() -> u16 {
+        0
+    }
+    #[inline]
+    fn to_u32() -> u32 {
+        0
+    }
+    #[inline]
+    fn to_u64() -> u64 {
+        0
+    }
+    #[inline]
+    fn to_usize() -> usize {
+        0
+    }
 
-    #[inline] fn to_i8() -> i8 { 0 }
-    #[inline] fn to_i16() -> i16 { 0 }
-    #[inline] fn to_i32() -> i32 { 0 }
-    #[inline] fn to_i64() -> i64 { 0 }
-    #[inline] fn to_isize() -> isize { 0 }
+    #[inline]
+    fn to_i8() -> i8 {
+        0
+    }
+    #[inline]
+    fn to_i16() -> i16 {
+        0
+    }
+    #[inline]
+    fn to_i32() -> i32 {
+        0
+    }
+    #[inline]
+    fn to_i64() -> i64 {
+        0
+    }
+    #[inline]
+    fn to_isize() -> isize {
+        0
+    }
 }
 
 /**
@@ -105,21 +141,51 @@ type U6 = UInt<UInt<UInt<UTerm, B1>, B1>, B0>;
 ```
 */
 pub struct UInt<U, B> {
-    _marker: PhantomData<(U, B)>
+    _marker: PhantomData<(U, B)>,
 }
 
 impl<U: Unsigned, B: Bit> Unsigned for UInt<U, B> {
-    #[inline] fn to_u8() -> u8 { B::to_u8() | U::to_u8() << 1 }
-    #[inline] fn to_u16() -> u16 { B::to_u8() as u16 | U::to_u16() << 1 }
-    #[inline] fn to_u32() -> u32 { B::to_u8() as u32 | U::to_u32() << 1 }
-    #[inline] fn to_u64() -> u64 { B::to_u8() as u64 | U::to_u64() << 1 }
-    #[inline] fn to_usize() -> usize { B::to_u8() as usize | U::to_usize() << 1 }
+    #[inline]
+    fn to_u8() -> u8 {
+        B::to_u8() | U::to_u8() << 1
+    }
+    #[inline]
+    fn to_u16() -> u16 {
+        B::to_u8() as u16 | U::to_u16() << 1
+    }
+    #[inline]
+    fn to_u32() -> u32 {
+        B::to_u8() as u32 | U::to_u32() << 1
+    }
+    #[inline]
+    fn to_u64() -> u64 {
+        B::to_u8() as u64 | U::to_u64() << 1
+    }
+    #[inline]
+    fn to_usize() -> usize {
+        B::to_u8() as usize | U::to_usize() << 1
+    }
 
-    #[inline] fn to_i8() -> i8 { B::to_u8() as i8 | U::to_i8() << 1 }
-    #[inline] fn to_i16() -> i16 { B::to_u8() as i16 | U::to_i16() << 1 }
-    #[inline] fn to_i32() -> i32 { B::to_u8() as i32 | U::to_i32() << 1 }
-    #[inline] fn to_i64() -> i64 { B::to_u8() as i64 | U::to_i64() << 1 }
-    #[inline] fn to_isize() -> isize { B::to_u8() as isize | U::to_isize() << 1 }
+    #[inline]
+    fn to_i8() -> i8 {
+        B::to_u8() as i8 | U::to_i8() << 1
+    }
+    #[inline]
+    fn to_i16() -> i16 {
+        B::to_u8() as i16 | U::to_i16() << 1
+    }
+    #[inline]
+    fn to_i32() -> i32 {
+        B::to_u8() as i32 | U::to_i32() << 1
+    }
+    #[inline]
+    fn to_i64() -> i64 {
+        B::to_u8() as i64 | U::to_i64() << 1
+    }
+    #[inline]
+    fn to_isize() -> isize {
+        B::to_u8() as isize | U::to_isize() << 1
+    }
 }
 
 impl<U: Unsigned, B: Bit> NonZero for UInt<U, B> {}
@@ -150,10 +216,9 @@ impl SizeOf for UTerm {
 }
 
 /// Size of a `UInt`
-impl<U: Unsigned, B: Bit> SizeOf for UInt<U, B>
-    where UInt<U, B>: PrivateSizeOf
+impl<U: Unsigned, B: Bit> SizeOf for UInt<U, B> where UInt<U, B>: PrivateSizeOf
 {
-    type Output = <UInt<U, B> as PrivateSizeOf>::Output;
+    type Output = PrivateSizeOfOut<UInt<U, B>>;
 }
 
 /// Size of `UTerm` inside a number is 0
@@ -164,9 +229,9 @@ impl PrivateSizeOf for UTerm {
 /// Size of bit is 1
 impl<U: Unsigned, B: Bit> PrivateSizeOf for UInt<U, B>
     where U: PrivateSizeOf,
-    <U as PrivateSizeOf>::Output: Add<B1>
+          PrivateSizeOfOut<U>: Add<B1>
 {
-    type Output = <<U as PrivateSizeOf>::Output as Add<B1>>::Output;
+    type Output = Add1<PrivateSizeOfOut<U>>;
 }
 
 // ---------------------------------------------------------------------------------------
@@ -175,27 +240,40 @@ impl<U: Unsigned, B: Bit> PrivateSizeOf for UInt<U, B>
 /// `UTerm + B0 = UTerm`
 impl Add<B0> for UTerm {
     type Output = UTerm;
-    fn add(self, _: B0) -> Self::Output { unreachable!() }
+    fn add(self, _: B0) -> Self::Output {
+        unreachable!()
+    }
 }
 /// `UInt + B0 = UInt`
 impl<U: Unsigned, B: Bit> Add<B0> for UInt<U, B> {
     type Output = UInt<U, B>;
-    fn add(self, _: B0) -> Self::Output { unreachable!() }
+    fn add(self, _: B0) -> Self::Output {
+        unreachable!()
+    }
 }
 /// `UTerm + B1 = UInt<UTerm, B1>`
 impl Add<B1> for UTerm {
     type Output = UInt<UTerm, B1>;
-    fn add(self, _: B1) -> Self::Output { unreachable!() }
+    fn add(self, _: B1) -> Self::Output {
+        unreachable!()
+    }
 }
 /// `UInt<U, B0> + B1 = UInt<U + B1>`
 impl<U: Unsigned> Add<B1> for UInt<U, B0> {
     type Output = UInt<U, B1>;
-    fn add(self, _: B1) -> Self::Output { unreachable!() }
+    fn add(self, _: B1) -> Self::Output {
+        unreachable!()
+    }
 }
 /// `UInt<U, B1> + B1 = UInt<U + B1, B0>`
-impl<U: Unsigned> Add<B1> for UInt<U, B1> where U: Add<B1>, <U as Add<B1>>::Output: Unsigned {
-    type Output = UInt<<U as Add<B1>>::Output, B0>;
-    fn add(self, _: B1) -> Self::Output { unreachable!() }
+impl<U: Unsigned> Add<B1> for UInt<U, B1>
+    where U: Add<B1>,
+          Sum<U, B1>: Unsigned
+{
+    type Output = UInt<Add1<U>, B0>;
+    fn add(self, _: B1) -> Self::Output {
+        unreachable!()
+    }
 }
 
 // ---------------------------------------------------------------------------------------
@@ -204,46 +282,63 @@ impl<U: Unsigned> Add<B1> for UInt<U, B1> where U: Add<B1>, <U as Add<B1>>::Outp
 /// `UTerm + UTerm = UTerm`
 impl Add<UTerm> for UTerm {
     type Output = UTerm;
-    fn add(self, _: UTerm) -> Self::Output { unreachable!() }
+    fn add(self, _: UTerm) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// `UTerm + UInt<U, B> = UInt<U, B>`
 impl<U: Unsigned, B: Bit> Add<UInt<U, B>> for UTerm {
     type Output = UInt<U, B>;
-    fn add(self, _: UInt<U, B>) -> Self::Output { unreachable!() }
+    fn add(self, _: UInt<U, B>) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// `UInt<U, B> + UTerm = UInt<U, B>`
 impl<U: Unsigned, B: Bit> Add<UTerm> for UInt<U, B> {
     type Output = UInt<U, B>;
-    fn add(self, _: UTerm) -> Self::Output { unreachable!() }
+    fn add(self, _: UTerm) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// `UInt<Ul, B0> + UInt<Ur, B0> = UInt<Ul + Ur, B0>`
-impl<Ul: Unsigned, Ur: Unsigned> Add<UInt<Ur, B0>> for UInt<Ul, B0> where Ul: Add<Ur> {
-    type Output = UInt<<Ul as Add<Ur>>::Output, B0>;
-    fn add(self, _:UInt<Ur, B0>) -> Self::Output { unreachable!() }
+impl<Ul: Unsigned, Ur: Unsigned> Add<UInt<Ur, B0>> for UInt<Ul, B0> where Ul: Add<Ur>
+{
+    type Output = UInt<Sum<Ul, Ur>, B0>;
+    fn add(self, _: UInt<Ur, B0>) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// `UInt<Ul, B0> + UInt<Ur, B1> = UInt<Ul + Ur, B1>`
-impl<Ul: Unsigned, Ur: Unsigned> Add<UInt<Ur, B1>> for UInt<Ul, B0> where Ul: Add<Ur> {
-    type Output = UInt<<Ul as Add<Ur>>::Output, B1>;
-    fn add(self, _:UInt<Ur, B1>) -> Self::Output { unreachable!() }
+impl<Ul: Unsigned, Ur: Unsigned> Add<UInt<Ur, B1>> for UInt<Ul, B0> where Ul: Add<Ur>
+{
+    type Output = UInt<Sum<Ul, Ur>, B1>;
+    fn add(self, _: UInt<Ur, B1>) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// `UInt<Ul, B1> + UInt<Ur, B0> = UInt<Ul + Ur, B1>`
-impl<Ul: Unsigned, Ur: Unsigned> Add<UInt<Ur, B0>> for UInt<Ul, B1> where Ul: Add<Ur> {
-    type Output = UInt<<Ul as Add<Ur>>::Output, B1>;
-    fn add(self, _:UInt<Ur, B0>) -> Self::Output { unreachable!() }
+impl<Ul: Unsigned, Ur: Unsigned> Add<UInt<Ur, B0>> for UInt<Ul, B1> where Ul: Add<Ur>
+{
+    type Output = UInt<Sum<Ul, Ur>, B1>;
+    fn add(self, _: UInt<Ur, B0>) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// `UInt<Ul, B1> + UInt<Ur, B1> = UInt<(Ul + Ur) + B1, B0>`
 impl<Ul: Unsigned, Ur: Unsigned> Add<UInt<Ur, B1>> for UInt<Ul, B1>
     where Ul: Add<Ur>,
-          <Ul as Add<Ur>>::Output: Add<B1>
+          Sum<Ul, Ur>: Add<B1>
 {
-    type Output = UInt<<<Ul as Add<Ur>>::Output as Add<B1>>::Output, B0>;
-    fn add(self, _:UInt<Ur, B1>) -> Self::Output { unreachable!() }
+    type Output = UInt<Add1<Sum<Ul, Ur>>, B0>;
+    fn add(self, _: UInt<Ur, B1>) -> Self::Output {
+        unreachable!()
+    }
 }
 
 // ---------------------------------------------------------------------------------------
@@ -252,30 +347,43 @@ impl<Ul: Unsigned, Ur: Unsigned> Add<UInt<Ur, B1>> for UInt<Ul, B1>
 /// `UTerm - B0 = Term`
 impl Sub<B0> for UTerm {
     type Output = UTerm;
-    fn sub(self, _:B0) -> Self::Output { unreachable!() }
+    fn sub(self, _: B0) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// `UInt - B0 = UInt`
 impl<U: Unsigned, B: Bit> Sub<B0> for UInt<U, B> {
     type Output = UInt<U, B>;
-    fn sub(self, _:B0) -> Self::Output { unreachable!() }
+    fn sub(self, _: B0) -> Self::Output {
+        unreachable!()
+    }
 }
 /// `UInt<U, B1> - B1 = UInt<U, B0>`
 impl<U: Unsigned, B: Bit> Sub<B1> for UInt<UInt<U, B>, B1> {
     type Output = UInt<UInt<U, B>, B0>;
-    fn sub(self, _:B1) -> Self::Output { unreachable!() }
+    fn sub(self, _: B1) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// `UInt<UTerm, B1> - B1 = UTerm`
 impl Sub<B1> for UInt<UTerm, B1> {
     type Output = UTerm;
-    fn sub(self, _:B1) -> Self::Output { unreachable!() }
+    fn sub(self, _: B1) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// `UInt<U, B0> - B1 = UInt<U - B1, B1>`
-impl<U: Unsigned> Sub<B1> for UInt<U, B0> where U:Sub<B1>, <U as Sub<B1>>::Output: Unsigned {
-    type Output = UInt<<U as Sub<B1>>::Output, B1>;
-    fn sub(self, _:B1) -> Self::Output { unreachable!() }
+impl<U: Unsigned> Sub<B1> for UInt<U, B0>
+    where U: Sub<B1>,
+          Sub1<U>: Unsigned
+{
+    type Output = UInt<Sub1<U>, B1>;
+    fn sub(self, _: B1) -> Self::Output {
+        unreachable!()
+    }
 }
 
 // ---------------------------------------------------------------------------------------
@@ -284,15 +392,19 @@ impl<U: Unsigned> Sub<B1> for UInt<U, B0> where U:Sub<B1>, <U as Sub<B1>>::Outpu
 /// `UTerm - UTerm = UTerm`
 impl Sub<UTerm> for UTerm {
     type Output = UTerm;
-    fn sub(self, _:UTerm) -> Self::Output { unreachable!() }
+    fn sub(self, _: UTerm) -> Self::Output {
+        unreachable!()
+    }
 }
 /// Subtracting unsigned integers. We just do our `PrivateSub` and then `Trim` the output.
 impl<Ul: Unsigned, Bl: Bit, Ur: Unsigned> Sub<Ur> for UInt<Ul, Bl>
     where UInt<Ul, Bl>: PrivateSub<Ur>,
-          <UInt<Ul, Bl> as PrivateSub<Ur>>::Output: Trim
+          PrivateSubOut<UInt<Ul, Bl>, Ur>: Trim
 {
-    type Output = <<UInt<Ul, Bl> as PrivateSub<Ur>>::Output as Trim>::Output;
-    fn sub(self, _:Ur) -> Self::Output { unreachable!() }
+    type Output = TrimOut<PrivateSubOut<UInt<Ul, Bl>, Ur>>;
+    fn sub(self, _: Ur) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// `U - UTerm = U`
@@ -301,32 +413,29 @@ impl<U: Unsigned> PrivateSub<UTerm> for U {
 }
 
 /// `UInt<Ul, B0> - UInt<Ur, B0> = UInt<Ul - Ur, B0>`
-impl<Ul: Unsigned, Ur: Unsigned> PrivateSub<UInt<Ur, B0>> for UInt<Ul, B0>
-    where Ul: PrivateSub<Ur>
+impl<Ul: Unsigned, Ur: Unsigned> PrivateSub<UInt<Ur, B0>> for UInt<Ul, B0> where Ul: PrivateSub<Ur>
 {
-    type Output = UInt<<Ul as PrivateSub<Ur>>::Output, B0>;
+    type Output = UInt<PrivateSubOut<Ul, Ur>, B0>;
 }
 
 /// `UInt<Ul, B0> - UInt<Ur, B1> = UInt<(Ul - Ur) - B1, B1>`
 impl<Ul: Unsigned, Ur: Unsigned> PrivateSub<UInt<Ur, B1>> for UInt<Ul, B0>
     where Ul: PrivateSub<Ur>,
-<Ul as PrivateSub<Ur>>::Output: Sub<B1>
+          PrivateSubOut<Ul, Ur>: Sub<B1>
 {
-    type Output = UInt<<<Ul as PrivateSub<Ur>>::Output as Sub<B1>>::Output, B1>;
+    type Output = UInt<Sub1<PrivateSubOut<Ul, Ur>>, B1>;
 }
 
 /// `UInt<Ul, B1> - UInt<Ur, B0> = UInt<Ul - Ur, B1>`
-impl<Ul: Unsigned, Ur: Unsigned> PrivateSub<UInt<Ur, B0>> for UInt<Ul, B1>
-    where Ul: PrivateSub<Ur>
+impl<Ul: Unsigned, Ur: Unsigned> PrivateSub<UInt<Ur, B0>> for UInt<Ul, B1> where Ul: PrivateSub<Ur>
 {
-    type Output = UInt<<Ul as PrivateSub<Ur>>::Output, B1>;
+    type Output = UInt<PrivateSubOut<Ul, Ur>, B1>;
 }
 
 /// `UInt<Ul, B1> - UInt<Ur, B1> = UInt<Ul - Ur, B0>`
-impl<Ul: Unsigned, Ur: Unsigned> PrivateSub<UInt<Ur, B1>> for UInt<Ul, B1>
-    where Ul: PrivateSub<Ur>
+impl<Ul: Unsigned, Ur: Unsigned> PrivateSub<UInt<Ur, B1>> for UInt<Ul, B1> where Ul: PrivateSub<Ur>
 {
-    type Output = UInt<<Ul as PrivateSub<Ur>>::Output, B0>;
+    type Output = UInt<PrivateSubOut<Ul, Ur>, B0>;
 }
 
 // ---------------------------------------------------------------------------------------
@@ -342,46 +451,46 @@ impl<B: Bit, U: Unsigned> PrivateAnd<UTerm> for UInt<U, B> {
 }
 
 /// `UInt<Ul, B0> & UInt<Ur, B0> = UInt<Ul & Ur, B0>`
-impl<Ul: Unsigned, Ur: Unsigned> PrivateAnd<UInt<Ur, B0>> for UInt<Ul, B0>
-    where Ul: PrivateAnd<Ur>
+impl<Ul: Unsigned, Ur: Unsigned> PrivateAnd<UInt<Ur, B0>> for UInt<Ul, B0> where Ul: PrivateAnd<Ur>
 {
-    type Output = UInt<<Ul as PrivateAnd<Ur>>::Output, B0>;
+    type Output = UInt<PrivateAndOut<Ul, Ur>, B0>;
 }
 
 /// `UInt<Ul, B0> & UInt<Ur, B1> = UInt<Ul & Ur, B0>`
-impl<Ul: Unsigned, Ur: Unsigned> PrivateAnd<UInt<Ur, B1>> for UInt<Ul, B0>
-    where Ul: PrivateAnd<Ur>
+impl<Ul: Unsigned, Ur: Unsigned> PrivateAnd<UInt<Ur, B1>> for UInt<Ul, B0> where Ul: PrivateAnd<Ur>
 {
-    type Output = UInt<<Ul as PrivateAnd<Ur>>::Output, B0>;
+    type Output = UInt<PrivateAndOut<Ul, Ur>, B0>;
 }
 
 /// `UInt<Ul, B1> & UInt<Ur, B0> = UInt<Ul & Ur, B0>`
-impl<Ul: Unsigned, Ur: Unsigned> PrivateAnd<UInt<Ur, B0>> for UInt<Ul, B1>
-    where Ul: PrivateAnd<Ur>
+impl<Ul: Unsigned, Ur: Unsigned> PrivateAnd<UInt<Ur, B0>> for UInt<Ul, B1> where Ul: PrivateAnd<Ur>
 {
-    type Output = UInt<<Ul as PrivateAnd<Ur>>::Output, B0>;
+    type Output = UInt<PrivateAndOut<Ul, Ur>, B0>;
 }
 
 /// `UInt<Ul, B1> & UInt<Ur, B1> = UInt<Ul & Ur, B1>`
-impl<Ul: Unsigned, Ur: Unsigned> PrivateAnd<UInt<Ur, B1>> for UInt<Ul, B1>
-    where Ul: PrivateAnd<Ur>
+impl<Ul: Unsigned, Ur: Unsigned> PrivateAnd<UInt<Ur, B1>> for UInt<Ul, B1> where Ul: PrivateAnd<Ur>
 {
-    type Output = UInt<<Ul as PrivateAnd<Ur>>::Output, B1>;
+    type Output = UInt<PrivateAndOut<Ul, Ur>, B1>;
 }
 
 impl<Ur: Unsigned> BitAnd<Ur> for UTerm {
     type Output = UTerm;
-    fn bitand(self, _: Ur) -> Self::Output { unreachable!() }
+    fn bitand(self, _: Ur) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// Anding unsigned integers.
 /// We use our `PrivateAnd` operator and then `Trim` the output.
 impl<Ul: Unsigned, Bl: Bit, Ur: Unsigned> BitAnd<Ur> for UInt<Ul, Bl>
     where UInt<Ul, Bl>: PrivateAnd<Ur>,
-          <UInt<Ul, Bl> as PrivateAnd<Ur>>::Output: Trim
+          PrivateAndOut<UInt<Ul, Bl>, Ur>: Trim
 {
-    type Output = <<UInt<Ul, Bl> as PrivateAnd<Ur>>::Output as Trim>::Output;
-    fn bitand(self, _: Ur) -> Self::Output { unreachable!() }
+    type Output = TrimOut<PrivateAndOut<UInt<Ul, Bl>, Ur>>;
+    fn bitand(self, _: Ur) -> Self::Output {
+        unreachable!()
+    }
 }
 
 // ---------------------------------------------------------------------------------------
@@ -390,36 +499,52 @@ impl<Ul: Unsigned, Bl: Bit, Ur: Unsigned> BitAnd<Ur> for UInt<Ul, Bl>
 /// `UTerm | X = X`
 impl<U: Unsigned> BitOr<U> for UTerm {
     type Output = U;
-    fn bitor(self, _: U) -> Self::Output { unreachable!() }
+    fn bitor(self, _: U) -> Self::Output {
+        unreachable!()
+    }
 }
 ///  `X | UTerm = X`
 impl<B: Bit, U: Unsigned> BitOr<UTerm> for UInt<U, B> {
     type Output = Self;
-    fn bitor(self, _: UTerm) -> Self::Output { unreachable!() }
+    fn bitor(self, _: UTerm) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// `UInt<Ul, B0> | UInt<Ur, B0> = UInt<Ul | Ur, B0>`
-impl<Ul: Unsigned, Ur: Unsigned> BitOr<UInt<Ur, B0>> for UInt<Ul, B0> where Ul: BitOr<Ur> {
+impl<Ul: Unsigned, Ur: Unsigned> BitOr<UInt<Ur, B0>> for UInt<Ul, B0> where Ul: BitOr<Ur>
+{
     type Output = UInt<<Ul as BitOr<Ur>>::Output, B0>;
-    fn bitor(self, _: UInt<Ur, B0>) -> Self::Output { unreachable!() }
+    fn bitor(self, _: UInt<Ur, B0>) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// `UInt<Ul, B0> | UInt<Ur, B1> = UInt<Ul | Ur, B1>`
-impl<Ul: Unsigned, Ur: Unsigned> BitOr<UInt<Ur, B1>> for UInt<Ul, B0> where Ul: BitOr<Ur> {
-    type Output = UInt<<Ul as BitOr<Ur>>::Output, B1>;
-    fn bitor(self, _: UInt<Ur, B1>) -> Self::Output { unreachable!() }
+impl<Ul: Unsigned, Ur: Unsigned> BitOr<UInt<Ur, B1>> for UInt<Ul, B0> where Ul: BitOr<Ur>
+{
+    type Output = UInt<Or<Ul, Ur>, B1>;
+    fn bitor(self, _: UInt<Ur, B1>) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// `UInt<Ul, B1> | UInt<Ur, B0> = UInt<Ul | Ur, B1>`
-impl<Ul: Unsigned, Ur: Unsigned> BitOr<UInt<Ur, B0>> for UInt<Ul, B1> where Ul: BitOr<Ur> {
-    type Output = UInt<<Ul as BitOr<Ur>>::Output, B1>;
-    fn bitor(self, _: UInt<Ur, B0>) -> Self::Output { unreachable!() }
+impl<Ul: Unsigned, Ur: Unsigned> BitOr<UInt<Ur, B0>> for UInt<Ul, B1> where Ul: BitOr<Ur>
+{
+    type Output = UInt<Or<Ul, Ur>, B1>;
+    fn bitor(self, _: UInt<Ur, B0>) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// `UInt<Ul, B1> | UInt<Ur, B1> = UInt<Ul | Ur, B1>`
-impl<Ul: Unsigned, Ur: Unsigned> BitOr<UInt<Ur, B1>> for UInt<Ul, B1> where Ul: BitOr<Ur> {
-    type Output = UInt<<Ul as BitOr<Ur>>::Output, B1>;
-    fn bitor(self, _: UInt<Ur, B1>) -> Self::Output { unreachable!() }
+impl<Ul: Unsigned, Ur: Unsigned> BitOr<UInt<Ur, B1>> for UInt<Ul, B1> where Ul: BitOr<Ur>
+{
+    type Output = UInt<Or<Ul, Ur>, B1>;
+    fn bitor(self, _: UInt<Ur, B1>) -> Self::Output {
+        unreachable!()
+    }
 }
 
 // ---------------------------------------------------------------------------------------
@@ -435,46 +560,46 @@ impl<B: Bit, U: Unsigned> PrivateXor<UTerm> for UInt<U, B> {
 }
 
 /// `UInt<Ul, B0> ^ UInt<Ur, B0> = UInt<Ul ^ Ur, B0>`
-impl<Ul: Unsigned, Ur: Unsigned> PrivateXor<UInt<Ur, B0>> for UInt<Ul, B0>
-    where Ul: PrivateXor<Ur>
+impl<Ul: Unsigned, Ur: Unsigned> PrivateXor<UInt<Ur, B0>> for UInt<Ul, B0> where Ul: PrivateXor<Ur>
 {
-    type Output = UInt<<Ul as PrivateXor<Ur>>::Output, B0>;
+    type Output = UInt<PrivateXorOut<Ul, Ur>, B0>;
 }
 
 /// `UInt<Ul, B0> ^ UInt<Ur, B1> = UInt<Ul ^ Ur, B1>`
-impl<Ul: Unsigned, Ur: Unsigned> PrivateXor<UInt<Ur, B1>> for UInt<Ul, B0>
-    where Ul: PrivateXor<Ur>
+impl<Ul: Unsigned, Ur: Unsigned> PrivateXor<UInt<Ur, B1>> for UInt<Ul, B0> where Ul: PrivateXor<Ur>
 {
-    type Output = UInt<<Ul as PrivateXor<Ur>>::Output, B1>;
+    type Output = UInt<PrivateXorOut<Ul, Ur>, B1>;
 }
 
 /// `UInt<Ul, B1> ^ UInt<Ur, B0> = UInt<Ul ^ Ur, B1>`
-impl<Ul: Unsigned, Ur: Unsigned> PrivateXor<UInt<Ur, B0>> for UInt<Ul, B1>
-    where Ul: PrivateXor<Ur>
+impl<Ul: Unsigned, Ur: Unsigned> PrivateXor<UInt<Ur, B0>> for UInt<Ul, B1> where Ul: PrivateXor<Ur>
 {
-    type Output = UInt<<Ul as PrivateXor<Ur>>::Output, B1>;
+    type Output = UInt<PrivateXorOut<Ul, Ur>, B1>;
 }
 
 /// `UInt<Ul, B1> ^ UInt<Ur, B1> = UInt<Ul ^ Ur, B0>`
-impl<Ul: Unsigned, Ur: Unsigned> PrivateXor<UInt<Ur, B1>> for UInt<Ul, B1>
-    where Ul: PrivateXor<Ur>
+impl<Ul: Unsigned, Ur: Unsigned> PrivateXor<UInt<Ur, B1>> for UInt<Ul, B1> where Ul: PrivateXor<Ur>
 {
-    type Output = UInt<<Ul as PrivateXor<Ur>>::Output, B0>;
+    type Output = UInt<PrivateXorOut<Ul, Ur>, B0>;
 }
 
 /// 0 ^ X = X
 impl<Ur: Unsigned> BitXor<Ur> for UTerm {
     type Output = Ur;
-    fn bitxor(self, _: Ur) -> Self::Output { unreachable!() }
+    fn bitxor(self, _: Ur) -> Self::Output {
+        unreachable!()
+    }
 }
 /// Xoring unsigned integers.
 /// We use our `PrivateXor` operator and then `Trim` the output.
 impl<Ul: Unsigned, Bl: Bit, Ur: Unsigned> BitXor<Ur> for UInt<Ul, Bl>
     where UInt<Ul, Bl>: PrivateXor<Ur>,
-          <UInt<Ul, Bl> as PrivateXor<Ur>>::Output: Trim
+          PrivateXorOut<UInt<Ul, Bl>, Ur>: Trim
 {
-    type Output = <<UInt<Ul, Bl> as PrivateXor<Ur>>::Output as Trim>::Output;
-    fn bitxor(self, _: Ur) -> Self::Output { unreachable!() }
+    type Output = TrimOut<PrivateXorOut<UInt<Ul, Bl>, Ur>>;
+    fn bitxor(self, _: Ur) -> Self::Output {
+        unreachable!()
+    }
 }
 
 // ---------------------------------------------------------------------------------------
@@ -483,51 +608,60 @@ impl<Ul: Unsigned, Bl: Bit, Ur: Unsigned> BitXor<Ur> for UInt<Ul, Bl>
 /// Shifting left `UTerm` by an unsigned integer: `UTerm << U = UTerm`
 impl<U: Unsigned> Shl<U> for UTerm {
     type Output = UTerm;
-    fn shl(self, _: U) -> Self::Output { unreachable!() }
+    fn shl(self, _: U) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// Shifting left `UInt` by `UTerm`: `UInt<U, B> << UTerm = UInt<U, B>`
 impl<U: Unsigned, B: Bit> Shl<UTerm> for UInt<U, B> {
     type Output = UInt<U, B>;
-    fn shl(self, _: UTerm) -> Self::Output { unreachable!() }
+    fn shl(self, _: UTerm) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// Shifting left any unsigned by a zero bit: `U << B0 = U`
 impl<U: Unsigned, B: Bit> Shl<B0> for UInt<U, B> {
     type Output = UInt<U, B>;
-    fn shl(self, _: B0) -> Self::Output { unreachable!() }
+    fn shl(self, _: B0) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// Shifting UTerm by a zero bit: `UTerm << B0 = UTerm`
 impl Shl<B0> for UTerm {
     type Output = UTerm;
-    fn shl(self, _: B0) -> Self::Output { unreachable!() }
+    fn shl(self, _: B0) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// Shifting left a `UInt` by a one bit: `UInt<U, B> << B1 = UInt<UInt<U, B>, B0>`
 impl<U: Unsigned, B: Bit> Shl<B1> for UInt<U, B> {
     type Output = UInt<UInt<U, B>, B0>;
-    fn shl(self, _: B1) -> Self::Output { unreachable!() }
+    fn shl(self, _: B1) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// Shifting left a `UTerm` by a 1 bit: `UTerm << B1 = UTerm`
 impl Shl<B1> for UTerm {
     type Output = UTerm;
-    fn shl(self, _: B1) -> Self::Output { unreachable!() }
+    fn shl(self, _: B1) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// Shifting left `UInt` by `UInt`: `X << Y` = `UInt(X, B0) << (Y - 1)`
 impl<U: Unsigned, B: Bit, Ur: Unsigned, Br: Bit> Shl<UInt<Ur, Br>> for UInt<U, B>
-where UInt<Ur, Br> : Sub<B1>,
-    UInt<UInt<U, B>, B0> : Shl<<UInt<Ur, Br> as Sub<B1>>::Output>
+    where UInt<Ur, Br>: Sub<B1>,
+          UInt<UInt<U, B>, B0>: Shl<Sub1<UInt<Ur, Br>>>
 {
-    type Output =
-        <
-            UInt<UInt<U, B>, B0> as Shl<
-                    <UInt<Ur, Br> as Sub<B1>>::Output
-                >
-        >::Output;
-        fn shl(self, _: UInt<Ur, Br>) -> Self::Output { unreachable!() }
+    type Output = Shleft<UInt<UInt<U, B>, B0>, Sub1<UInt<Ur, Br>>>;
+    fn shl(self, _: UInt<Ur, Br>) -> Self::Output {
+        unreachable!()
+    }
 }
 
 // ---------------------------------------------------------------------------------------
@@ -536,46 +670,60 @@ where UInt<Ur, Br> : Sub<B1>,
 /// Shifting right a `UTerm` by an unsigned integer: `UTerm >> U = UTerm`
 impl<U: Unsigned> Shr<U> for UTerm {
     type Output = UTerm;
-    fn shr(self, _: U) -> Self::Output { unreachable!() }
+    fn shr(self, _: U) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// Shifting right `UInt` by `UTerm`: `UInt<U, B> >> UTerm = UInt<U, B>`
 impl<U: Unsigned, B: Bit> Shr<UTerm> for UInt<U, B> {
     type Output = UInt<U, B>;
-    fn shr(self, _: UTerm) -> Self::Output { unreachable!() }
+    fn shr(self, _: UTerm) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// Shifting right UTerm by a zero bit: `UTerm >> B0 = UTerm`
 impl Shr<B0> for UTerm {
     type Output = UTerm;
-    fn shr(self, _: B0) -> Self::Output { unreachable!() }
+    fn shr(self, _: B0) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// Shifting right any unsigned by a zero bit: `U >> B0 = U`
 impl<U: Unsigned, B: Bit> Shr<B0> for UInt<U, B> {
     type Output = UInt<U, B>;
-    fn shr(self, _: B0) -> Self::Output { unreachable!() }
+    fn shr(self, _: B0) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// Shifting right a `UInt` by a 1 bit: `UInt<U, B> >> B1 = U`
 impl<U: Unsigned, B: Bit> Shr<B1> for UInt<U, B> {
     type Output = U;
-    fn shr(self, _: B1) -> Self::Output { unreachable!() }
+    fn shr(self, _: B1) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// Shifting right a `UTerm` by a 1 bit: `UTerm >> B1 = UTerm`
 impl Shr<B1> for UTerm {
     type Output = UTerm;
-    fn shr(self, _: B1) -> Self::Output { unreachable!() }
+    fn shr(self, _: B1) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// Shifting right `UInt` by `UInt`: `UInt(U, B) >> Y` = `U >> (Y - 1)`
 impl<U: Unsigned, B: Bit, Ur: Unsigned, Br: Bit> Shr<UInt<Ur, Br>> for UInt<U, B>
-where UInt<Ur, Br> : Sub<B1>,
-    U : Shr<<UInt<Ur, Br> as Sub<B1>>::Output>
+    where UInt<Ur, Br>: Sub<B1>,
+          U: Shr<Sub1<UInt<Ur, Br>>>
 {
-    type Output = <U as Shr<<UInt<Ur, Br> as Sub<B1>>::Output>>::Output;
-    fn shr(self, _: UInt<Ur, Br>) -> Self::Output { unreachable!() }
+    type Output = Shright<U, Sub1<UInt<Ur, Br>>>;
+    fn shr(self, _: UInt<Ur, Br>) -> Self::Output {
+        unreachable!()
+    }
 }
 
 // ---------------------------------------------------------------------------------------
@@ -584,54 +732,70 @@ where UInt<Ur, Br> : Sub<B1>,
 /// `UInt * B0 = UTerm`
 impl<U: Unsigned, B: Bit> Mul<B0> for UInt<U, B> {
     type Output = UTerm;
-    fn mul(self, _: B0) -> Self::Output { unreachable!() }
+    fn mul(self, _: B0) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// `UTerm * B = UTerm`
 impl<B: Bit> Mul<B> for UTerm {
     type Output = UTerm;
-    fn mul(self, _: B) -> Self::Output { unreachable!() }
+    fn mul(self, _: B) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// `UInt * B1 = UInt`
 impl<U: Unsigned, B: Bit> Mul<B1> for UInt<U, B> {
     type Output = UInt<U, B>;
-    fn mul(self, _: B1) -> Self::Output { unreachable!() }
+    fn mul(self, _: B1) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// `UInt<U, B> * UTerm = UTerm`
 impl<U: Unsigned, B: Bit> Mul<UTerm> for UInt<U, B> {
     type Output = UTerm;
-    fn mul(self, _: UTerm) -> Self::Output { unreachable!() }
+    fn mul(self, _: UTerm) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// `UTerm * UInt<U, B> = UTerm`
 impl<U: Unsigned, B: Bit> Mul<UInt<U, B>> for UTerm {
     type Output = UTerm;
-    fn mul(self, _: UInt<U, B>) -> Self::Output { unreachable!() }
+    fn mul(self, _: UInt<U, B>) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// `UTerm * UTerm = UTerm`
 impl Mul<UTerm> for UTerm {
     type Output = UTerm;
-    fn mul(self, _: UTerm) -> Self::Output { unreachable!() }
+    fn mul(self, _: UTerm) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// `UInt<Ul, B0> * UInt<Ur, B> = UInt<(Ul * UInt<Ur, B>), B0>`
 impl<Ul: Unsigned, B: Bit, Ur: Unsigned> Mul<UInt<Ur, B>> for UInt<Ul, B0>
-   where Ul: Mul<UInt<Ur, B>>
+    where Ul: Mul<UInt<Ur, B>>
 {
-    type Output = UInt<<Ul as Mul<UInt<Ur, B>>>::Output, B0>;
-    fn mul(self, _: UInt<Ur, B>) -> Self::Output { unreachable!() }
+    type Output = UInt<Prod<Ul, UInt<Ur, B>>, B0>;
+    fn mul(self, _: UInt<Ur, B>) -> Self::Output {
+        unreachable!()
+    }
 }
 
 /// `UInt<Ul, B1> * UInt<Ur, B> = UInt<(Ul * UInt<Ur, B>), B0> + UInt<Ur, B>`
 impl<Ul: Unsigned, B: Bit, Ur: Unsigned> Mul<UInt<Ur, B>> for UInt<Ul, B1>
     where Ul: Mul<UInt<Ur, B>>,
-UInt<<Ul as Mul<UInt<Ur, B>>>::Output, B0>: Add<UInt<Ur, B>>
+          UInt<Prod<Ul, UInt<Ur, B>>, B0>: Add<UInt<Ur, B>>
 {
-    type Output = <UInt<<Ul as Mul<UInt<Ur, B>>>::Output, B0> as Add<UInt<Ur, B>>>::Output;
-    fn mul(self, _: UInt<Ur, B>) -> Self::Output { unreachable!() }
+    type Output = Sum<UInt<Prod<Ul, UInt<Ur, B>>, B0>, UInt<Ur, B>>;
+    fn mul(self, _: UInt<Ur, B>) -> Self::Output {
+        unreachable!()
+    }
 }
 
 // ---------------------------------------------------------------------------------------
@@ -655,51 +819,75 @@ impl<U: Unsigned, B: Bit> Cmp<UInt<U, B>> for UTerm {
 impl<Ul: Unsigned, Bl: Bit, Ur: Unsigned, Br: Bit> Cmp<UInt<Ur, Br>> for UInt<Ul, Bl>
     where UInt<Ul, Bl>: PrivateCmp<UInt<Ur, Br>, Equal>
 {
-    type Output = <UInt<Ul, Bl> as PrivateCmp<UInt<Ur, Br>, Equal>>::Output;
+    type Output = PrivateCmpOut<UInt<Ul, Bl>, UInt<Ur, Br>, Equal>;
 }
 
 /// Comparing non-terimal bits, with both having bit B0. These are the same, so we propogate `SoFar`.
 impl<Ul, Bl, Ur, Br, S> PrivateCmp<UInt<UInt<Ur, Br>, B0>, S> for UInt<UInt<Ul, Bl>, B0>
-    where Ul: Unsigned, Bl: Bit, Ur: Unsigned, Br: Bit, S: Ord,
-          UInt<Ul, Bl>: PrivateCmp<UInt<Ur, Br>, S>,
+    where Ul: Unsigned,
+          Bl: Bit,
+          Ur: Unsigned,
+          Br: Bit,
+          S: Ord,
+          UInt<Ul, Bl>: PrivateCmp<UInt<Ur, Br>, S>
 {
-    type Output = <UInt<Ul, Bl> as PrivateCmp<UInt<Ur, Br>, S>>::Output;
+    type Output = PrivateCmpOut<UInt<Ul, Bl>, UInt<Ur, Br>, S>;
 }
 
 /// Comparing non-terimal bits, with both having bit B1. These are the same, so we propogate `SoFar`.
 impl<Ul, Bl, Ur, Br, S> PrivateCmp<UInt<UInt<Ur, Br>, B1>, S> for UInt<UInt<Ul, Bl>, B1>
-    where Ul: Unsigned, Bl: Bit, Ur: Unsigned, Br: Bit, S: Ord,
-          UInt<Ul, Bl>: PrivateCmp<UInt<Ur, Br>, S>,
+    where Ul: Unsigned,
+          Bl: Bit,
+          Ur: Unsigned,
+          Br: Bit,
+          S: Ord,
+          UInt<Ul, Bl>: PrivateCmp<UInt<Ur, Br>, S>
 {
-    type Output = <UInt<Ul, Bl> as PrivateCmp<UInt<Ur, Br>, S>>::Output;
+    type Output = PrivateCmpOut<UInt<Ul, Bl>, UInt<Ur, Br>, S>;
 }
 
 /// Comparing non-terimal bits, with Lhs having bit B0 and Rhs having bit B1. `SoFar`, Lhs is `Less`.
 impl<Ul, Bl, Ur, Br, S> PrivateCmp<UInt<UInt<Ur, Br>, B1>, S> for UInt<UInt<Ul, Bl>, B0>
-    where Ul: Unsigned, Bl: Bit, Ur: Unsigned, Br: Bit, S: Ord,
-          UInt<Ul, Bl>: PrivateCmp<UInt<Ur, Br>, Less>,
+    where Ul: Unsigned,
+          Bl: Bit,
+          Ur: Unsigned,
+          Br: Bit,
+          S: Ord,
+          UInt<Ul, Bl>: PrivateCmp<UInt<Ur, Br>, Less>
 {
-    type Output = <UInt<Ul, Bl> as PrivateCmp<UInt<Ur, Br>, Less>>::Output;
+    type Output = PrivateCmpOut<UInt<Ul, Bl>, UInt<Ur, Br>, Less>;
 }
 
 /// Comparing non-terimal bits, with Lhs having bit B1 and Rhs having bit B0. `SoFar`, Lhs is `Greater`.
 impl<Ul, Bl, Ur, Br, S> PrivateCmp<UInt<UInt<Ur, Br>, B0>, S> for UInt<UInt<Ul, Bl>, B1>
-    where Ul: Unsigned, Bl: Bit, Ur: Unsigned, Br: Bit, S: Ord,
-          UInt<Ul, Bl>: PrivateCmp<UInt<Ur, Br>, Greater>,
+    where Ul: Unsigned,
+          Bl: Bit,
+          Ur: Unsigned,
+          Br: Bit,
+          S: Ord,
+          UInt<Ul, Bl>: PrivateCmp<UInt<Ur, Br>, Greater>
 {
-    type Output = <UInt<Ul, Bl> as PrivateCmp<UInt<Ur, Br>, Greater>>::Output;
+    type Output = PrivateCmpOut<UInt<Ul, Bl>, UInt<Ur, Br>, Greater>;
 }
 
 /// Comparing when Rhs has finished but Lhs has not; Lhs is `Greater`.
 impl<Ul, Bl1, Bl2, Br, S> PrivateCmp<UInt<UTerm, Br>, S> for UInt<UInt<Ul, Bl2>, Bl1>
-    where Ul: Unsigned, Bl1: Bit, Bl2: Bit, Br: Bit, S: Ord
+    where Ul: Unsigned,
+          Bl1: Bit,
+          Bl2: Bit,
+          Br: Bit,
+          S: Ord
 {
     type Output = Greater;
 }
 
 /// Comparing when Lhs has finished but Rhs has not; Lhs is `Less`.
 impl<Bl, Ur, Br1, Br2, S> PrivateCmp<UInt<UInt<Ur, Br2>, Br1>, S> for UInt<UTerm, Bl>
-    where Bl: Bit, Ur: Unsigned, Br1: Bit, Br2: Bit, S: Ord
+    where Bl: Bit,
+          Ur: Unsigned,
+          Br1: Bit,
+          Br2: Bit,
+          S: Ord
 {
     type Output = Less;
 }
@@ -749,14 +937,18 @@ macro_rules! test_ord {
 // Getting difference in number of bits
 
 impl<Ul, Bl, Ur, Br> BitDiff<UInt<Ur, Br>> for UInt<Ul, Bl>
-    where Ul: Unsigned, Bl: Bit, Ur: Unsigned, Br: Bit,
+    where Ul: Unsigned,
+          Bl: Bit,
+          Ur: Unsigned,
+          Br: Bit,
           Ul: BitDiff<Ur>
 {
-    type Output = <Ul as BitDiff<Ur>>::Output;
+    type Output = BitDiffOut<Ul, Ur>;
 }
 
-impl<Ul> BitDiff<UTerm> for Ul where Ul: Unsigned + SizeOf {
-    type Output = <Ul as SizeOf>::Output;
+impl<Ul> BitDiff<UTerm> for Ul where Ul: Unsigned + SizeOf
+{
+    type Output = SizeOfOut<Ul>;
 }
 
 // ---------------------------------------------------------------------------------------
@@ -764,42 +956,42 @@ impl<Ul> BitDiff<UTerm> for Ul where Ul: Unsigned + SizeOf {
 
 impl<Ul: Unsigned, Ur: Unsigned> ShiftDiff<Ur> for Ul
     where Ur: BitDiff<Ul>,
-          Ul: Shl<<Ur as BitDiff<Ul>>::Output>
+          Ul: Shl<BitDiffOut<Ur, Ul>>
 {
-    type Output = <Ul as Shl<<Ur as BitDiff<Ul>>::Output>>::Output;
+    type Output = Shleft<Ul, BitDiffOut<Ur, Ul>>;
 }
 
 // ---------------------------------------------------------------------------------------
 // Powers of unsigned integers
 
-impl<X: Unsigned, N: Unsigned> Pow<N> for X
-    where X: PrivatePow<U1, N>
+impl<X: Unsigned, N: Unsigned> Pow<N> for X where X: PrivatePow<U1, N>
 {
-    type Output = <X as PrivatePow<U1, N>>::Output;
+    type Output = PrivatePowOut<X, U1, N>;
 }
 
 impl<Y: Unsigned, X: Unsigned> PrivatePow<Y, U0> for X {
     type Output = Y;
 }
 
-impl<Y: Unsigned, X: Unsigned> PrivatePow<Y, U1> for X
-    where X: Mul<Y>
+impl<Y: Unsigned, X: Unsigned> PrivatePow<Y, U1> for X where X: Mul<Y>
 {
-    type Output = <X as Mul<Y>>::Output;
+    type Output = Prod<X, Y>;
 }
 
 // N is even
 impl<Y: Unsigned, U: Unsigned, B: Bit, X: Unsigned> PrivatePow<Y, UInt<UInt<U, B>, B0>> for X
-    where X: Mul, <X as Mul>::Output: PrivatePow<Y, UInt<U, B>>
+    where X: Mul,
+          Square<X>: PrivatePow<Y, UInt<U, B>>
 {
-    type Output = <<X as Mul>::Output as PrivatePow<Y, UInt<U, B>>>::Output;
+    type Output = PrivatePowOut<Square<X>, Y, UInt<U, B>>;
 }
+
 // N is odd
 impl<Y: Unsigned, U: Unsigned, B: Bit, X: Unsigned> PrivatePow<Y, UInt<UInt<U, B>, B1>> for X
     where X: Mul + Mul<Y>,
-<X as Mul>::Output: PrivatePow<<X as Mul<Y>>::Output, UInt<U, B>>
+          Square<X>: PrivatePow<Prod<X, Y>, UInt<U, B>>
 {
-    type Output = <<X as Mul>::Output as PrivatePow<<X as Mul<Y>>::Output, UInt<U, B>>>::Output;
+    type Output = PrivatePowOut<Square<X>, Prod<X, Y>, UInt<U, B>>;
 }
 
 // ---------------------------------------------------------------------------------------
@@ -841,7 +1033,9 @@ impl<Y: Unsigned, U: Unsigned, B: Bit, X: Unsigned> PrivatePow<Y, UInt<UInt<U, B
 // Div
 impl<Ur: Unsigned, Br: Bit> Div<UInt<Ur, Br>> for UTerm {
     type Output = UTerm;
-    fn div(self, _: UInt<Ur, Br>) -> Self::Output { unreachable!() }
+    fn div(self, _: UInt<Ur, Br>) -> Self::Output {
+        unreachable!()
+    }
 }
 
 impl<Ul: Unsigned, Bl: Bit, Ur: Unsigned, Br: Bit> Div<UInt<Ur, Br>> for UInt<Ul, Bl>
@@ -901,7 +1095,9 @@ impl<Divisor: Unsigned, Numerator: Unsigned> PrivateDivFirstStep<Greater, Diviso
 
 // Remainder < Divisor: return Q
 impl<Q, Divisor, Remainder> PrivateDiv<Less, U0, Q, Divisor> for Remainder
-    where Q: Unsigned, Divisor: Unsigned, Remainder: Unsigned
+    where Q: Unsigned,
+          Divisor: Unsigned,
+          Remainder: Unsigned
 {
     type Quotient = Q;
     type Remainder = Remainder;
@@ -909,7 +1105,9 @@ impl<Q, Divisor, Remainder> PrivateDiv<Less, U0, Q, Divisor> for Remainder
 
 // Remainder == Divisor: return Q + 1
 impl<Q, Divisor, Remainder> PrivateDiv<Equal, U0, Q, Divisor> for Remainder
-    where Q: Unsigned, Divisor: Unsigned, Remainder: Unsigned,
+    where Q: Unsigned,
+          Divisor: Unsigned,
+          Remainder: Unsigned,
           Q: Add<U1>
 {
     type Quotient = <Q as Add<U1>>::Output;
@@ -918,8 +1116,11 @@ impl<Q, Divisor, Remainder> PrivateDiv<Equal, U0, Q, Divisor> for Remainder
 
 // Remainder > Divisor: return Q + 1
 impl<Q, Divisor, Remainder> PrivateDiv<Greater, U0, Q, Divisor> for Remainder
-    where Q: Unsigned, Divisor: Unsigned, Remainder: Unsigned,
-          Q: Add<U1>, Remainder: Sub<Divisor>
+    where Q: Unsigned,
+          Divisor: Unsigned,
+          Remainder: Unsigned,
+          Q: Add<U1>,
+          Remainder: Sub<Divisor>
 {
     type Quotient = <Q as Add<U1>>::Output;
     type Remainder = <Remainder as Sub<Divisor>>::Output;
@@ -930,7 +1131,11 @@ impl<Q, Divisor, Remainder> PrivateDiv<Greater, U0, Q, Divisor> for Remainder
 
 // Remainder == Divisor: return Q + 2^I = Q + 1 << I
 impl<Ui, Bi, Q, Divisor, Remainder> PrivateDiv<Equal, UInt<Ui, Bi>, Q, Divisor> for Remainder
-    where Ui: Unsigned, Bi: Bit, Q: Unsigned, Divisor: Unsigned, Remainder: Unsigned,
+    where Ui: Unsigned,
+          Bi: Bit,
+          Q: Unsigned,
+          Divisor: Unsigned,
+          Remainder: Unsigned,
           U1: Shl<UInt<Ui, Bi>>,
           Q: Add<<U1 as Shl<UInt<Ui, Bi>>>::Output>
 {
@@ -1003,7 +1208,9 @@ impl<Ui, Bi, Q, Divisor, Remainder> PrivateDiv<Greater, UInt<Ui, Bi>, Q, Divisor
 
 impl<Ur: Unsigned, Br: Bit> Rem<UInt<Ur, Br>> for UTerm {
     type Output = UTerm;
-    fn rem(self, _: UInt<Ur, Br>) -> Self::Output { unreachable!() }
+    fn rem(self, _: UInt<Ur, Br>) -> Self::Output {
+        unreachable!()
+    }
 }
 
 impl<Ul: Unsigned, Bl: Bit, Ur: Unsigned, Br: Bit> Rem<UInt<Ur, Br>> for UInt<Ul, Bl>


### PR DESCRIPTION
See #48

Here is the full mapping of operator trait to alias. I'm not super happy with some of these, and would be happy to consider different names. I have also not included one for `Not` as I can't come up with a name for it.

`And` for `BitAnd`
`Or` for `BitOr`
`Xor` for `BitXor`

`Shleft` for `Shl`
`Shright` for `Shr`

`Sum` for `Add`
`Diff` for `Sub`
`Prod` for `Mul`
`Quot` for `Div`
`Mod` for `Rem`

`Negate` for `Neg`
`Exp` for `Pow`

`Add1` for `Add<B1>`
`Sub1` for `Sub<B1>`

`Square` and `Cube` for doing those things.

`Compare` for `Cmp`


For all of the private operators, I have also created aliased that have the same name followed by a shortened version of the associated type(usually `Out`. `Rem` and `Quot` are used in division-related operators). E.g. `TrimOut<A> = <A as Trim>::Output`. I started switching code to use these for better readability, but did not finish.