### PR TITLE
get rid of PhantomData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,10 @@
 This project follows semantic versioning.
 
 ### Unpublished
+    - [changed] Integers no longer use PhantomData
 
 ### 1.3.1 (2016-03-31)
-	- [fixed] Bug with recent nightlies.
+    - [fixed] Bug with recent nightlies.
 
 ### 1.3.0 (2016-02-07)
     - [changed] Removed dependency on libstd. (Issue #53, PR #55)

--- a/src/int.rs
+++ b/src/int.rs
@@ -27,8 +27,6 @@
 //! ```
 //!
 
-use core::marker::PhantomData;
-
 use core::ops::{Neg, Add, Sub, Mul, Div, Rem};
 
 use {NonZero, Pow, Cmp, Greater, Equal, Less};
@@ -42,13 +40,13 @@ pub use marker_traits::Integer;
 /// Type-level signed integers with positive sign.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug)]
 pub struct PInt<U: Unsigned + NonZero> {
-    _marker: PhantomData<U>,
+    _marker: U,
 }
 
 /// Type-level signed integers with negative sign.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug)]
 pub struct NInt<U: Unsigned + NonZero> {
-    _marker: PhantomData<U>,
+    _marker: U,
 }
 
 /// The type-level signed integer 0.

--- a/src/private.rs
+++ b/src/private.rs
@@ -21,8 +21,6 @@
 
 #![doc(hidden)]
 
-use core::marker::PhantomData;
-
 // use ::{Sub};
 use bit::{Bit, B1, B0};
 use uint::{Unsigned, UInt, UTerm};
@@ -71,7 +69,7 @@ pub enum InvertedUTerm {}
 
 /// Inverted `UInt` (has most significant digit on the outside)
 pub struct InvertedUInt<IU: InvertedUnsigned, B: Bit> {
-    _marker: PhantomData<(IU, B)>,
+    _marker: (IU, B),
 }
 
 /// Does the real anding for `UInt`s; `And` just calls this and then `Trim`.

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -28,8 +28,6 @@
 //! ```
 //!
 
-use core::marker::PhantomData;
-
 use core::ops::{BitAnd, BitOr, BitXor, Shl, Shr, Add, Sub, Mul, Div, Rem};
 use {NonZero, Ord, Greater, Equal, Less, Pow, Cmp};
 use bit::{Bit, B0, B1};
@@ -112,7 +110,7 @@ impl Unsigned for UTerm {
 /// ```
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug)]
 pub struct UInt<U, B> {
-    _marker: PhantomData<(U, B)>,
+    _marker: (U, B),
 }
 
 impl<U: Unsigned, B: Bit> Unsigned for UInt<U, B> {


### PR DESCRIPTION
Since our types are already zero-sized and/or uninstantiable, we can as
well get rid of the PhantomData and use the tuples directly.

Doing so drops 3MB and 3/100 seconds from the build profile, which is
inconsequential, but since it makes the code easier, I'll suggest it
anyway.

Not sure if this is a breaking change, so I'll let you update the
version number.