### PR TITLE
Functions for `Pow` and `Len`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rust:
   - stable
   - nightly
   - beta
+cache: cargo
 
 notifications:
   email:
@@ -12,12 +13,16 @@ notifications:
 before_script:
   - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
   - export TRAVIS_CARGO_NIGHTLY_FEATURE=""
+  - (cargo install rustfmt || true) # the || true keeps cargo from throwing an error if it's already installed
+
 script:
   - |
+    PATH=$PATH:~/.cargo/bin cargo fmt -- --write-mode=diff &&
     travis-cargo build &&
     travis-cargo test &&
     # Note: The "no_std" flag is deprecated and this test remains to make sure we don't break compatibility.
     travis-cargo --only stable test -- --features "no_std" &&
+    travis-cargo --only nightly test -- --features "clippy" &&
     travis-cargo --only stable doc
 
 after_success:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This project follows semantic versioning.
 
+### Unpublished
+    - [added] Functions to the `Pow` and `Len` traits. This is *technically* a breaking change, but
+      it would only break someone's code if they have a custom impl for `Pow`. I would be very
+      surprised if that is anyone other than me.
+    - [added]
+
 ### 1.4.0 (2016-10-29)
     - [added] Type-level arrays of type-level integers. (PR #66)
     - [added] The types in this crate are now instantiable. (Issue #67, PR #68)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ This project follows semantic versioning.
     - [added] Functions to the `Pow` and `Len` traits. This is *technically* a breaking change, but
       it would only break someone's code if they have a custom impl for `Pow`. I would be very
       surprised if that is anyone other than me.
-    - [added]
 
 ### 1.4.0 (2016-10-29)
     - [added] Type-level arrays of type-level integers. (PR #66)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@
     "Paho Lurie-Gregg <paho@paholg.com>",
     "Andre Bogus <bogusandre@gmail.com>"
   ]
-  description = "Typenum is a Rust library for type-level numbers evaluated at compile time. It currently supports bits, unsigned integers, and signed integers."
+  description = "Typenum is a Rust library for type-level numbers evaluated at compile time. It currently supports bits, unsigned integers, and signed integers. It also provides a type-level array of type-level numbers, but its implementation is incomplete."
   homepage = "http://paholg.com/project/typenum"
   documentation = "http://paholg.com/typenum"
   repository = "https://github.com/paholg/typenum"
@@ -18,3 +18,6 @@
 
 [features]
   no_std = []
+
+[dependencies]
+  clippy = { version = "*", optional = true }

--- a/README.md
+++ b/README.md
@@ -11,7 +11,17 @@ Typenum depends only on libcore, and so is suitable for use on any platform!
 
 For the full documentation, go [here](http://paholg.com/typenum).
 
-Here is a trivial example of its use:
+### Importing
+
+While `typenum` is divided into several modules, they are all re-exported through the crate root,
+so you can import anything contained herein with `use typenum::whatever;`, ignoring the
+crate structure.
+
+You may also find it useful to treat the `consts` module as a prelude, perfoming a glob import.
+
+### Example
+
+Here is a trivial example of `typenum`'s use:
 
 ```rust
 use typenum::{Sum, Exp, Integer, N2, P3, P4};
@@ -29,3 +39,4 @@ list is [here](https://crates.io/crates/typenum/reverse_dependencies). Of note a
 checking for arbitrary unit systems and
 [generic-array](https://crates.io/crates/generic-array/) which provides arrays whose
 length you can generically refer to.
+

--- a/src/array.rs
+++ b/src/array.rs
@@ -261,3 +261,21 @@ impl<V, A, U> Div<TArr<V, A>> for NInt<U>
 }
 
 // ---------------------------------------------------------------------------------------
+// Negate an array
+use core::ops::Neg;
+impl Neg for ATerm {
+    type Output = ATerm;
+    fn neg(self) -> Self::Output {
+        unreachable!()
+    }
+}
+
+impl<V, A> Neg for TArr<V, A>
+    where V: Neg,
+          A: Neg
+{
+    type Output = TArr<Negate<V>, Negate<A>>;
+    fn neg(self) -> Self::Output {
+        unreachable!()
+    }
+}

--- a/src/array.rs
+++ b/src/array.rs
@@ -53,6 +53,9 @@ macro_rules! tarr {
 /// Length of `ATerm` by itself is 0
 impl Len for ATerm {
     type Output = U0;
+    fn len(&self) -> Self::Output {
+        UTerm
+    }
 }
 
 /// Size of a `TypeArray`
@@ -62,6 +65,9 @@ impl<V, A> Len for TArr<V, A>
           Sum<Length<A>, B1>: Unsigned
 {
     type Output = Add1<Length<A>>;
+    fn len(&self) -> Self::Output {
+        unsafe { ::core::mem::uninitialized() }
+    }
 }
 
 // ---------------------------------------------------------------------------------------

--- a/src/bit.rs
+++ b/src/bit.rs
@@ -14,7 +14,7 @@ use {NonZero, Cmp, Greater, Less, Equal};
 pub use marker_traits::Bit;
 
 /// The type-level bit 0.
-#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug)]
+#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug, Default)]
 pub struct B0;
 
 impl B0 {
@@ -26,7 +26,7 @@ impl B0 {
 }
 
 /// The type-level bit 1.
-#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug)]
+#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug, Default)]
 pub struct B1;
 
 impl B1 {

--- a/src/int.rs
+++ b/src/int.rs
@@ -39,13 +39,13 @@ use consts::{U0, U1, P1, N1};
 pub use marker_traits::Integer;
 
 /// Type-level signed integers with positive sign.
-#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug)]
+#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug, Default)]
 pub struct PInt<U: Unsigned + NonZero> {
     _marker: PhantomData<U>,
 }
 
 /// Type-level signed integers with negative sign.
-#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug)]
+#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug, Default)]
 pub struct NInt<U: Unsigned + NonZero> {
     _marker: PhantomData<U>,
 }
@@ -54,9 +54,7 @@ impl<U: Unsigned + NonZero> PInt<U> {
     /// Instantiates a singleton representing this strictly positive integer.
     #[inline]
     pub fn new() -> PInt<U> {
-        PInt {
-            _marker: PhantomData
-        }
+        PInt { _marker: PhantomData }
     }
 }
 
@@ -64,15 +62,13 @@ impl<U: Unsigned + NonZero> NInt<U> {
     /// Instantiates a singleton representing this strictly negative integer.
     #[inline]
     pub fn new() -> NInt<U> {
-        NInt {
-            _marker: PhantomData
-        }
+        NInt { _marker: PhantomData }
     }
 }
 
 
 /// The type-level signed integer 0.
-#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug)]
+#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug, Default)]
 pub struct Z0;
 
 impl Z0 {
@@ -621,41 +617,65 @@ impl_int_rem!(NInt, NInt, NInt);
 /// 0^0 = 1
 impl Pow<Z0> for Z0 {
     type Output = P1;
+    fn powi(self, _: Z0) -> Self::Output {
+        P1::new()
+    }
 }
 
 /// 0^P = 0
 impl<U: Unsigned + NonZero> Pow<PInt<U>> for Z0 {
     type Output = Z0;
+    fn powi(self, _: PInt<U>) -> Self::Output {
+        Z0
+    }
 }
 
 /// 0^N = 0
 impl<U: Unsigned + NonZero> Pow<NInt<U>> for Z0 {
     type Output = Z0;
+    fn powi(self, _: NInt<U>) -> Self::Output {
+        Z0
+    }
 }
 
 /// 1^N = 1
 impl<U: Unsigned + NonZero> Pow<NInt<U>> for P1 {
     type Output = P1;
+    fn powi(self, _: NInt<U>) -> Self::Output {
+        P1::new()
+    }
 }
 
 /// (-1)^N = 1 if N is even
 impl<U: Unsigned> Pow<NInt<UInt<U, B0>>> for N1 {
     type Output = P1;
+    fn powi(self, _: NInt<UInt<U, B0>>) -> Self::Output {
+        P1::new()
+    }
 }
 
 /// (-1)^N = -1 if N is odd
 impl<U: Unsigned> Pow<NInt<UInt<U, B1>>> for N1 {
     type Output = N1;
+    fn powi(self, _: NInt<UInt<U, B1>>) -> Self::Output {
+        N1::new()
+    }
 }
 
 /// P^0 = 1
 impl<U: Unsigned + NonZero> Pow<Z0> for PInt<U> {
     type Output = P1;
+    fn powi(self, _: Z0) -> Self::Output {
+        P1::new()
+    }
 }
 
 /// N^0 = 1
 impl<U: Unsigned + NonZero> Pow<Z0> for NInt<U> {
     type Output = P1;
+    fn powi(self, _: Z0) -> Self::Output {
+        P1::new()
+    }
 }
 
 /// P(Ul)^P(Ur) = P(Ul^Ur)
@@ -664,6 +684,9 @@ impl<Ul: Unsigned + NonZero, Ur: Unsigned + NonZero> Pow<PInt<Ur>> for PInt<Ul>
           <Ul as Pow<Ur>>::Output: Unsigned + NonZero
 {
     type Output = PInt<<Ul as Pow<Ur>>::Output>;
+    fn powi(self, _: PInt<Ur>) -> Self::Output {
+        PInt::new()
+    }
 }
 
 /// N(Ul)^P(Ur) = P(Ul^Ur) if Ur is even
@@ -672,6 +695,9 @@ impl<Ul: Unsigned + NonZero, Ur: Unsigned> Pow<PInt<UInt<Ur, B0>>> for NInt<Ul>
           <Ul as Pow<UInt<Ur, B0>>>::Output: Unsigned + NonZero
 {
     type Output = PInt<<Ul as Pow<UInt<Ur, B0>>>::Output>;
+    fn powi(self, _: PInt<UInt<Ur, B0>>) -> Self::Output {
+        PInt::new()
+    }
 }
 
 /// N(Ul)^P(Ur) = N(Ul^Ur) if Ur is odd
@@ -680,4 +706,7 @@ impl<Ul: Unsigned + NonZero, Ur: Unsigned> Pow<PInt<UInt<Ur, B1>>> for NInt<Ul>
           <Ul as Pow<UInt<Ur, B1>>>::Output: Unsigned + NonZero
 {
     type Output = NInt<<Ul as Pow<UInt<Ur, B1>>>::Output>;
+    fn powi(self, _: PInt<UInt<Ur, B1>>) -> Self::Output {
+        NInt::new()
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,8 +48,12 @@
 
 
 // For clippy:
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
+
 #![allow(unknown_lints)]
-#![allow(type_complexity, expl_impl_clone_on_copy)]
+#![deny(clippy)]
+#![allow(type_complexity, len_without_is_empty)]
 
 use core::cmp::Ordering;
 
@@ -75,17 +79,17 @@ pub use array::{TArr, ATerm};
 
 /// A potential output from `Cmp`, this is the type equivalent to the enum variant
 /// `core::cmp::Ordering::Greater`.
-#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug)]
+#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug, Default)]
 pub struct Greater;
 
 /// A potential output from `Cmp`, this is the type equivalent to the enum variant
 /// `core::cmp::Ordering::Less`.
-#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug)]
+#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug, Default)]
 pub struct Less;
 
 /// A potential output from `Cmp`, this is the type equivalent to the enum variant
 /// `core::cmp::Ordering::Equal`.
-#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug)]
+#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug, Default)]
 pub struct Equal;
 
 /// Returns `core::cmp::Ordering::Greater`

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -48,7 +48,7 @@ pub use marker_traits::Unsigned;
 
 /// The terminating type for `UInt`; it always comes after the most significant
 /// bit. `UTerm` by itself represents zero, which is aliased to `U0`.
-#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug)]
+#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug, Default)]
 pub struct UTerm;
 
 impl UTerm {
@@ -118,7 +118,7 @@ impl Unsigned for UTerm {
 ///
 /// type U6 = UInt<UInt<UInt<UTerm, B1>, B1>, B0>;
 /// ```
-#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug)]
+#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug, Default)]
 pub struct UInt<U, B> {
     _marker: PhantomData<(U, B)>,
 }
@@ -127,9 +127,7 @@ impl<U: Unsigned, B: Bit> UInt<U, B> {
     /// Instantiates a singleton representing this unsigned integer.
     #[inline]
     pub fn new() -> UInt<U, B> {
-        UInt {
-            _marker: PhantomData
-        }
+        UInt { _marker: PhantomData }
     }
 }
 
@@ -203,6 +201,9 @@ macro_rules! test_uint_op {
 /// Length of `UTerm` by itself is 0
 impl Len for UTerm {
     type Output = U0;
+    fn len(&self) -> Self::Output {
+        UTerm
+    }
 }
 
 /// Length of a bit is 1
@@ -212,6 +213,9 @@ impl<U: Unsigned, B: Bit> Len for UInt<U, B>
           Add1<Length<U>>: Unsigned
 {
     type Output = Add1<Length<U>>;
+    fn len(&self) -> Self::Output {
+        unsafe { ::core::mem::uninitialized() }
+    }
 }
 
 // ---------------------------------------------------------------------------------------
@@ -962,6 +966,9 @@ impl<X: Unsigned, N: Unsigned> Pow<N> for X
     where X: PrivatePow<U1, N>
 {
     type Output = PrivatePowOut<X, U1, N>;
+    fn powi(self, _: N) -> Self::Output {
+        unsafe { ::core::mem::uninitialized() }
+    }
 }
 
 impl<Y: Unsigned, X: Unsigned> PrivatePow<Y, U0> for X {


### PR DESCRIPTION
This adds and implements member functions for the `Pow` and `Len` traits.

This is technically a breaking change, but I doubt it will break anyone's code in practice, as that would require them to have implemented one of those traits for a type outside this library. `Len` was just introduced a couple days ago, and I have yet to see anyone other than me use arithmetic operations beyond `Add`.

So, I think it's okay to just boost the minor version for this.