### PR TITLE
Make UTerm, UInt, NInt, and PInt instantiable.

### DIFF
--- a/src/int.rs
+++ b/src/int.rs
@@ -51,7 +51,7 @@ pub struct NInt<U: Unsigned + NonZero> {
 }
 
 impl<U: Unsigned + NonZero> PInt<U> {
-    /// Instanciates a singleton representing this strictly positive integer.
+    /// Instantiates a singleton representing this strictly positive integer.
     #[inline]
     pub fn new() -> PInt<U> {
         PInt {
@@ -61,7 +61,7 @@ impl<U: Unsigned + NonZero> PInt<U> {
 }
 
 impl<U: Unsigned + NonZero> NInt<U> {
-    /// Instanciates a singleton representing this strictly negative integer.
+    /// Instantiates a singleton representing this strictly negative integer.
     #[inline]
     pub fn new() -> NInt<U> {
         NInt {

--- a/src/int.rs
+++ b/src/int.rs
@@ -28,6 +28,7 @@
 //!
 
 use core::ops::{Neg, Add, Sub, Mul, Div, Rem};
+use core::marker::PhantomData;
 
 use {NonZero, Pow, Cmp, Greater, Equal, Less};
 use uint::{Unsigned, UInt};
@@ -40,13 +41,33 @@ pub use marker_traits::Integer;
 /// Type-level signed integers with positive sign.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug)]
 pub struct PInt<U: Unsigned + NonZero> {
-    _marker: U,
+    _marker: PhantomData<U>,
 }
 
 /// Type-level signed integers with negative sign.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug)]
 pub struct NInt<U: Unsigned + NonZero> {
-    _marker: U,
+    _marker: PhantomData<U>,
+}
+
+impl<U: Unsigned + NonZero> PInt<U> {
+    /// Instanciates a singleton representing this strictly positive integer.
+    #[inline]
+    pub fn new() -> PInt<U> {
+        PInt {
+            _marker: PhantomData
+        }
+    }
+}
+
+impl<U: Unsigned + NonZero> NInt<U> {
+    /// Instanciates a singleton representing this strictly negative integer.
+    #[inline]
+    pub fn new() -> NInt<U> {
+        NInt {
+            _marker: PhantomData
+        }
+    }
 }
 
 /// The type-level signed integer 0.

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -115,7 +115,7 @@ pub struct UInt<U, B> {
 }
 
 impl<U: Unsigned, B: Bit> UInt<U, B> {
-    /// Instanciates a singleton representing this unsigned integer.
+    /// Instantiates a singleton representing this unsigned integer.
     #[inline]
     pub fn new() -> UInt<U, B> {
         UInt {

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -29,6 +29,7 @@
 //!
 
 use core::ops::{BitAnd, BitOr, BitXor, Shl, Shr, Add, Sub, Mul, Div, Rem};
+use core::marker::PhantomData;
 use {NonZero, Ord, Greater, Equal, Less, Pow, Cmp};
 use bit::{Bit, B0, B1};
 
@@ -46,8 +47,8 @@ pub use marker_traits::Unsigned;
 
 /// The terminating type for `UInt`; it always comes after the most significant
 /// bit. `UTerm` by itself represents zero, which is aliased to `U0`.
-pub enum UTerm {}
-impl_derivable!{UTerm}
+#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug)]
+pub struct UTerm {}
 
 impl Unsigned for UTerm {
     #[inline]
@@ -110,7 +111,17 @@ impl Unsigned for UTerm {
 /// ```
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug)]
 pub struct UInt<U, B> {
-    _marker: (U, B),
+    _marker: PhantomData<(U, B)>,
+}
+
+impl<U: Unsigned, B: Bit> UInt<U, B> {
+    /// Instanciates a singleton representing this unsigned integer.
+    #[inline]
+    pub fn new() -> UInt<U, B> {
+        UInt {
+            _marker: PhantomData
+        }
+    }
 }
 
 impl<U: Unsigned, B: Bit> Unsigned for UInt<U, B> {


### PR DESCRIPTION
See #67 for the use-case.

This does not implement `Add`, `Sub`, etc. without `unreachable()` as I am not sure how to proceed. In particular some implementations return associated types like `type Output = TrimOut<PrivateSubOut<UInt<Ul, Bl>, Ur>>` which are not instanciable explicitly. I can see two options here:

* return `unsafe { mem::uninitialized() }`, which is OK because we use ZSTs anyway. The `uninitialized()` will be a no-op:
```rust
impl<Ul: Unsigned, Bl: Bit, Ur: Unsigned> Sub<Ur> for UInt<Ul, Bl>
    where UInt<Ul, Bl>: PrivateSub<Ur>,
          PrivateSubOut<UInt<Ul, Bl>, Ur>: Trim
{
    type Output = TrimOut<PrivateSubOut<UInt<Ul, Bl>, Ur>>;

    #[inline]
    fn sub(self, _: Ur) -> Self::Output {
        unsafe { mem::uninitialized() }
    }
} 
```

* Or specify some trait for the Output types and give this trait the power to create our ZSTs. For example:

```rust
trait IntBuilder {
    fn singleton() -> Self;
}

// Replaces std::ops::Mul.
trait MyMul {
    type Output: IntBuilder;
}
```
This second option is a deeper (and breaking) change of the library so it is probably not desirable.