### PR TITLE
Implement PartialDiv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This project follows semantic versioning.
 
-### Unpublished
+### 1.6.0 (2017-02-24)
     - [fixed] Bug in `Array` division.
     - [fixed] Bug where `Rem` would sometimes exit early with the wrong answer.
     - [added] `PartialDiv` operator that performs division as a partial function -- it's defined

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project follows semantic versioning.
 
 ### Unpublished
     - [fixed] Bug in `Array` division.
+    - [fixed] Bug where `Rem` would sometimes exit early with the wrong answer.
+    - [added] `PartialDiv` operator that performs division as a partial function -- it's defined
+      only when there is no remainder.
 
 ### 1.5.2 (2017-02-04)
     - [fixed] Bug between `Div` implementation and type system.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
   name = "typenum"
   build = "build.rs"
-  version = "1.5.2"
+  version = "1.6.0"
   authors = [
     "Paho Lurie-Gregg <paho@paholg.com>",
     "Andre Bogus <bogusandre@gmail.com>"

--- a/src/int.rs
+++ b/src/int.rs
@@ -506,7 +506,9 @@ impl_int_div!(NInt, NInt, PInt);
 
 use {PartialDiv, Quot};
 
-impl<M, N> PartialDiv<N> for M where M: Integer + Div<N> + Rem<N, Output = Z0> {
+impl<M, N> PartialDiv<N> for M
+    where M: Integer + Div<N> + Rem<N, Output = Z0>
+{
     type Output = Quot<M, N>;
     fn partial_div(self, _: N) -> Self::Output {
         unsafe { ::core::mem::uninitialized() }

--- a/src/int.rs
+++ b/src/int.rs
@@ -502,6 +502,18 @@ impl_int_div!(NInt, PInt, NInt);
 impl_int_div!(NInt, NInt, PInt);
 
 // ---------------------------------------------------------------------------------------
+// PartialDiv
+
+use {PartialDiv, Quot};
+
+impl<M, N> PartialDiv<N> for M where M: Integer + Div<N> + Rem<N, Output = Z0> {
+    type Output = Quot<M, N>;
+    fn partial_div(self, _: N) -> Self::Output {
+        unsafe { ::core::mem::uninitialized() }
+    }
+}
+
+// ---------------------------------------------------------------------------------------
 // Cmp
 
 /// 0 == 0

--- a/src/operator_aliases.rs
+++ b/src/operator_aliases.rs
@@ -14,7 +14,7 @@
 //!
 //! Aliases!!!
 use core::ops::{BitAnd, BitOr, BitXor, Shl, Shr, Add, Sub, Mul, Div, Rem, Neg};
-use type_operators::{Pow, Cmp, Len};
+use type_operators::{Pow, Cmp, Len, PartialDiv};
 
 /// Alias for the associated type of `BitAnd`: `And<A, B> = <A as BitAnd<B>>::Output`
 pub type And<A, B> = <A as BitAnd<B>>::Output;
@@ -39,6 +39,9 @@ pub type Prod<A, B> = <A as Mul<B>>::Output;
 pub type Quot<A, B> = <A as Div<B>>::Output;
 /// Alias for the associated type of `Rem`: `Mod<A, B> = <A as Rem<B>>::Output`
 pub type Mod<A, B> = <A as Rem<B>>::Output;
+
+/// Alias for the associated type of `PartialDiv`: `PartialQuot<A, B> = <A as PartialDiv<B>>::Output`
+pub type PartialQuot<A, B> = <A as PartialDiv<B>>::Output;
 
 /// Alias for the associated type of `Neg`: `Negate<A> = <A as Neg>::Output`
 pub type Negate<A> = <A as Neg>::Output;

--- a/src/operator_aliases.rs
+++ b/src/operator_aliases.rs
@@ -40,7 +40,8 @@ pub type Quot<A, B> = <A as Div<B>>::Output;
 /// Alias for the associated type of `Rem`: `Mod<A, B> = <A as Rem<B>>::Output`
 pub type Mod<A, B> = <A as Rem<B>>::Output;
 
-/// Alias for the associated type of `PartialDiv`: `PartialQuot<A, B> = <A as PartialDiv<B>>::Output`
+/// Alias for the associated type of
+/// `PartialDiv`: `PartialQuot<A, B> = <A as PartialDiv<B>>::Output`
 pub type PartialQuot<A, B> = <A as PartialDiv<B>>::Output;
 
 /// Alias for the associated type of `Neg`: `Negate<A> = <A as Neg>::Output`

--- a/src/type_operators.rs
+++ b/src/type_operators.rs
@@ -256,3 +256,12 @@ pub trait Len {
     /// This function isn't used in this crate, but may be useful for others.
     fn len(&self) -> Self::Output;
 }
+
+/// Division as a partial function. This **type operator** performs division just as `Div`, but is
+/// only defined when the result is an integer (i.e. there is no remainder).
+pub trait PartialDiv<Rhs = Self> {
+    /// The type of the result of the division
+    type Output;
+    /// Method for performing the division
+    fn partial_div(self, _: Rhs) -> Self::Output;
+}

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -995,41 +995,6 @@ impl<Y: Unsigned, U: Unsigned, B: Bit, X: Unsigned> PrivatePow<Y, UInt<UInt<U, B
     type Output = PrivatePowOut<Square<X>, Prod<X, Y>, UInt<U, B>>;
 }
 
-// ---------------------------------------------------------------------------------------
-// Dividing unsigned integers                 fixme: old algorithm
-
-// Here is the algorithm we use:
-// Div:
-//   Call PrivateDivFirstStep with C = Numerator.cmp(Divisor)
-// PrivateDivFirstStep:
-//   if Numerator < Divisor:
-//     return 0
-//   if Numerator == Divisor:
-//     return 1
-//   I = Len(Numerator) - Len(Divisor)
-//   Divisor = Divisor << I
-//   Call PrivateDiv with C = Numerator.cmp(Divisor), I = I, Q = 0, Remainder = Numerator
-// PrivateDiv:
-//   if I == 0:
-//     if C == Less: # Can't do any more
-//       return Q
-//     if C == Equal # We are done, no remainder
-//       return Q + 1
-//     if C == Greater # Same as Equal, but we have a remainder
-//       return Q + 1
-//   # I > 0
-//   if C == Less: # Divisor is too big
-//     Call PrivateDiv with Divisor >> 1, I - 1, C = Remainder.cmp(Divisor)
-//   if C == Equal: # Sweet, we're done early with no remainder
-//     return Q + 2^I
-//   if C == Greater: # Do a step and keep going
-//     Q += 2^I
-//     I -= 1
-//     Remainder -= Divisor
-//     Divisor = Divisor >> 1
-//     C = Remainder.cmp(Divisor)
-//     Call PrivateDiv
-
 // -----------------------------------------
 // GetBit
 
@@ -1322,7 +1287,7 @@ impl<N, D, Q, R, Ui, Bi> PrivateDivIf<N, D, Q, R, UInt<Ui, Bi>, Equal> for ()
           (): PrivateDiv<N, D, SetBitOut<Q, UInt<Ui, Bi>, B1>, U0, Sub1<UInt<Ui, Bi>>>
 {
     type Quotient = PrivateDivQuot<N, D, SetBitOut<Q, UInt<Ui, Bi>, B1>, U0, Sub1<UInt<Ui, Bi>>>;
-    type Remainder = U0;
+    type Remainder = PrivateDivRem<N, D, SetBitOut<Q, UInt<Ui, Bi>, B1>, U0, Sub1<UInt<Ui, Bi>>>;
 }
 
 use Diff;
@@ -1366,4 +1331,24 @@ impl<N, D, Q, R> PrivateDivIf<N, D, Q, R, U0, Greater> for ()
 {
     type Quotient = SetBitOut<Q, U0, B1>;
     type Remainder = Diff<R, D>;
+}
+
+// -----------------------------------------
+// PartialDiv
+use {PartialDiv, Quot};
+impl<Ur: Unsigned, Br: Bit> PartialDiv<UInt<Ur, Br>> for UTerm {
+    type Output = UTerm;
+    fn partial_div(self, _: UInt<Ur, Br>) -> Self::Output {
+        UTerm
+    }
+}
+
+// M / N
+impl<Ul: Unsigned, Bl: Bit, Ur: Unsigned, Br: Bit> PartialDiv<UInt<Ur, Br>> for UInt<Ul, Bl>
+    where UInt<Ul, Bl>: Div<UInt<Ur, Br>> + Rem<UInt<Ur, Br>, Output = U0>,
+{
+    type Output = Quot<UInt<Ul, Bl>, UInt<Ur, Br>>;
+    fn partial_div(self, _: UInt<Ur, Br>) -> Self::Output {
+        unsafe { ::core::mem::uninitialized() }
+    }
 }

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -1345,7 +1345,7 @@ impl<Ur: Unsigned, Br: Bit> PartialDiv<UInt<Ur, Br>> for UTerm {
 
 // M / N
 impl<Ul: Unsigned, Bl: Bit, Ur: Unsigned, Br: Bit> PartialDiv<UInt<Ur, Br>> for UInt<Ul, Bl>
-    where UInt<Ul, Bl>: Div<UInt<Ur, Br>> + Rem<UInt<Ur, Br>, Output = U0>,
+    where UInt<Ul, Bl>: Div<UInt<Ur, Br>> + Rem<UInt<Ur, Br>, Output = U0>
 {
     type Output = Quot<UInt<Ul, Bl>, UInt<Ur, Br>>;
     fn partial_div(self, _: UInt<Ur, Br>) -> Self::Output {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -211,7 +211,7 @@ fn int_cmp_test(a: i64, b: i64) -> String {
 #[test]
 fn test_all() {
     // will test all permutations of number pairs up to this (and down to its opposite for ints)
-    let high: i64 = 4;
+    let high: i64 = 5;
 
     let uints = (0u64..high as u64 + 1).flat_map(|a| (a..a + 1).cycle().zip((0..high as u64 + 1)));
     let ints = (-high..high + 1).flat_map(|a| (a..a + 1).cycle().zip((-high..high + 1)));
@@ -260,7 +260,7 @@ extern crate typenum;
 
 use std::ops::{BitAnd, BitOr, BitXor, Shl, Shr, Neg, Add, Sub, Mul, Div, Rem};
 use std::cmp::Ordering;
-use typenum::{NonZero, Same, Pow, Ord, Cmp, Greater, Less, Equal};
+use typenum::{NonZero, Same, Pow, Ord, Cmp, Greater, Less, Equal, PartialDiv};
 use typenum::bit::{Bit, B0, B1};
 use typenum::uint::{Unsigned, UInt, UTerm};
 use typenum::int::{Integer, NInt, PInt, Z0};
@@ -283,6 +283,9 @@ fn main() {
         if b != 0 {
             write!(writer, "{}", uint_binary_test(a, "Div", b, a / b)).unwrap();
             write!(writer, "{}", uint_binary_test(a, "Rem", b, a % b)).unwrap();
+            if a % b == 0 {
+                write!(writer, "{}", uint_binary_test(a, "PartialDiv", b, a / b)).unwrap();
+            }
         }
         write!(writer, "{}", uint_binary_test(a, "Pow", b, a.pow(b as u32))).unwrap();
         write!(writer, "{}", uint_cmp_test(a, b)).unwrap();


### PR DESCRIPTION
This creates a type operator, `PartialDiv` that performs division as a partial function. It is only defined when the result has no remainder, but otherwise performs a normal division.

In addition, this patch fixes a bug where `Rem` would sometimes terminate early. Our tests missed it because we weren't testing high enough numbers.