### PR TITLE
Instantiate tweaks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 This project follows semantic versioning.
 
 ### Unpublished
-    - [changed] Integers no longer use PhantomData
+    - [added] The types in this crate are now instantiable. (Issue #67, PR #68)
 
 ### 1.3.1 (2016-03-31)
     - [fixed] Bug with recent nightlies.

--- a/src/bit.rs
+++ b/src/bit.rs
@@ -76,14 +76,14 @@ macro_rules! test_bit_op {
 impl Not for B0 {
     type Output = B1;
     fn not(self) -> Self::Output {
-        unreachable!()
+        Bit::new()
     }
 }
 /// Not of 1 (!1 = 0)
 impl Not for B1 {
     type Output = B0;
     fn not(self) -> Self::Output {
-        unreachable!()
+        Bit::new()
     }
 }
 
@@ -91,14 +91,14 @@ impl Not for B1 {
 impl<Rhs: Bit> BitAnd<Rhs> for B0 {
     type Output = B0;
     fn bitand(self, _: Rhs) -> Self::Output {
-        unreachable!()
+        Bit::new()
     }
 }
 /// And with 1 ( 1 & B = B)
 impl<Rhs: Bit> BitAnd<Rhs> for B1 {
     type Output = Rhs;
     fn bitand(self, _: Rhs) -> Self::Output {
-        unreachable!()
+        Bit::new()
     }
 }
 
@@ -106,14 +106,14 @@ impl<Rhs: Bit> BitAnd<Rhs> for B1 {
 impl<Rhs: Bit> BitOr<Rhs> for B0 {
     type Output = Rhs;
     fn bitor(self, _: Rhs) -> Self::Output {
-        unreachable!()
+        Bit::new()
     }
 }
 /// Or with 1 ( 1 | B = 1)
 impl<Rhs: Bit> BitOr<Rhs> for B1 {
     type Output = B1;
     fn bitor(self, _: Rhs) -> Self::Output {
-        unreachable!()
+        Bit::new()
     }
 }
 
@@ -121,28 +121,28 @@ impl<Rhs: Bit> BitOr<Rhs> for B1 {
 impl BitXor<B0> for B0 {
     type Output = B0;
     fn bitxor(self, _: B0) -> Self::Output {
-        unreachable!()
+        Bit::new()
     }
 }
 /// Xor between 1 and 0 ( 1 ^ 0 = 1)
 impl BitXor<B0> for B1 {
     type Output = B1;
     fn bitxor(self, _: B0) -> Self::Output {
-        unreachable!()
+        Bit::new()
     }
 }
 /// Xor between 0 and 1 ( 0 ^ 1 = 1)
 impl BitXor<B1> for B0 {
     type Output = B1;
     fn bitxor(self, _: B1) -> Self::Output {
-        unreachable!()
+        Bit::new()
     }
 }
 /// Xor between 1 and 1 ( 1 ^ 1 = 0)
 impl BitXor<B1> for B1 {
     type Output = B0;
     fn bitxor(self, _: B1) -> Self::Output {
-        unreachable!()
+        Bit::new()
     }
 }
 

--- a/src/bit.rs
+++ b/src/bit.rs
@@ -14,12 +14,12 @@ use {NonZero, Cmp, Greater, Less, Equal};
 pub use marker_traits::Bit;
 
 /// The type-level bit 0.
-pub enum B0 {}
-impl_derivable!{B0}
+#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug)]
+pub struct B0;
 
 /// The type-level bit 1.
-pub enum B1 {}
-impl_derivable!{B1}
+#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug)]
+pub struct B1;
 
 impl Bit for B0 {
     #[inline]
@@ -30,7 +30,13 @@ impl Bit for B0 {
     fn to_bool() -> bool {
         false
     }
+
+    #[inline]
+    fn new() -> Self {
+        B0
+    }
 }
+
 impl Bit for B1 {
     #[inline]
     fn to_u8() -> u8 {
@@ -39,6 +45,11 @@ impl Bit for B1 {
     #[inline]
     fn to_bool() -> bool {
         true
+    }
+
+    #[inline]
+    fn new() -> Self {
+        B1
     }
 }
 

--- a/src/bit.rs
+++ b/src/bit.rs
@@ -20,7 +20,7 @@ pub struct B0;
 impl B0 {
     /// Instantiates a singleton representing this bit.
     #[inline]
-    fn new() -> B0 {
+    pub fn new() -> B0 {
         B0
     }
 }
@@ -32,7 +32,7 @@ pub struct B1;
 impl B1 {
     /// Instantiates a singleton representing this bit.
     #[inline]
-    fn new() -> B1 {
+    pub fn new() -> B1 {
         B1
     }
 }
@@ -100,21 +100,39 @@ impl<Rhs: Bit> BitAnd<Rhs> for B0 {
         B0
     }
 }
-/// And with 1 ( 1 & B = B)
-impl<Rhs: Bit> BitAnd<Rhs> for B1 {
-    type Output = Rhs;
-    fn bitand(self, _: Rhs) -> Self::Output {
+
+/// And with 1 ( 1 & 0 = 0)
+impl BitAnd<B0> for B1 {
+    type Output = B0;
+    fn bitand(self, _: B0) -> Self::Output {
+        B0
+    }
+}
+
+/// And with 1 ( 1 & 1 = 1)
+impl BitAnd<B1> for B1 {
+    type Output = B1;
+    fn bitand(self, _: B1) -> Self::Output {
         B1
     }
 }
 
-/// Or with 0 ( 0 | B = B)
-impl<Rhs: Bit> BitOr<Rhs> for B0 {
-    type Output = Rhs;
-    fn bitor(self, _: Rhs) -> Self::Output {
+/// Or with 0 ( 0 | 0 = 0)
+impl BitOr<B0> for B0 {
+    type Output = B0;
+    fn bitor(self, _: B0) -> Self::Output {
         B0
     }
 }
+
+/// Or with 0 ( 0 | 1 = 1)
+impl BitOr<B1> for B0 {
+    type Output = B1;
+    fn bitor(self, _: B1) -> Self::Output {
+        B1
+    }
+}
+
 /// Or with 1 ( 1 | B = 1)
 impl<Rhs: Bit> BitOr<Rhs> for B1 {
     type Output = B1;
@@ -134,14 +152,14 @@ impl BitXor<B0> for B0 {
 impl BitXor<B0> for B1 {
     type Output = B1;
     fn bitxor(self, _: B0) -> Self::Output {
-        B0
+        B1
     }
 }
 /// Xor between 0 and 1 ( 0 ^ 1 = 1)
 impl BitXor<B1> for B0 {
     type Output = B1;
     fn bitxor(self, _: B1) -> Self::Output {
-        B0
+        B1
     }
 }
 /// Xor between 1 and 1 ( 1 ^ 1 = 0)

--- a/src/bit.rs
+++ b/src/bit.rs
@@ -17,9 +17,25 @@ pub use marker_traits::Bit;
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug)]
 pub struct B0;
 
+impl B0 {
+    /// Instantiates a singleton representing this bit.
+    #[inline]
+    fn new() -> B0 {
+        B0
+    }
+}
+
 /// The type-level bit 1.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug)]
 pub struct B1;
+
+impl B1 {
+    /// Instantiates a singleton representing this bit.
+    #[inline]
+    fn new() -> B1 {
+        B1
+    }
+}
 
 impl Bit for B0 {
     #[inline]
@@ -29,11 +45,6 @@ impl Bit for B0 {
     #[inline]
     fn to_bool() -> bool {
         false
-    }
-
-    #[inline]
-    fn new() -> Self {
-        B0
     }
 }
 
@@ -45,11 +56,6 @@ impl Bit for B1 {
     #[inline]
     fn to_bool() -> bool {
         true
-    }
-
-    #[inline]
-    fn new() -> Self {
-        B1
     }
 }
 
@@ -76,14 +82,14 @@ macro_rules! test_bit_op {
 impl Not for B0 {
     type Output = B1;
     fn not(self) -> Self::Output {
-        Bit::new()
+        B1
     }
 }
 /// Not of 1 (!1 = 0)
 impl Not for B1 {
     type Output = B0;
     fn not(self) -> Self::Output {
-        Bit::new()
+        B0
     }
 }
 
@@ -91,14 +97,14 @@ impl Not for B1 {
 impl<Rhs: Bit> BitAnd<Rhs> for B0 {
     type Output = B0;
     fn bitand(self, _: Rhs) -> Self::Output {
-        Bit::new()
+        B0
     }
 }
 /// And with 1 ( 1 & B = B)
 impl<Rhs: Bit> BitAnd<Rhs> for B1 {
     type Output = Rhs;
     fn bitand(self, _: Rhs) -> Self::Output {
-        Bit::new()
+        B1
     }
 }
 
@@ -106,14 +112,14 @@ impl<Rhs: Bit> BitAnd<Rhs> for B1 {
 impl<Rhs: Bit> BitOr<Rhs> for B0 {
     type Output = Rhs;
     fn bitor(self, _: Rhs) -> Self::Output {
-        Bit::new()
+        B0
     }
 }
 /// Or with 1 ( 1 | B = 1)
 impl<Rhs: Bit> BitOr<Rhs> for B1 {
     type Output = B1;
     fn bitor(self, _: Rhs) -> Self::Output {
-        Bit::new()
+        B1
     }
 }
 
@@ -121,28 +127,28 @@ impl<Rhs: Bit> BitOr<Rhs> for B1 {
 impl BitXor<B0> for B0 {
     type Output = B0;
     fn bitxor(self, _: B0) -> Self::Output {
-        Bit::new()
+        B0
     }
 }
 /// Xor between 1 and 0 ( 1 ^ 0 = 1)
 impl BitXor<B0> for B1 {
     type Output = B1;
     fn bitxor(self, _: B0) -> Self::Output {
-        Bit::new()
+        B0
     }
 }
 /// Xor between 0 and 1 ( 0 ^ 1 = 1)
 impl BitXor<B1> for B0 {
     type Output = B1;
     fn bitxor(self, _: B1) -> Self::Output {
-        Bit::new()
+        B0
     }
 }
 /// Xor between 1 and 1 ( 1 ^ 1 = 0)
 impl BitXor<B1> for B1 {
     type Output = B0;
     fn bitxor(self, _: B1) -> Self::Output {
-        Bit::new()
+        B0
     }
 }
 

--- a/src/int.rs
+++ b/src/int.rs
@@ -50,29 +50,9 @@ pub struct NInt<U: Unsigned + NonZero> {
     _marker: PhantomData<U>,
 }
 
-impl<U: Unsigned + NonZero> PInt<U> {
-    /// Instantiates a singleton representing this strictly positive integer.
-    #[inline]
-    pub fn new() -> PInt<U> {
-        PInt {
-            _marker: PhantomData
-        }
-    }
-}
-
-impl<U: Unsigned + NonZero> NInt<U> {
-    /// Instantiates a singleton representing this strictly negative integer.
-    #[inline]
-    pub fn new() -> NInt<U> {
-        NInt {
-            _marker: PhantomData
-        }
-    }
-}
-
 /// The type-level signed integer 0.
-pub enum Z0 {}
-impl_derivable!{Z0}
+#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug)]
+pub struct Z0;
 
 impl<U: Unsigned + NonZero> NonZero for PInt<U> {}
 impl<U: Unsigned + NonZero> NonZero for NInt<U> {}
@@ -98,6 +78,11 @@ impl Integer for Z0 {
     fn to_isize() -> isize {
         0
     }
+
+    #[inline]
+    fn new() -> Self {
+        Z0
+    }
 }
 
 impl<U: Unsigned + NonZero> Integer for PInt<U> {
@@ -121,6 +106,11 @@ impl<U: Unsigned + NonZero> Integer for PInt<U> {
     fn to_isize() -> isize {
         <U as Unsigned>::to_isize()
     }
+
+    #[inline]
+    fn new() -> Self {
+        PInt { _marker: PhantomData }
+    }
 }
 
 impl<U: Unsigned + NonZero> Integer for NInt<U> {
@@ -143,6 +133,11 @@ impl<U: Unsigned + NonZero> Integer for NInt<U> {
     #[inline]
     fn to_isize() -> isize {
         -<U as Unsigned>::to_isize()
+    }
+
+    #[inline]
+    fn new() -> Self {
+        NInt { _marker: PhantomData }
     }
 }
 

--- a/src/int.rs
+++ b/src/int.rs
@@ -78,7 +78,7 @@ pub struct Z0;
 impl Z0 {
     /// Instantiates a singleton representing the integer 0.
     #[inline]
-    pub fn new() -> PInt<U> {
+    pub fn new() -> Z0 {
         Z0
     }
 }
@@ -179,7 +179,7 @@ macro_rules! test_int_op {
 impl Neg for Z0 {
     type Output = Z0;
     fn neg(self) -> Self::Output {
-        Integer::new()
+        Z0
     }
 }
 
@@ -187,7 +187,7 @@ impl Neg for Z0 {
 impl<U: Unsigned + NonZero> Neg for PInt<U> {
     type Output = NInt<U>;
     fn neg(self) -> Self::Output {
-        Integer::new()
+        NInt::new()
     }
 }
 
@@ -195,7 +195,7 @@ impl<U: Unsigned + NonZero> Neg for PInt<U> {
 impl<U: Unsigned + NonZero> Neg for NInt<U> {
     type Output = PInt<U>;
     fn neg(self) -> Self::Output {
-        Integer::new()
+        PInt::new()
     }
 }
 
@@ -206,7 +206,7 @@ impl<U: Unsigned + NonZero> Neg for NInt<U> {
 impl<I: Integer> Add<I> for Z0 {
     type Output = I;
     fn add(self, _: I) -> Self::Output {
-        Integer::new()
+        unsafe { ::core::mem::uninitialized() }
     }
 }
 
@@ -214,7 +214,7 @@ impl<I: Integer> Add<I> for Z0 {
 impl<U: Unsigned + NonZero> Add<Z0> for PInt<U> {
     type Output = PInt<U>;
     fn add(self, _: Z0) -> Self::Output {
-        Integer::new()
+        PInt::new()
     }
 }
 
@@ -222,7 +222,7 @@ impl<U: Unsigned + NonZero> Add<Z0> for PInt<U> {
 impl<U: Unsigned + NonZero> Add<Z0> for NInt<U> {
     type Output = NInt<U>;
     fn add(self, _: Z0) -> Self::Output {
-        Integer::new()
+        NInt::new()
     }
 }
 
@@ -233,7 +233,7 @@ impl<Ul: Unsigned + NonZero, Ur: Unsigned + NonZero> Add<PInt<Ur>> for PInt<Ul>
 {
     type Output = PInt<<Ul as Add<Ur>>::Output>;
     fn add(self, _: PInt<Ur>) -> Self::Output {
-        Integer::new()
+        PInt::new()
     }
 }
 
@@ -244,7 +244,7 @@ impl<Ul: Unsigned + NonZero, Ur: Unsigned + NonZero> Add<NInt<Ur>> for NInt<Ul>
 {
     type Output = NInt<<Ul as Add<Ur>>::Output>;
     fn add(self, _: NInt<Ur>) -> Self::Output {
-        Integer::new()
+        NInt::new()
     }
 }
 
@@ -301,7 +301,7 @@ impl<N: Unsigned, P: Unsigned> PrivateIntegerAdd<Less, N> for P
 impl Sub<Z0> for Z0 {
     type Output = Z0;
     fn sub(self, _: Z0) -> Self::Output {
-        Integer::new()
+        Z0
     }
 }
 
@@ -309,7 +309,7 @@ impl Sub<Z0> for Z0 {
 impl<U: Unsigned + NonZero> Sub<PInt<U>> for Z0 {
     type Output = NInt<U>;
     fn sub(self, _: PInt<U>) -> Self::Output {
-        Integer::new()
+        NInt::new()
     }
 }
 
@@ -317,7 +317,7 @@ impl<U: Unsigned + NonZero> Sub<PInt<U>> for Z0 {
 impl<U: Unsigned + NonZero> Sub<NInt<U>> for Z0 {
     type Output = PInt<U>;
     fn sub(self, _: NInt<U>) -> Self::Output {
-        Integer::new()
+        PInt::new()
     }
 }
 
@@ -325,7 +325,7 @@ impl<U: Unsigned + NonZero> Sub<NInt<U>> for Z0 {
 impl<U: Unsigned + NonZero> Sub<Z0> for PInt<U> {
     type Output = PInt<U>;
     fn sub(self, _: Z0) -> Self::Output {
-        Integer::new()
+        PInt::new()
     }
 }
 
@@ -333,7 +333,7 @@ impl<U: Unsigned + NonZero> Sub<Z0> for PInt<U> {
 impl<U: Unsigned + NonZero> Sub<Z0> for NInt<U> {
     type Output = NInt<U>;
     fn sub(self, _: Z0) -> Self::Output {
-        Integer::new()
+        NInt::new()
     }
 }
 
@@ -344,7 +344,7 @@ impl<Ul: Unsigned + NonZero, Ur: Unsigned + NonZero> Sub<NInt<Ur>> for PInt<Ul>
 {
     type Output = PInt<<Ul as Add<Ur>>::Output>;
     fn sub(self, _: NInt<Ur>) -> Self::Output {
-        Integer::new()
+        PInt::new()
     }
 }
 
@@ -355,7 +355,7 @@ impl<Ul: Unsigned + NonZero, Ur: Unsigned + NonZero> Sub<PInt<Ur>> for NInt<Ul>
 {
     type Output = NInt<<Ul as Add<Ur>>::Output>;
     fn sub(self, _: PInt<Ur>) -> Self::Output {
-        Integer::new()
+        NInt::new()
     }
 }
 
@@ -391,7 +391,7 @@ impl<Ul: Unsigned + NonZero, Ur: Unsigned + NonZero> Sub<NInt<Ur>> for NInt<Ul>
 impl<I: Integer> Mul<I> for Z0 {
     type Output = Z0;
     fn mul(self, _: I) -> Self::Output {
-        Integer::new()
+        Z0
     }
 }
 
@@ -399,7 +399,7 @@ impl<I: Integer> Mul<I> for Z0 {
 impl<U: Unsigned + NonZero> Mul<Z0> for PInt<U> {
     type Output = Z0;
     fn mul(self, _: Z0) -> Self::Output {
-        Integer::new()
+        Z0
     }
 }
 
@@ -407,7 +407,7 @@ impl<U: Unsigned + NonZero> Mul<Z0> for PInt<U> {
 impl<U: Unsigned + NonZero> Mul<Z0> for NInt<U> {
     type Output = Z0;
     fn mul(self, _: Z0) -> Self::Output {
-        Integer::new()
+        Z0
     }
 }
 
@@ -418,7 +418,7 @@ impl<Ul: Unsigned + NonZero, Ur: Unsigned + NonZero> Mul<PInt<Ur>> for PInt<Ul>
 {
     type Output = PInt<<Ul as Mul<Ur>>::Output>;
     fn mul(self, _: PInt<Ur>) -> Self::Output {
-        Integer::new()
+        PInt::new()
     }
 }
 
@@ -429,7 +429,7 @@ impl<Ul: Unsigned + NonZero, Ur: Unsigned + NonZero> Mul<NInt<Ur>> for NInt<Ul>
 {
     type Output = PInt<<Ul as Mul<Ur>>::Output>;
     fn mul(self, _: NInt<Ur>) -> Self::Output {
-        Integer::new()
+        PInt::new()
     }
 }
 
@@ -440,7 +440,7 @@ impl<Ul: Unsigned + NonZero, Ur: Unsigned + NonZero> Mul<NInt<Ur>> for PInt<Ul>
 {
     type Output = NInt<<Ul as Mul<Ur>>::Output>;
     fn mul(self, _: NInt<Ur>) -> Self::Output {
-        Integer::new()
+        NInt::new()
     }
 }
 
@@ -451,7 +451,7 @@ impl<Ul: Unsigned + NonZero, Ur: Unsigned + NonZero> Mul<PInt<Ur>> for NInt<Ul>
 {
     type Output = NInt<<Ul as Mul<Ur>>::Output>;
     fn mul(self, _: PInt<Ur>) -> Self::Output {
-        Integer::new()
+        NInt::new()
     }
 }
 
@@ -462,7 +462,7 @@ impl<Ul: Unsigned + NonZero, Ur: Unsigned + NonZero> Mul<PInt<Ur>> for NInt<Ul>
 impl<I: Integer + NonZero> Div<I> for Z0 {
     type Output = Z0;
     fn div(self, _: I) -> Self::Output {
-        Integer::new()
+        Z0
     }
 }
 
@@ -581,7 +581,7 @@ macro_rules! test_ord {
 impl<I: Integer + NonZero> Rem<I> for Z0 {
     type Output = Z0;
     fn rem(self, _: I) -> Self::Output {
-        Integer::new()
+        Z0
     }
 }
 

--- a/src/int.rs
+++ b/src/int.rs
@@ -165,7 +165,7 @@ macro_rules! test_int_op {
 impl Neg for Z0 {
     type Output = Z0;
     fn neg(self) -> Self::Output {
-        unreachable!()
+        Integer::new()
     }
 }
 
@@ -173,7 +173,7 @@ impl Neg for Z0 {
 impl<U: Unsigned + NonZero> Neg for PInt<U> {
     type Output = NInt<U>;
     fn neg(self) -> Self::Output {
-        unreachable!()
+        Integer::new()
     }
 }
 
@@ -181,7 +181,7 @@ impl<U: Unsigned + NonZero> Neg for PInt<U> {
 impl<U: Unsigned + NonZero> Neg for NInt<U> {
     type Output = PInt<U>;
     fn neg(self) -> Self::Output {
-        unreachable!()
+        Integer::new()
     }
 }
 
@@ -192,7 +192,7 @@ impl<U: Unsigned + NonZero> Neg for NInt<U> {
 impl<I: Integer> Add<I> for Z0 {
     type Output = I;
     fn add(self, _: I) -> Self::Output {
-        unreachable!()
+        Integer::new()
     }
 }
 
@@ -200,7 +200,7 @@ impl<I: Integer> Add<I> for Z0 {
 impl<U: Unsigned + NonZero> Add<Z0> for PInt<U> {
     type Output = PInt<U>;
     fn add(self, _: Z0) -> Self::Output {
-        unreachable!()
+        Integer::new()
     }
 }
 
@@ -208,7 +208,7 @@ impl<U: Unsigned + NonZero> Add<Z0> for PInt<U> {
 impl<U: Unsigned + NonZero> Add<Z0> for NInt<U> {
     type Output = NInt<U>;
     fn add(self, _: Z0) -> Self::Output {
-        unreachable!()
+        Integer::new()
     }
 }
 
@@ -219,7 +219,7 @@ impl<Ul: Unsigned + NonZero, Ur: Unsigned + NonZero> Add<PInt<Ur>> for PInt<Ul>
 {
     type Output = PInt<<Ul as Add<Ur>>::Output>;
     fn add(self, _: PInt<Ur>) -> Self::Output {
-        unreachable!()
+        Integer::new()
     }
 }
 
@@ -230,7 +230,7 @@ impl<Ul: Unsigned + NonZero, Ur: Unsigned + NonZero> Add<NInt<Ur>> for NInt<Ul>
 {
     type Output = NInt<<Ul as Add<Ur>>::Output>;
     fn add(self, _: NInt<Ur>) -> Self::Output {
-        unreachable!()
+        Integer::new()
     }
 }
 
@@ -242,7 +242,7 @@ impl<Ul: Unsigned + NonZero, Ur: Unsigned + NonZero> Add<NInt<Ur>> for PInt<Ul>
         <Ul as Cmp<Ur>>::Output, Ur
         >>::Output;
     fn add(self, _: NInt<Ur>) -> Self::Output {
-        unreachable!()
+        unsafe { ::core::mem::uninitialized() }
     }
 }
 
@@ -255,7 +255,7 @@ impl<Ul: Unsigned + NonZero, Ur: Unsigned + NonZero> Add<PInt<Ur>> for NInt<Ul>
         <Ur as Cmp<Ul>>::Output, Ul
         >>::Output;
     fn add(self, _: PInt<Ur>) -> Self::Output {
-        unreachable!()
+        unsafe { ::core::mem::uninitialized() }
     }
 }
 
@@ -287,7 +287,7 @@ impl<N: Unsigned, P: Unsigned> PrivateIntegerAdd<Less, N> for P
 impl Sub<Z0> for Z0 {
     type Output = Z0;
     fn sub(self, _: Z0) -> Self::Output {
-        unreachable!()
+        Integer::new()
     }
 }
 
@@ -295,7 +295,7 @@ impl Sub<Z0> for Z0 {
 impl<U: Unsigned + NonZero> Sub<PInt<U>> for Z0 {
     type Output = NInt<U>;
     fn sub(self, _: PInt<U>) -> Self::Output {
-        unreachable!()
+        Integer::new()
     }
 }
 
@@ -303,7 +303,7 @@ impl<U: Unsigned + NonZero> Sub<PInt<U>> for Z0 {
 impl<U: Unsigned + NonZero> Sub<NInt<U>> for Z0 {
     type Output = PInt<U>;
     fn sub(self, _: NInt<U>) -> Self::Output {
-        unreachable!()
+        Integer::new()
     }
 }
 
@@ -311,7 +311,7 @@ impl<U: Unsigned + NonZero> Sub<NInt<U>> for Z0 {
 impl<U: Unsigned + NonZero> Sub<Z0> for PInt<U> {
     type Output = PInt<U>;
     fn sub(self, _: Z0) -> Self::Output {
-        unreachable!()
+        Integer::new()
     }
 }
 
@@ -319,7 +319,7 @@ impl<U: Unsigned + NonZero> Sub<Z0> for PInt<U> {
 impl<U: Unsigned + NonZero> Sub<Z0> for NInt<U> {
     type Output = NInt<U>;
     fn sub(self, _: Z0) -> Self::Output {
-        unreachable!()
+        Integer::new()
     }
 }
 
@@ -330,7 +330,7 @@ impl<Ul: Unsigned + NonZero, Ur: Unsigned + NonZero> Sub<NInt<Ur>> for PInt<Ul>
 {
     type Output = PInt<<Ul as Add<Ur>>::Output>;
     fn sub(self, _: NInt<Ur>) -> Self::Output {
-        unreachable!()
+        Integer::new()
     }
 }
 
@@ -341,7 +341,7 @@ impl<Ul: Unsigned + NonZero, Ur: Unsigned + NonZero> Sub<PInt<Ur>> for NInt<Ul>
 {
     type Output = NInt<<Ul as Add<Ur>>::Output>;
     fn sub(self, _: PInt<Ur>) -> Self::Output {
-        unreachable!()
+        Integer::new()
     }
 }
 
@@ -353,7 +353,7 @@ impl<Ul: Unsigned + NonZero, Ur: Unsigned + NonZero> Sub<PInt<Ur>> for PInt<Ul>
         <Ul as Cmp<Ur>>::Output, Ur
         >>::Output;
     fn sub(self, _: PInt<Ur>) -> Self::Output {
-        unreachable!()
+        unsafe { ::core::mem::uninitialized() }
     }
 }
 
@@ -366,7 +366,7 @@ impl<Ul: Unsigned + NonZero, Ur: Unsigned + NonZero> Sub<NInt<Ur>> for NInt<Ul>
         <Ur as Cmp<Ul>>::Output, Ul
         >>::Output;
     fn sub(self, _: NInt<Ur>) -> Self::Output {
-        unreachable!()
+        unsafe { ::core::mem::uninitialized() }
     }
 }
 
@@ -377,7 +377,7 @@ impl<Ul: Unsigned + NonZero, Ur: Unsigned + NonZero> Sub<NInt<Ur>> for NInt<Ul>
 impl<I: Integer> Mul<I> for Z0 {
     type Output = Z0;
     fn mul(self, _: I) -> Self::Output {
-        unreachable!()
+        Integer::new()
     }
 }
 
@@ -385,7 +385,7 @@ impl<I: Integer> Mul<I> for Z0 {
 impl<U: Unsigned + NonZero> Mul<Z0> for PInt<U> {
     type Output = Z0;
     fn mul(self, _: Z0) -> Self::Output {
-        unreachable!()
+        Integer::new()
     }
 }
 
@@ -393,7 +393,7 @@ impl<U: Unsigned + NonZero> Mul<Z0> for PInt<U> {
 impl<U: Unsigned + NonZero> Mul<Z0> for NInt<U> {
     type Output = Z0;
     fn mul(self, _: Z0) -> Self::Output {
-        unreachable!()
+        Integer::new()
     }
 }
 
@@ -404,7 +404,7 @@ impl<Ul: Unsigned + NonZero, Ur: Unsigned + NonZero> Mul<PInt<Ur>> for PInt<Ul>
 {
     type Output = PInt<<Ul as Mul<Ur>>::Output>;
     fn mul(self, _: PInt<Ur>) -> Self::Output {
-        unreachable!()
+        Integer::new()
     }
 }
 
@@ -415,7 +415,7 @@ impl<Ul: Unsigned + NonZero, Ur: Unsigned + NonZero> Mul<NInt<Ur>> for NInt<Ul>
 {
     type Output = PInt<<Ul as Mul<Ur>>::Output>;
     fn mul(self, _: NInt<Ur>) -> Self::Output {
-        unreachable!()
+        Integer::new()
     }
 }
 
@@ -426,7 +426,7 @@ impl<Ul: Unsigned + NonZero, Ur: Unsigned + NonZero> Mul<NInt<Ur>> for PInt<Ul>
 {
     type Output = NInt<<Ul as Mul<Ur>>::Output>;
     fn mul(self, _: NInt<Ur>) -> Self::Output {
-        unreachable!()
+        Integer::new()
     }
 }
 
@@ -437,7 +437,7 @@ impl<Ul: Unsigned + NonZero, Ur: Unsigned + NonZero> Mul<PInt<Ur>> for NInt<Ul>
 {
     type Output = NInt<<Ul as Mul<Ur>>::Output>;
     fn mul(self, _: PInt<Ur>) -> Self::Output {
-        unreachable!()
+        Integer::new()
     }
 }
 
@@ -448,7 +448,7 @@ impl<Ul: Unsigned + NonZero, Ur: Unsigned + NonZero> Mul<PInt<Ur>> for NInt<Ul>
 impl<I: Integer + NonZero> Div<I> for Z0 {
     type Output = Z0;
     fn div(self, _: I) -> Self::Output {
-        unreachable!()
+        Integer::new()
     }
 }
 
@@ -462,7 +462,9 @@ macro_rules! impl_int_div {
             type Output = <$A<Ul> as PrivateDivInt<
                 <Ul as Cmp<Ur>>::Output,
                 $B<Ur>>>::Output;
-            fn div(self, _: $B<Ur>) -> Self::Output { unreachable!() }
+            fn div(self, _: $B<Ur>) -> Self::Output {
+                unsafe { ::core::mem::uninitialized() }
+            }
         }
         impl<Ul, Ur> PrivateDivInt<Less, $B<Ur>> for $A<Ul>
             where Ul: Unsigned + NonZero, Ur: Unsigned + NonZero,
@@ -565,7 +567,7 @@ macro_rules! test_ord {
 impl<I: Integer + NonZero> Rem<I> for Z0 {
     type Output = Z0;
     fn rem(self, _: I) -> Self::Output {
-        unreachable!()
+        Integer::new()
     }
 }
 
@@ -579,7 +581,9 @@ macro_rules! impl_int_rem {
             type Output = <$A<Ul> as PrivateRem<
                 <Ul as Rem<Ur>>::Output,
                 $B<Ur>>>::Output;
-            fn rem(self, _: $B<Ur>) -> Self::Output { unreachable!() }
+            fn rem(self, _: $B<Ur>) -> Self::Output {
+                unsafe { ::core::mem::uninitialized() }
+            }
         }
         impl<Ul: Unsigned + NonZero, Ur: Unsigned + NonZero> PrivateRem<U0, $B<Ur>> for $A<Ul> {
             type Output = Z0;

--- a/src/int.rs
+++ b/src/int.rs
@@ -50,9 +50,38 @@ pub struct NInt<U: Unsigned + NonZero> {
     _marker: PhantomData<U>,
 }
 
+impl<U: Unsigned + NonZero> PInt<U> {
+    /// Instantiates a singleton representing this strictly positive integer.
+    #[inline]
+    pub fn new() -> PInt<U> {
+        PInt {
+            _marker: PhantomData
+        }
+    }
+}
+
+impl<U: Unsigned + NonZero> NInt<U> {
+    /// Instantiates a singleton representing this strictly negative integer.
+    #[inline]
+    pub fn new() -> NInt<U> {
+        NInt {
+            _marker: PhantomData
+        }
+    }
+}
+
+
 /// The type-level signed integer 0.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug)]
 pub struct Z0;
+
+impl Z0 {
+    /// Instantiates a singleton representing the integer 0.
+    #[inline]
+    pub fn new() -> PInt<U> {
+        Z0
+    }
+}
 
 impl<U: Unsigned + NonZero> NonZero for PInt<U> {}
 impl<U: Unsigned + NonZero> NonZero for NInt<U> {}
@@ -78,11 +107,6 @@ impl Integer for Z0 {
     fn to_isize() -> isize {
         0
     }
-
-    #[inline]
-    fn new() -> Self {
-        Z0
-    }
 }
 
 impl<U: Unsigned + NonZero> Integer for PInt<U> {
@@ -106,11 +130,6 @@ impl<U: Unsigned + NonZero> Integer for PInt<U> {
     fn to_isize() -> isize {
         <U as Unsigned>::to_isize()
     }
-
-    #[inline]
-    fn new() -> Self {
-        PInt { _marker: PhantomData }
-    }
 }
 
 impl<U: Unsigned + NonZero> Integer for NInt<U> {
@@ -133,11 +152,6 @@ impl<U: Unsigned + NonZero> Integer for NInt<U> {
     #[inline]
     fn to_isize() -> isize {
         -<U as Unsigned>::to_isize()
-    }
-
-    #[inline]
-    fn new() -> Self {
-        NInt { _marker: PhantomData }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,11 +87,6 @@ pub struct Equal;
 /// Returns `core::cmp::Ordering::Greater`
 impl Ord for Greater {
     #[inline]
-    fn new() -> Self {
-        Greater
-    }
-
-    #[inline]
     fn to_ordering() -> Ordering {
         Ordering::Greater
     }
@@ -100,11 +95,6 @@ impl Ord for Greater {
 /// Returns `core::cmp::Ordering::Less`
 impl Ord for Less {
     #[inline]
-    fn new() -> Self {
-        Less
-    }
-
-    #[inline]
     fn to_ordering() -> Ordering {
         Ordering::Less
     }
@@ -112,11 +102,6 @@ impl Ord for Less {
 
 /// Returns `core::cmp::Ordering::Equal`
 impl Ord for Equal {
-    #[inline]
-    fn new() -> Self {
-        Equal
-    }
-
     #[inline]
     fn to_ordering() -> Ordering {
         Ordering::Equal

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,37 +52,6 @@
 
 use core::cmp::Ordering;
 
-macro_rules! impl_derivable {
-    ($Type: ty) => (
-        impl ::core::cmp::PartialEq for $Type {
-            fn eq(&self, _: &Self) -> bool { match *self {} }
-        }
-        impl ::core::cmp::Eq for $Type { }
-        impl ::core::cmp::PartialOrd for $Type {
-            fn partial_cmp(&self, _: &Self) -> Option<::core::cmp::Ordering> { match *self {} }
-        }
-        impl ::core::cmp::Ord for $Type {
-            fn cmp(&self, _: &Self) -> ::core::cmp::Ordering { match *self {} }
-        }
-        impl ::core::clone::Clone for $Type {
-            fn clone(&self) -> Self { match *self {} }
-        }
-        impl ::core::marker::Copy for $Type {}
-        impl ::core::hash::Hash for $Type {
-            fn hash<H>(&self, _: &mut H) where H: ::core::hash::Hasher { match *self {} }
-        }
-        impl ::core::default::Default for $Type {
-            fn default() -> Self { unreachable!() }
-        }
-        impl ::core::fmt::Debug for $Type {
-            fn fmt(&self, _: &mut ::core::fmt::Formatter) ->
-                ::core::result::Result<(), ::core::fmt::Error> {
-                match *self {}
-            }
-        }
-        );
-}
-
 pub mod consts;
 pub mod bit;
 pub mod uint;
@@ -102,35 +71,52 @@ pub use int::{NInt, PInt};
 
 /// A potential output from `Cmp`, this is the type equivalent to the enum variant
 /// `core::cmp::Ordering::Greater`.
-pub enum Greater {}
-impl_derivable!{Greater}
+#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug)]
+pub struct Greater;
 
 /// A potential output from `Cmp`, this is the type equivalent to the enum variant
 /// `core::cmp::Ordering::Less`.
-pub enum Less {}
-impl_derivable!{Less}
+#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug)]
+pub struct Less;
 
 /// A potential output from `Cmp`, this is the type equivalent to the enum variant
 /// `core::cmp::Ordering::Equal`.
-pub enum Equal {}
-impl_derivable!{Equal}
+#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug)]
+pub struct Equal;
 
 /// Returns `core::cmp::Ordering::Greater`
 impl Ord for Greater {
+    #[inline]
+    fn new() -> Self {
+        Greater
+    }
+
     #[inline]
     fn to_ordering() -> Ordering {
         Ordering::Greater
     }
 }
+
 /// Returns `core::cmp::Ordering::Less`
 impl Ord for Less {
+    #[inline]
+    fn new() -> Self {
+        Less
+    }
+
     #[inline]
     fn to_ordering() -> Ordering {
         Ordering::Less
     }
 }
+
 /// Returns `core::cmp::Ordering::Equal`
 impl Ord for Equal {
+    #[inline]
+    fn new() -> Self {
+        Equal
+    }
+
     #[inline]
     fn to_ordering() -> Ordering {
         Ordering::Equal

--- a/src/marker_traits.rs
+++ b/src/marker_traits.rs
@@ -23,9 +23,6 @@ pub trait NonZero {}
 pub trait Ord {
     #[allow(missing_docs)]
     fn to_ordering() -> ::core::cmp::Ordering;
-
-    /// Instantiate a singleton representing this comparison.
-    fn new() -> Self;
 }
 
 /// The **marker trait** for compile time bits.
@@ -36,9 +33,6 @@ pub trait Bit {
     fn to_u8() -> u8;
     #[allow(missing_docs)]
     fn to_bool() -> bool;
-
-    /// Instantiate a singleton representing this bit.
-    fn new() -> Self;
 }
 
 /// The **marker trait** for compile time unsigned integers.
@@ -73,9 +67,6 @@ pub trait Unsigned {
     fn to_i64() -> i64;
     #[allow(missing_docs)]
     fn to_isize() -> isize;
-
-    /// Instantiate a singleton representing this unsigned integer.
-    fn new() -> Self;
 }
 
 /// The **marker trait** for compile time signed integers.
@@ -99,7 +90,4 @@ pub trait Integer {
     fn to_i64() -> i64;
     #[allow(missing_docs)]
     fn to_isize() -> isize;
-
-    /// Instantiate a singleton representing this signed integer.
-    fn new() -> Self;
 }

--- a/src/marker_traits.rs
+++ b/src/marker_traits.rs
@@ -23,6 +23,9 @@ pub trait NonZero {}
 pub trait Ord {
     #[allow(missing_docs)]
     fn to_ordering() -> ::core::cmp::Ordering;
+
+    /// Instantiate a singleton representing this comparison.
+    fn new() -> Self;
 }
 
 /// The **marker trait** for compile time bits.
@@ -33,6 +36,9 @@ pub trait Bit {
     fn to_u8() -> u8;
     #[allow(missing_docs)]
     fn to_bool() -> bool;
+
+    /// Instantiate a singleton representing this bit.
+    fn new() -> Self;
 }
 
 /// The **marker trait** for compile time unsigned integers.
@@ -67,6 +73,9 @@ pub trait Unsigned {
     fn to_i64() -> i64;
     #[allow(missing_docs)]
     fn to_isize() -> isize;
+
+    /// Instantiate a singleton representing this unsigned integer.
+    fn new() -> Self;
 }
 
 /// The **marker trait** for compile time signed integers.
@@ -90,4 +99,7 @@ pub trait Integer {
     fn to_i64() -> i64;
     #[allow(missing_docs)]
     fn to_isize() -> isize;
+
+    /// Instantiate a singleton representing this signed integer.
+    fn new() -> Self;
 }

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -231,7 +231,7 @@ impl<U: Unsigned, B: Bit> PrivateSizeOf for UInt<U, B>
 impl Add<B0> for UTerm {
     type Output = UTerm;
     fn add(self, _: B0) -> Self::Output {
-        Unsigned::new()
+        UTerm
     }
 }
 
@@ -239,7 +239,7 @@ impl Add<B0> for UTerm {
 impl<U: Unsigned, B: Bit> Add<B0> for UInt<U, B> {
     type Output = UInt<U, B>;
     fn add(self, _: B0) -> Self::Output {
-        Unsigned::new()
+        UInt::new()
     }
 }
 
@@ -247,7 +247,7 @@ impl<U: Unsigned, B: Bit> Add<B0> for UInt<U, B> {
 impl Add<B1> for UTerm {
     type Output = UInt<UTerm, B1>;
     fn add(self, _: B1) -> Self::Output {
-        Unsigned::new()
+        UInt::new()
     }
 }
 
@@ -255,7 +255,7 @@ impl Add<B1> for UTerm {
 impl<U: Unsigned> Add<B1> for UInt<U, B0> {
     type Output = UInt<U, B1>;
     fn add(self, _: B1) -> Self::Output {
-        Unsigned::new()
+        UInt::new()
     }
 }
 
@@ -266,7 +266,7 @@ impl<U: Unsigned> Add<B1> for UInt<U, B1>
 {
     type Output = UInt<Add1<U>, B0>;
     fn add(self, _: B1) -> Self::Output {
-        Unsigned::new()
+        UInt::new()
     }
 }
 
@@ -277,7 +277,7 @@ impl<U: Unsigned> Add<B1> for UInt<U, B1>
 impl<U: Unsigned> Add<U> for UTerm {
     type Output = U;
     fn add(self, _: U) -> Self::Output {
-        Unsigned::new()
+        unsafe { ::core::mem::uninitialized() }
     }
 }
 
@@ -285,7 +285,7 @@ impl<U: Unsigned> Add<U> for UTerm {
 impl<U: Unsigned, B: Bit> Add<UTerm> for UInt<U, B> {
     type Output = UInt<U, B>;
     fn add(self, _: UTerm) -> Self::Output {
-        Unsigned::new()
+        UInt::new()
     }
 }
 
@@ -337,7 +337,7 @@ impl<Ul: Unsigned, Ur: Unsigned> Add<UInt<Ur, B1>> for UInt<Ul, B1>
 impl Sub<B0> for UTerm {
     type Output = UTerm;
     fn sub(self, _: B0) -> Self::Output {
-        Unsigned::new()
+        UTerm
     }
 }
 
@@ -345,7 +345,7 @@ impl Sub<B0> for UTerm {
 impl<U: Unsigned, B: Bit> Sub<B0> for UInt<U, B> {
     type Output = UInt<U, B>;
     fn sub(self, _: B0) -> Self::Output {
-        Unsigned::new()
+        UInt::new()
     }
 }
 
@@ -353,7 +353,7 @@ impl<U: Unsigned, B: Bit> Sub<B0> for UInt<U, B> {
 impl<U: Unsigned, B: Bit> Sub<B1> for UInt<UInt<U, B>, B1> {
     type Output = UInt<UInt<U, B>, B0>;
     fn sub(self, _: B1) -> Self::Output {
-        Unsigned::new()
+        UInt::new()
     }
 }
 
@@ -361,7 +361,7 @@ impl<U: Unsigned, B: Bit> Sub<B1> for UInt<UInt<U, B>, B1> {
 impl Sub<B1> for UInt<UTerm, B1> {
     type Output = UTerm;
     fn sub(self, _: B1) -> Self::Output {
-        Unsigned::new()
+        UTerm
     }
 }
 
@@ -372,7 +372,7 @@ impl<U: Unsigned> Sub<B1> for UInt<U, B0>
 {
     type Output = UInt<Sub1<U>, B1>;
     fn sub(self, _: B1) -> Self::Output {
-        Unsigned::new()
+        UInt::new()
     }
 }
 
@@ -383,7 +383,7 @@ impl<U: Unsigned> Sub<B1> for UInt<U, B0>
 impl Sub<UTerm> for UTerm {
     type Output = UTerm;
     fn sub(self, _: UTerm) -> Self::Output {
-        Unsigned::new()
+        UTerm
     }
 }
 
@@ -439,7 +439,7 @@ impl<Ul: Unsigned, Ur: Unsigned> PrivateSub<UInt<Ur, B1>> for UInt<Ul, B1>
 impl<Ur: Unsigned> BitAnd<Ur> for UTerm {
     type Output = UTerm;
     fn bitand(self, _: Ur) -> Self::Output {
-        Unsigned::new()
+        UTerm
     }
 }
 
@@ -500,7 +500,7 @@ impl<Ul: Unsigned, Ur: Unsigned> PrivateAnd<UInt<Ur, B1>> for UInt<Ul, B1>
 impl<U: Unsigned> BitOr<U> for UTerm {
     type Output = U;
     fn bitor(self, _: U) -> Self::Output {
-        Unsigned::new()
+        unsafe { ::core::mem::uninitialized() }
     }
 }
 
@@ -508,7 +508,7 @@ impl<U: Unsigned> BitOr<U> for UTerm {
 impl<B: Bit, U: Unsigned> BitOr<UTerm> for UInt<U, B> {
     type Output = Self;
     fn bitor(self, _: UTerm) -> Self::Output {
-        Unsigned::new()
+        UInt::new()
     }
 }
 
@@ -559,7 +559,7 @@ impl<Ul: Unsigned, Ur: Unsigned> BitOr<UInt<Ur, B1>> for UInt<Ul, B1>
 impl<Ur: Unsigned> BitXor<Ur> for UTerm {
     type Output = Ur;
     fn bitxor(self, _: Ur) -> Self::Output {
-        Unsigned::new()
+        unsafe { ::core::mem::uninitialized() }
     }
 }
 
@@ -620,7 +620,7 @@ impl<Ul: Unsigned, Ur: Unsigned> PrivateXor<UInt<Ur, B1>> for UInt<Ul, B1>
 impl<U: Unsigned> Shl<U> for UTerm {
     type Output = UTerm;
     fn shl(self, _: U) -> Self::Output {
-        Unsigned::new()
+        UTerm
     }
 }
 
@@ -628,7 +628,7 @@ impl<U: Unsigned> Shl<U> for UTerm {
 impl<U: Unsigned, B: Bit> Shl<UTerm> for UInt<U, B> {
     type Output = UInt<U, B>;
     fn shl(self, _: UTerm) -> Self::Output {
-        Unsigned::new()
+        UInt::new()
     }
 }
 
@@ -636,7 +636,7 @@ impl<U: Unsigned, B: Bit> Shl<UTerm> for UInt<U, B> {
 impl<U: Unsigned, B: Bit> Shl<B0> for UInt<U, B> {
     type Output = UInt<U, B>;
     fn shl(self, _: B0) -> Self::Output {
-        Unsigned::new()
+        UInt::new()
     }
 }
 
@@ -644,7 +644,7 @@ impl<U: Unsigned, B: Bit> Shl<B0> for UInt<U, B> {
 impl Shl<B0> for UTerm {
     type Output = UTerm;
     fn shl(self, _: B0) -> Self::Output {
-        Unsigned::new()
+        UTerm
     }
 }
 
@@ -652,7 +652,7 @@ impl Shl<B0> for UTerm {
 impl Shl<B1> for UTerm {
     type Output = UTerm;
     fn shl(self, _: B1) -> Self::Output {
-        Unsigned::new()
+        UTerm
     }
 }
 
@@ -660,7 +660,7 @@ impl Shl<B1> for UTerm {
 impl<U: Unsigned, B: Bit> Shl<B1> for UInt<U, B> {
     type Output = UInt<UInt<U, B>, B0>;
     fn shl(self, _: B1) -> Self::Output {
-        Unsigned::new()
+        UInt::new()
     }
 }
 
@@ -682,7 +682,7 @@ impl<U: Unsigned, B: Bit, Ur: Unsigned, Br: Bit> Shl<UInt<Ur, Br>> for UInt<U, B
 impl<U: Unsigned> Shr<U> for UTerm {
     type Output = UTerm;
     fn shr(self, _: U) -> Self::Output {
-        Unsigned::new()
+        UTerm
     }
 }
 
@@ -690,7 +690,7 @@ impl<U: Unsigned> Shr<U> for UTerm {
 impl<U: Unsigned, B: Bit> Shr<UTerm> for UInt<U, B> {
     type Output = UInt<U, B>;
     fn shr(self, _: UTerm) -> Self::Output {
-        Unsigned::new()
+        UInt::new()
     }
 }
 
@@ -698,7 +698,7 @@ impl<U: Unsigned, B: Bit> Shr<UTerm> for UInt<U, B> {
 impl Shr<B0> for UTerm {
     type Output = UTerm;
     fn shr(self, _: B0) -> Self::Output {
-        Unsigned::new()
+        UTerm
     }
 }
 
@@ -706,7 +706,7 @@ impl Shr<B0> for UTerm {
 impl Shr<B1> for UTerm {
     type Output = UTerm;
     fn shr(self, _: B1) -> Self::Output {
-        Unsigned::new()
+        UTerm
     }
 }
 
@@ -714,7 +714,7 @@ impl Shr<B1> for UTerm {
 impl<U: Unsigned, B: Bit> Shr<B0> for UInt<U, B> {
     type Output = UInt<U, B>;
     fn shr(self, _: B0) -> Self::Output {
-        Unsigned::new()
+        UInt::new()
     }
 }
 
@@ -722,7 +722,7 @@ impl<U: Unsigned, B: Bit> Shr<B0> for UInt<U, B> {
 impl<U: Unsigned, B: Bit> Shr<B1> for UInt<U, B> {
     type Output = U;
     fn shr(self, _: B1) -> Self::Output {
-        Unsigned::new()
+        unsafe { ::core::mem::uninitialized() }
     }
 }
 
@@ -744,7 +744,7 @@ impl<U: Unsigned, B: Bit, Ur: Unsigned, Br: Bit> Shr<UInt<Ur, Br>> for UInt<U, B
 impl<U: Unsigned, B: Bit> Mul<B0> for UInt<U, B> {
     type Output = UTerm;
     fn mul(self, _: B0) -> Self::Output {
-        Unsigned::new()
+        UTerm
     }
 }
 
@@ -752,7 +752,7 @@ impl<U: Unsigned, B: Bit> Mul<B0> for UInt<U, B> {
 impl Mul<B0> for UTerm {
     type Output = UTerm;
     fn mul(self, _: B0) -> Self::Output {
-        Unsigned::new()
+        UTerm
     }
 }
 
@@ -760,7 +760,7 @@ impl Mul<B0> for UTerm {
 impl Mul<B1> for UTerm {
     type Output = UTerm;
     fn mul(self, _: B1) -> Self::Output {
-        Unsigned::new()
+        UTerm
     }
 }
 
@@ -768,7 +768,7 @@ impl Mul<B1> for UTerm {
 impl<U: Unsigned, B: Bit> Mul<B1> for UInt<U, B> {
     type Output = UInt<U, B>;
     fn mul(self, _: B1) -> Self::Output {
-        Unsigned::new()
+        UInt::new()
     }
 }
 
@@ -776,7 +776,7 @@ impl<U: Unsigned, B: Bit> Mul<B1> for UInt<U, B> {
 impl<U: Unsigned, B: Bit> Mul<UTerm> for UInt<U, B> {
     type Output = UTerm;
     fn mul(self, _: UTerm) -> Self::Output {
-        Unsigned::new()
+        UTerm
     }
 }
 
@@ -784,7 +784,7 @@ impl<U: Unsigned, B: Bit> Mul<UTerm> for UInt<U, B> {
 impl<U: Unsigned> Mul<U> for UTerm {
     type Output = UTerm;
     fn mul(self, _: U) -> Self::Output {
-        Unsigned::new()
+        UTerm
     }
 }
 
@@ -1040,7 +1040,7 @@ impl<Y: Unsigned, U: Unsigned, B: Bit, X: Unsigned> PrivatePow<Y, UInt<UInt<U, B
 impl<Ur: Unsigned> Div<Ur> for UTerm {
     type Output = UTerm;
     fn div(self, _: Ur) -> Self::Output {
-        Unsigned::new()
+        UTerm
     }
 }
 
@@ -1214,7 +1214,7 @@ impl<Ui, Bi, Q, Divisor, Remainder> PrivateDiv<Greater, UInt<Ui, Bi>, Q, Divisor
 impl<Ur: Unsigned> Rem<Ur> for UTerm {
     type Output = UTerm;
     fn rem(self, _: Ur) -> Self::Output {
-        Unsigned::new()
+        UTerm
     }
 }
 

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -222,7 +222,7 @@ impl<U: Unsigned, B: Bit> PrivateSizeOf for UInt<U, B>
 impl Add<B0> for UTerm {
     type Output = UTerm;
     fn add(self, _: B0) -> Self::Output {
-        unreachable!()
+        Unsigned::new()
     }
 }
 
@@ -230,7 +230,7 @@ impl Add<B0> for UTerm {
 impl<U: Unsigned, B: Bit> Add<B0> for UInt<U, B> {
     type Output = UInt<U, B>;
     fn add(self, _: B0) -> Self::Output {
-        unreachable!()
+        Unsigned::new()
     }
 }
 
@@ -238,7 +238,7 @@ impl<U: Unsigned, B: Bit> Add<B0> for UInt<U, B> {
 impl Add<B1> for UTerm {
     type Output = UInt<UTerm, B1>;
     fn add(self, _: B1) -> Self::Output {
-        unreachable!()
+        Unsigned::new()
     }
 }
 
@@ -246,7 +246,7 @@ impl Add<B1> for UTerm {
 impl<U: Unsigned> Add<B1> for UInt<U, B0> {
     type Output = UInt<U, B1>;
     fn add(self, _: B1) -> Self::Output {
-        unreachable!()
+        Unsigned::new()
     }
 }
 
@@ -257,7 +257,7 @@ impl<U: Unsigned> Add<B1> for UInt<U, B1>
 {
     type Output = UInt<Add1<U>, B0>;
     fn add(self, _: B1) -> Self::Output {
-        unreachable!()
+        Unsigned::new()
     }
 }
 
@@ -268,7 +268,7 @@ impl<U: Unsigned> Add<B1> for UInt<U, B1>
 impl<U: Unsigned> Add<U> for UTerm {
     type Output = U;
     fn add(self, _: U) -> Self::Output {
-        unreachable!()
+        Unsigned::new()
     }
 }
 
@@ -276,7 +276,7 @@ impl<U: Unsigned> Add<U> for UTerm {
 impl<U: Unsigned, B: Bit> Add<UTerm> for UInt<U, B> {
     type Output = UInt<U, B>;
     fn add(self, _: UTerm) -> Self::Output {
-        unreachable!()
+        Unsigned::new()
     }
 }
 
@@ -286,7 +286,7 @@ impl<Ul: Unsigned, Ur: Unsigned> Add<UInt<Ur, B0>> for UInt<Ul, B0>
 {
     type Output = UInt<Sum<Ul, Ur>, B0>;
     fn add(self, _: UInt<Ur, B0>) -> Self::Output {
-        unreachable!()
+        unsafe { ::core::mem::uninitialized() }
     }
 }
 
@@ -296,7 +296,7 @@ impl<Ul: Unsigned, Ur: Unsigned> Add<UInt<Ur, B1>> for UInt<Ul, B0>
 {
     type Output = UInt<Sum<Ul, Ur>, B1>;
     fn add(self, _: UInt<Ur, B1>) -> Self::Output {
-        unreachable!()
+        unsafe { ::core::mem::uninitialized() }
     }
 }
 
@@ -306,7 +306,7 @@ impl<Ul: Unsigned, Ur: Unsigned> Add<UInt<Ur, B0>> for UInt<Ul, B1>
 {
     type Output = UInt<Sum<Ul, Ur>, B1>;
     fn add(self, _: UInt<Ur, B0>) -> Self::Output {
-        unreachable!()
+        unsafe { ::core::mem::uninitialized() }
     }
 }
 
@@ -317,7 +317,7 @@ impl<Ul: Unsigned, Ur: Unsigned> Add<UInt<Ur, B1>> for UInt<Ul, B1>
 {
     type Output = UInt<Add1<Sum<Ul, Ur>>, B0>;
     fn add(self, _: UInt<Ur, B1>) -> Self::Output {
-        unreachable!()
+        unsafe { ::core::mem::uninitialized() }
     }
 }
 
@@ -328,7 +328,7 @@ impl<Ul: Unsigned, Ur: Unsigned> Add<UInt<Ur, B1>> for UInt<Ul, B1>
 impl Sub<B0> for UTerm {
     type Output = UTerm;
     fn sub(self, _: B0) -> Self::Output {
-        unreachable!()
+        Unsigned::new()
     }
 }
 
@@ -336,7 +336,7 @@ impl Sub<B0> for UTerm {
 impl<U: Unsigned, B: Bit> Sub<B0> for UInt<U, B> {
     type Output = UInt<U, B>;
     fn sub(self, _: B0) -> Self::Output {
-        unreachable!()
+        Unsigned::new()
     }
 }
 
@@ -344,7 +344,7 @@ impl<U: Unsigned, B: Bit> Sub<B0> for UInt<U, B> {
 impl<U: Unsigned, B: Bit> Sub<B1> for UInt<UInt<U, B>, B1> {
     type Output = UInt<UInt<U, B>, B0>;
     fn sub(self, _: B1) -> Self::Output {
-        unreachable!()
+        Unsigned::new()
     }
 }
 
@@ -352,7 +352,7 @@ impl<U: Unsigned, B: Bit> Sub<B1> for UInt<UInt<U, B>, B1> {
 impl Sub<B1> for UInt<UTerm, B1> {
     type Output = UTerm;
     fn sub(self, _: B1) -> Self::Output {
-        unreachable!()
+        Unsigned::new()
     }
 }
 
@@ -363,7 +363,7 @@ impl<U: Unsigned> Sub<B1> for UInt<U, B0>
 {
     type Output = UInt<Sub1<U>, B1>;
     fn sub(self, _: B1) -> Self::Output {
-        unreachable!()
+        Unsigned::new()
     }
 }
 
@@ -374,7 +374,7 @@ impl<U: Unsigned> Sub<B1> for UInt<U, B0>
 impl Sub<UTerm> for UTerm {
     type Output = UTerm;
     fn sub(self, _: UTerm) -> Self::Output {
-        unreachable!()
+        Unsigned::new()
     }
 }
 
@@ -385,7 +385,7 @@ impl<Ul: Unsigned, Bl: Bit, Ur: Unsigned> Sub<Ur> for UInt<Ul, Bl>
 {
     type Output = TrimOut<PrivateSubOut<UInt<Ul, Bl>, Ur>>;
     fn sub(self, _: Ur) -> Self::Output {
-        unreachable!()
+        unsafe { ::core::mem::uninitialized() }
     }
 }
 
@@ -430,7 +430,7 @@ impl<Ul: Unsigned, Ur: Unsigned> PrivateSub<UInt<Ur, B1>> for UInt<Ul, B1>
 impl<Ur: Unsigned> BitAnd<Ur> for UTerm {
     type Output = UTerm;
     fn bitand(self, _: Ur) -> Self::Output {
-        unreachable!()
+        Unsigned::new()
     }
 }
 
@@ -442,7 +442,7 @@ impl<Ul: Unsigned, Bl: Bit, Ur: Unsigned> BitAnd<Ur> for UInt<Ul, Bl>
 {
     type Output = TrimOut<PrivateAndOut<UInt<Ul, Bl>, Ur>>;
     fn bitand(self, _: Ur) -> Self::Output {
-        unreachable!()
+        unsafe { ::core::mem::uninitialized() }
     }
 }
 
@@ -491,7 +491,7 @@ impl<Ul: Unsigned, Ur: Unsigned> PrivateAnd<UInt<Ur, B1>> for UInt<Ul, B1>
 impl<U: Unsigned> BitOr<U> for UTerm {
     type Output = U;
     fn bitor(self, _: U) -> Self::Output {
-        unreachable!()
+        Unsigned::new()
     }
 }
 
@@ -499,7 +499,7 @@ impl<U: Unsigned> BitOr<U> for UTerm {
 impl<B: Bit, U: Unsigned> BitOr<UTerm> for UInt<U, B> {
     type Output = Self;
     fn bitor(self, _: UTerm) -> Self::Output {
-        unreachable!()
+        Unsigned::new()
     }
 }
 
@@ -509,7 +509,7 @@ impl<Ul: Unsigned, Ur: Unsigned> BitOr<UInt<Ur, B0>> for UInt<Ul, B0>
 {
     type Output = UInt<<Ul as BitOr<Ur>>::Output, B0>;
     fn bitor(self, _: UInt<Ur, B0>) -> Self::Output {
-        unreachable!()
+        unsafe { ::core::mem::uninitialized() }
     }
 }
 
@@ -519,7 +519,7 @@ impl<Ul: Unsigned, Ur: Unsigned> BitOr<UInt<Ur, B1>> for UInt<Ul, B0>
 {
     type Output = UInt<Or<Ul, Ur>, B1>;
     fn bitor(self, _: UInt<Ur, B1>) -> Self::Output {
-        unreachable!()
+        unsafe { ::core::mem::uninitialized() }
     }
 }
 
@@ -529,7 +529,7 @@ impl<Ul: Unsigned, Ur: Unsigned> BitOr<UInt<Ur, B0>> for UInt<Ul, B1>
 {
     type Output = UInt<Or<Ul, Ur>, B1>;
     fn bitor(self, _: UInt<Ur, B0>) -> Self::Output {
-        unreachable!()
+        unsafe { ::core::mem::uninitialized() }
     }
 }
 
@@ -539,7 +539,7 @@ impl<Ul: Unsigned, Ur: Unsigned> BitOr<UInt<Ur, B1>> for UInt<Ul, B1>
 {
     type Output = UInt<Or<Ul, Ur>, B1>;
     fn bitor(self, _: UInt<Ur, B1>) -> Self::Output {
-        unreachable!()
+        unsafe { ::core::mem::uninitialized() }
     }
 }
 
@@ -550,7 +550,7 @@ impl<Ul: Unsigned, Ur: Unsigned> BitOr<UInt<Ur, B1>> for UInt<Ul, B1>
 impl<Ur: Unsigned> BitXor<Ur> for UTerm {
     type Output = Ur;
     fn bitxor(self, _: Ur) -> Self::Output {
-        unreachable!()
+        Unsigned::new()
     }
 }
 
@@ -562,7 +562,7 @@ impl<Ul: Unsigned, Bl: Bit, Ur: Unsigned> BitXor<Ur> for UInt<Ul, Bl>
 {
     type Output = TrimOut<PrivateXorOut<UInt<Ul, Bl>, Ur>>;
     fn bitxor(self, _: Ur) -> Self::Output {
-        unreachable!()
+        unsafe { ::core::mem::uninitialized() }
     }
 }
 
@@ -611,7 +611,7 @@ impl<Ul: Unsigned, Ur: Unsigned> PrivateXor<UInt<Ur, B1>> for UInt<Ul, B1>
 impl<U: Unsigned> Shl<U> for UTerm {
     type Output = UTerm;
     fn shl(self, _: U) -> Self::Output {
-        unreachable!()
+        Unsigned::new()
     }
 }
 
@@ -619,7 +619,7 @@ impl<U: Unsigned> Shl<U> for UTerm {
 impl<U: Unsigned, B: Bit> Shl<UTerm> for UInt<U, B> {
     type Output = UInt<U, B>;
     fn shl(self, _: UTerm) -> Self::Output {
-        unreachable!()
+        Unsigned::new()
     }
 }
 
@@ -627,7 +627,7 @@ impl<U: Unsigned, B: Bit> Shl<UTerm> for UInt<U, B> {
 impl<U: Unsigned, B: Bit> Shl<B0> for UInt<U, B> {
     type Output = UInt<U, B>;
     fn shl(self, _: B0) -> Self::Output {
-        unreachable!()
+        Unsigned::new()
     }
 }
 
@@ -635,7 +635,7 @@ impl<U: Unsigned, B: Bit> Shl<B0> for UInt<U, B> {
 impl Shl<B0> for UTerm {
     type Output = UTerm;
     fn shl(self, _: B0) -> Self::Output {
-        unreachable!()
+        Unsigned::new()
     }
 }
 
@@ -643,7 +643,7 @@ impl Shl<B0> for UTerm {
 impl Shl<B1> for UTerm {
     type Output = UTerm;
     fn shl(self, _: B1) -> Self::Output {
-        unreachable!()
+        Unsigned::new()
     }
 }
 
@@ -651,7 +651,7 @@ impl Shl<B1> for UTerm {
 impl<U: Unsigned, B: Bit> Shl<B1> for UInt<U, B> {
     type Output = UInt<UInt<U, B>, B0>;
     fn shl(self, _: B1) -> Self::Output {
-        unreachable!()
+        Unsigned::new()
     }
 }
 
@@ -662,7 +662,7 @@ impl<U: Unsigned, B: Bit, Ur: Unsigned, Br: Bit> Shl<UInt<Ur, Br>> for UInt<U, B
 {
     type Output = Shleft<UInt<UInt<U, B>, B0>, Sub1<UInt<Ur, Br>>>;
     fn shl(self, _: UInt<Ur, Br>) -> Self::Output {
-        unreachable!()
+        unsafe { ::core::mem::uninitialized() }
     }
 }
 
@@ -673,7 +673,7 @@ impl<U: Unsigned, B: Bit, Ur: Unsigned, Br: Bit> Shl<UInt<Ur, Br>> for UInt<U, B
 impl<U: Unsigned> Shr<U> for UTerm {
     type Output = UTerm;
     fn shr(self, _: U) -> Self::Output {
-        unreachable!()
+        Unsigned::new()
     }
 }
 
@@ -681,7 +681,7 @@ impl<U: Unsigned> Shr<U> for UTerm {
 impl<U: Unsigned, B: Bit> Shr<UTerm> for UInt<U, B> {
     type Output = UInt<U, B>;
     fn shr(self, _: UTerm) -> Self::Output {
-        unreachable!()
+        Unsigned::new()
     }
 }
 
@@ -689,7 +689,7 @@ impl<U: Unsigned, B: Bit> Shr<UTerm> for UInt<U, B> {
 impl Shr<B0> for UTerm {
     type Output = UTerm;
     fn shr(self, _: B0) -> Self::Output {
-        unreachable!()
+        Unsigned::new()
     }
 }
 
@@ -697,7 +697,7 @@ impl Shr<B0> for UTerm {
 impl Shr<B1> for UTerm {
     type Output = UTerm;
     fn shr(self, _: B1) -> Self::Output {
-        unreachable!()
+        Unsigned::new()
     }
 }
 
@@ -705,7 +705,7 @@ impl Shr<B1> for UTerm {
 impl<U: Unsigned, B: Bit> Shr<B0> for UInt<U, B> {
     type Output = UInt<U, B>;
     fn shr(self, _: B0) -> Self::Output {
-        unreachable!()
+        Unsigned::new()
     }
 }
 
@@ -713,7 +713,7 @@ impl<U: Unsigned, B: Bit> Shr<B0> for UInt<U, B> {
 impl<U: Unsigned, B: Bit> Shr<B1> for UInt<U, B> {
     type Output = U;
     fn shr(self, _: B1) -> Self::Output {
-        unreachable!()
+        Unsigned::new()
     }
 }
 
@@ -724,7 +724,7 @@ impl<U: Unsigned, B: Bit, Ur: Unsigned, Br: Bit> Shr<UInt<Ur, Br>> for UInt<U, B
 {
     type Output = Shright<U, Sub1<UInt<Ur, Br>>>;
     fn shr(self, _: UInt<Ur, Br>) -> Self::Output {
-        unreachable!()
+        unsafe { ::core::mem::uninitialized() }
     }
 }
 
@@ -735,7 +735,7 @@ impl<U: Unsigned, B: Bit, Ur: Unsigned, Br: Bit> Shr<UInt<Ur, Br>> for UInt<U, B
 impl<U: Unsigned, B: Bit> Mul<B0> for UInt<U, B> {
     type Output = UTerm;
     fn mul(self, _: B0) -> Self::Output {
-        unreachable!()
+        Unsigned::new()
     }
 }
 
@@ -743,7 +743,7 @@ impl<U: Unsigned, B: Bit> Mul<B0> for UInt<U, B> {
 impl Mul<B0> for UTerm {
     type Output = UTerm;
     fn mul(self, _: B0) -> Self::Output {
-        unreachable!()
+        Unsigned::new()
     }
 }
 
@@ -751,7 +751,7 @@ impl Mul<B0> for UTerm {
 impl Mul<B1> for UTerm {
     type Output = UTerm;
     fn mul(self, _: B1) -> Self::Output {
-        unreachable!()
+        Unsigned::new()
     }
 }
 
@@ -759,7 +759,7 @@ impl Mul<B1> for UTerm {
 impl<U: Unsigned, B: Bit> Mul<B1> for UInt<U, B> {
     type Output = UInt<U, B>;
     fn mul(self, _: B1) -> Self::Output {
-        unreachable!()
+        Unsigned::new()
     }
 }
 
@@ -767,7 +767,7 @@ impl<U: Unsigned, B: Bit> Mul<B1> for UInt<U, B> {
 impl<U: Unsigned, B: Bit> Mul<UTerm> for UInt<U, B> {
     type Output = UTerm;
     fn mul(self, _: UTerm) -> Self::Output {
-        unreachable!()
+        Unsigned::new()
     }
 }
 
@@ -775,7 +775,7 @@ impl<U: Unsigned, B: Bit> Mul<UTerm> for UInt<U, B> {
 impl<U: Unsigned> Mul<U> for UTerm {
     type Output = UTerm;
     fn mul(self, _: U) -> Self::Output {
-        unreachable!()
+        Unsigned::new()
     }
 }
 
@@ -785,7 +785,7 @@ impl<Ul: Unsigned, B: Bit, Ur: Unsigned> Mul<UInt<Ur, B>> for UInt<Ul, B0>
 {
     type Output = UInt<Prod<Ul, UInt<Ur, B>>, B0>;
     fn mul(self, _: UInt<Ur, B>) -> Self::Output {
-        unreachable!()
+        unsafe { ::core::mem::uninitialized() }
     }
 }
 
@@ -796,7 +796,7 @@ impl<Ul: Unsigned, B: Bit, Ur: Unsigned> Mul<UInt<Ur, B>> for UInt<Ul, B1>
 {
     type Output = Sum<UInt<Prod<Ul, UInt<Ur, B>>, B0>, UInt<Ur, B>>;
     fn mul(self, _: UInt<Ur, B>) -> Self::Output {
-        unreachable!()
+        unsafe { ::core::mem::uninitialized() }
     }
 }
 
@@ -1031,7 +1031,7 @@ impl<Y: Unsigned, U: Unsigned, B: Bit, X: Unsigned> PrivatePow<Y, UInt<UInt<U, B
 impl<Ur: Unsigned> Div<Ur> for UTerm {
     type Output = UTerm;
     fn div(self, _: Ur) -> Self::Output {
-        unreachable!()
+        Unsigned::new()
     }
 }
 
@@ -1041,7 +1041,7 @@ impl<Ul: Unsigned, Bl: Bit, Ur: Unsigned> Div<Ur> for UInt<Ul, Bl>
 {
     type Output = PrivateDivFirstStepQuot<UInt<Ul, Bl>, Compare<UInt<Ul, Bl>, Ur>, Ur>;
     fn div(self, _: Ur) -> Self::Output {
-        unreachable!()
+        unsafe { ::core::mem::uninitialized() }
     }
 }
 
@@ -1205,7 +1205,7 @@ impl<Ui, Bi, Q, Divisor, Remainder> PrivateDiv<Greater, UInt<Ui, Bi>, Q, Divisor
 impl<Ur: Unsigned> Rem<Ur> for UTerm {
     type Output = UTerm;
     fn rem(self, _: Ur) -> Self::Output {
-        unreachable!()
+        Unsigned::new()
     }
 }
 
@@ -1215,6 +1215,6 @@ impl<Ul: Unsigned, Bl: Bit, Ur: Unsigned> Rem<Ur> for UInt<Ul, Bl>
 {
     type Output = PrivateDivFirstStepRem<UInt<Ul, Bl>, Compare<UInt<Ul, Bl>, Ur>, Ur>;
     fn rem(self, _: Ur) -> Self::Output {
-        unreachable!()
+        unsafe { ::core::mem::uninitialized() }
     }
 }

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -48,7 +48,7 @@ pub use marker_traits::Unsigned;
 /// The terminating type for `UInt`; it always comes after the most significant
 /// bit. `UTerm` by itself represents zero, which is aliased to `U0`.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug)]
-pub struct UTerm {}
+pub struct UTerm;
 
 impl Unsigned for UTerm {
     #[inline]
@@ -92,6 +92,11 @@ impl Unsigned for UTerm {
     fn to_isize() -> isize {
         0
     }
+
+    #[inline]
+    fn new() -> Self {
+        UTerm
+    }
 }
 
 /// `UInt` is defined recursively, where `B` is the least significant bit and `U` is the rest
@@ -112,16 +117,6 @@ impl Unsigned for UTerm {
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug)]
 pub struct UInt<U, B> {
     _marker: PhantomData<(U, B)>,
-}
-
-impl<U: Unsigned, B: Bit> UInt<U, B> {
-    /// Instantiates a singleton representing this unsigned integer.
-    #[inline]
-    pub fn new() -> UInt<U, B> {
-        UInt {
-            _marker: PhantomData
-        }
-    }
 }
 
 impl<U: Unsigned, B: Bit> Unsigned for UInt<U, B> {
@@ -165,6 +160,11 @@ impl<U: Unsigned, B: Bit> Unsigned for UInt<U, B> {
     #[inline]
     fn to_isize() -> isize {
         B::to_u8() as isize | U::to_isize() << 1
+    }
+
+    #[inline]
+    fn new() -> Self {
+        UInt { _marker: PhantomData }
     }
 }
 

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -50,6 +50,14 @@ pub use marker_traits::Unsigned;
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug)]
 pub struct UTerm;
 
+impl UTerm {
+    /// Instantiates a singleton representing this unsigned integer.
+    #[inline]
+    pub fn new() -> UTerm {
+        UTerm
+    }
+}
+
 impl Unsigned for UTerm {
     #[inline]
     fn to_u8() -> u8 {
@@ -92,11 +100,6 @@ impl Unsigned for UTerm {
     fn to_isize() -> isize {
         0
     }
-
-    #[inline]
-    fn new() -> Self {
-        UTerm
-    }
 }
 
 /// `UInt` is defined recursively, where `B` is the least significant bit and `U` is the rest
@@ -118,6 +121,17 @@ impl Unsigned for UTerm {
 pub struct UInt<U, B> {
     _marker: PhantomData<(U, B)>,
 }
+
+impl<U: Unsigned, B: Bit> UInt<U, B> {
+    /// Instantiates a singleton representing this unsigned integer.
+    #[inline]
+    pub fn new() -> UInt<U, B> {
+        UInt {
+            _marker: PhantomData
+        }
+    }
+}
+
 
 impl<U: Unsigned, B: Bit> Unsigned for UInt<U, B> {
     #[inline]
@@ -160,11 +174,6 @@ impl<U: Unsigned, B: Bit> Unsigned for UInt<U, B> {
     #[inline]
     fn to_isize() -> isize {
         B::to_u8() as isize | U::to_isize() << 1
-    }
-
-    #[inline]
-    fn new() -> Self {
-        UInt { _marker: PhantomData }
     }
 }
 


### PR DESCRIPTION
Make the functions non-divergent, which involves some calls to `mem::uninitialized`. These *should* be no-ops, so it shouldn't matter, but it's worth testing.