### PR TITLE
Remove all dependency on std in favor of core.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ script:
   - |
     travis-cargo build &&
     travis-cargo test &&
-    travis-cargo --only beta test -- --features "no_std" &&
-    travis-cargo --only nightly test -- --features "no_std" &&
+    # Note: The "no_std" flag is deprecated and this test remains to make sure we don't break compatibility.
+    travis-cargo --only stable test -- --features "no_std" &&
     travis-cargo --only stable doc
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,17 +14,17 @@ before_script:
   - export TRAVIS_CARGO_NIGHTLY_FEATURE=""
 script:
   - |
-    travis-cargo build
-    && travis-cargo test
+    travis-cargo build &&
+    travis-cargo test &&
     # Note: The "no_std" flag is deprecated and this test remains to make sure we don't break compatibility.
-    && travis-cargo --only stable test -- --features "no_std"
-    && travis-cargo --only stable doc
+    travis-cargo --only stable test -- --features "no_std" &&
+    travis-cargo --only stable doc
 
 after_success:
-  - test $TRAVIS_PULL_REQUEST == "false"
-    && test $TRAVIS_BRANCH == "master"
-    && cargo publish --token ${CRATESIO_TOKEN}
-    && travis-cargo --only stable doc-upload
+  - test $TRAVIS_PULL_REQUEST == "false" &&
+    test $TRAVIS_BRANCH == "master" &&
+    cargo publish --token ${CRATESIO_TOKEN} &&
+    travis-cargo --only stable doc-upload &&
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,15 +14,17 @@ before_script:
   - export TRAVIS_CARGO_NIGHTLY_FEATURE=""
 script:
   - |
-    travis-cargo build &&
-    travis-cargo test &&
+    travis-cargo build
+    && travis-cargo test
     # Note: The "no_std" flag is deprecated and this test remains to make sure we don't break compatibility.
-    travis-cargo --only stable test -- --features "no_std" &&
-    travis-cargo --only stable doc
+    && travis-cargo --only stable test -- --features "no_std"
+    && travis-cargo --only stable doc
 
 after_success:
-  - travis-cargo --only stable doc-upload
-  - test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "master" && cargo publish --token ${CRATESIO_TOKEN}
+  - test $TRAVIS_PULL_REQUEST == "false"
+    && test $TRAVIS_BRANCH == "master"
+    && cargo publish --token ${CRATESIO_TOKEN}
+    && travis-cargo --only stable doc-upload
 
 env:
   global:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,10 @@
 This project follows semantic versioning.
 
 ### Unpublished
+    - [changed] Removed dependency on libstd. ([Issue #53](https://github.com/paholg/typenum/issues/53), [PR #55](https://github.com/paholg/typenum/pull/55))
+
 
 ### 1.2.0 (2016-01-03)
-- [added] This change log!
-- [added] Convenience type aliases for operators. ([Issues #48](https://github.com/paholg/typenum/issues/48), [PR #50](https://github.com/paholg/typenum/pull/50))
-- [added] Types in this crate now derive all possible traits. ([Issue #42](https://github.com/paholg/typenum/issues/48), [PR #51](https://github.com/paholg/typenum/pull/51))
+    - [added] This change log!
+    - [added] Convenience type aliases for operators. ([Issue #48](https://github.com/paholg/typenum/issues/48), [PR #50](https://github.com/paholg/typenum/pull/50))
+    - [added] Types in this crate now derive all possible traits. ([Issue #42](https://github.com/paholg/typenum/issues/48), [PR #51](https://github.com/paholg/typenum/pull/51))

--- a/README.md
+++ b/README.md
@@ -7,9 +7,11 @@ Typenum
 Typenum is a Rust library for type-level numbers evaluated at compile time. It currently
 supports bits, unsigned integers, and signed integers.
 
+Typenum depends only on libcore, and so is suitable for use on any platform!
+
 For the full documentation, go [here](http://paholg.com/typenum).
 
-Here is a short example of its use:
+Here is a trivial example of its use:
 
 ```rust
 use std::ops::Add;
@@ -23,3 +25,10 @@ assert_eq!(<X as Integer>::to_i32(), 7);
 type Y = <N2 as Pow<P3>>::Output;
 assert_eq!(<Y as Integer>::to_i32(), -8);
 ```
+
+For a non-trivial example of its use, see one of the crates that depends on it. The full
+list is [here](https://crates.io/crates/typenum/reverse_dependencies). Of note are
+[dimensioned](https://crates.io/crates/dimensioned/) which does compile-time type
+checking for arbitrary unit systems and
+[generic-array](https://crates.io/crates/generic-array/) which provides arrays whose
+length you can generically refer to.

--- a/src/__private.rs
+++ b/src/__private.rs
@@ -22,7 +22,7 @@
 
 #![doc(hidden)]
 
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 // use ::{Sub};
 use bit::{Bit, B1, B0};

--- a/src/bit.rs
+++ b/src/bit.rs
@@ -6,20 +6,20 @@ other number types in this crate.
 
 *Type operators** implemented:
 
-From std::ops: `BitAnd`, `BitOr`, `BitXor`, and `Not`.
+From core::ops: `BitAnd`, `BitOr`, `BitXor`, and `Not`.
 From typenum: `Same` and `Cmp`.
 */
 
-use std::ops::{BitAnd, BitOr, BitXor, Not};
+use core::ops::{BitAnd, BitOr, BitXor, Not};
 use {NonZero, Cmp, Greater, Less, Equal};
 
 /// The type-level bit 0.
-#[cfg_attr(not(feature="no_std"), derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug))]
 pub enum B0 {}
+impl_derivable!{B0}
 
 /// The type-level bit 1.
-#[cfg_attr(not(feature="no_std"), derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug))]
 pub enum B1 {}
+impl_derivable!{B1}
 
 /**
 The **marker trait** for compile time bits.

--- a/src/int.rs
+++ b/src/int.rs
@@ -5,7 +5,7 @@ Type-level signed integers.
 
 *Type operators** implemented:
 
-From std::ops: `Add`, `Sub`, `Mul`, `Div`, and `Rem`.
+From core::ops: `Add`, `Sub`, `Mul`, `Div`, and `Rem`.
 From typenum: `Same`, `Cmp`, and `Pow`.
 
 Rather than directly using the structs defined in this module, it is recommended that
@@ -30,9 +30,9 @@ assert_eq!(<N3 as Rem<P2>>::Output::to_i32(), -1);
 ```
 */
 
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
-use std::ops::{Neg, Add, Sub, Mul, Div, Rem};
+use core::ops::{Neg, Add, Sub, Mul, Div, Rem};
 
 use {NonZero, Pow, Cmp, Greater, Equal, Less};
 use uint::{Unsigned, UInt};
@@ -43,7 +43,7 @@ use consts::{U0, U1, P1, N1};
 /**
 Type-level signed integers with positive sign.
  */
-#[cfg_attr(not(feature="no_std"), derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug))]
+#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug)]
 pub struct PInt<U: Unsigned + NonZero> {
     _marker: PhantomData<U>,
 }
@@ -51,7 +51,7 @@ pub struct PInt<U: Unsigned + NonZero> {
 /**
 Type-level signed integers with negative sign.
 */
-#[cfg_attr(not(feature="no_std"), derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug))]
+#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug)]
 pub struct NInt<U: Unsigned + NonZero> {
     _marker: PhantomData<U>,
 }
@@ -59,8 +59,8 @@ pub struct NInt<U: Unsigned + NonZero> {
 /**
 The type-level signed integer 0.
 */
-#[cfg_attr(not(feature="no_std"), derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug))]
 pub enum Z0 {}
+impl_derivable!{Z0}
 
 /**
 The **marker trait** for compile time signed integers.
@@ -550,19 +550,19 @@ macro_rules! test_ord {
     ($Lhs:ident > $Rhs:ident) => (
         {
             type Test = <$Lhs as Cmp<$Rhs>>::Output;
-            assert_eq!(::std::cmp::Ordering::Greater, <Test as Ord>::to_ordering());
+            assert_eq!(::core::cmp::Ordering::Greater, <Test as Ord>::to_ordering());
         }
         );
     ($Lhs:ident == $Rhs:ident) => (
         {
             type Test = <$Lhs as Cmp<$Rhs>>::Output;
-            assert_eq!(::std::cmp::Ordering::Equal, <Test as Ord>::to_ordering());
+            assert_eq!(::core::cmp::Ordering::Equal, <Test as Ord>::to_ordering());
         }
         );
     ($Lhs:ident < $Rhs:ident) => (
         {
             type Test = <$Lhs as Cmp<$Rhs>>::Output;
-            assert_eq!(::std::cmp::Ordering::Less, <Test as Ord>::to_ordering());
+            assert_eq!(::core::cmp::Ordering::Less, <Test as Ord>::to_ordering());
         }
         );
 }

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -5,7 +5,7 @@ Type-level unsigned integers.
 
 *Type operators** implemented:
 
-From std::ops: `BitAnd`, `BitOr`, `BitXor`, `Shl`, `Shr`, `Add`, `Sub`, `Mul`, `Div`, and `Rem`.
+From core::ops: `BitAnd`, `BitOr`, `BitXor`, `Shl`, `Shr`, `Add`, `Sub`, `Mul`, `Div`, and `Rem`.
 From typenum: `Same`, `Cmp`, and `Pow`.
 
 Rather than directly using the structs defined in this module, it is recommended that
@@ -30,9 +30,9 @@ assert_eq!(<U3 as Rem<U2>>::Output::to_u32(), 1);
 ```
 */
 
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
-use std::ops::{BitAnd, BitOr, BitXor, Shl, Shr, Add, Sub, Mul, Div, Rem};
+use core::ops::{BitAnd, BitOr, BitXor, Shl, Shr, Add, Sub, Mul, Div, Rem};
 use {NonZero, Ord, Greater, Equal, Less, Cmp, Pow};
 use bit::{Bit, B0, B1};
 
@@ -76,8 +76,8 @@ pub trait Unsigned {
 The terminating type for `UInt`; it always comes after the most significant bit. `UTerm`
  by itself represents zero, which is aliased to `U0`.
  */
-#[cfg_attr(not(feature="no_std"), derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug))]
 pub enum UTerm {}
+impl_derivable!{UTerm}
 
 impl Unsigned for UTerm {
     #[inline]
@@ -141,7 +141,7 @@ use typenum::bit::{B1, B0};
 type U6 = UInt<UInt<UInt<UTerm, B1>, B1>, B0>;
 ```
  */
-#[cfg_attr(not(feature="no_std"), derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug))]
+#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug)]
 pub struct UInt<U, B> {
     _marker: PhantomData<(U, B)>,
 }
@@ -918,19 +918,19 @@ macro_rules! test_ord {
     ($Lhs:ident > $Rhs:ident) => (
         {
             type Test = <$Lhs as Cmp<$Rhs>>::Output;
-            assert_eq!(::std::cmp::Ordering::Greater, <Test as Ord>::to_ordering());
+            assert_eq!(::core::cmp::Ordering::Greater, <Test as Ord>::to_ordering());
         }
         );
     ($Lhs:ident == $Rhs:ident) => (
         {
             type Test = <$Lhs as Cmp<$Rhs>>::Output;
-            assert_eq!(::std::cmp::Ordering::Equal, <Test as Ord>::to_ordering());
+            assert_eq!(::core::cmp::Ordering::Equal, <Test as Ord>::to_ordering());
         }
         );
     ($Lhs:ident < $Rhs:ident) => (
         {
             type Test = <$Lhs as Cmp<$Rhs>>::Output;
-            assert_eq!(::std::cmp::Ordering::Less, <Test as Ord>::to_ordering());
+            assert_eq!(::core::cmp::Ordering::Less, <Test as Ord>::to_ordering());
         }
         );
 }


### PR DESCRIPTION
With libcore stabilized in 1.6, we no longer need to depend on std.

This comes with a couple caveats, however.

First, `#derive` is currently broken for empty enums in libcore. I have worked around this by creating a macro to do it instead, but I'm not positive that it does what `#derive` would and would like a second pair of eyes.

Second, the feature flag `no_std` is no longer necessary. Removing it causes an error for anyone who passes the flag, though, so to keep from breaking anything downstream, I would like to make passing the flag issue a warning, although I'm uncertain if this is possible or how to do it.

This closes #53.