### PR TITLE
Improve op macro, add assert macros for types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This project follows semantic versioning.
 
+### Unpublished ()
+    - [added] The `assert_type!` and `assert_type_eq!` macros.
+    - [added] Operators to the `op!` macro, including those performed by `cmp!`.
+    - [fixed] Bug in `op!` macro involving functions and convoluted expressions.
+    - [deprecated] The `cmp!` macro.
+
 ### 1.8.0 (2017-04-12)
     - [added] The `op!` macro for conveniently performing type-level operations.
     - [added] The `cmp!` macro for conveniently performing type-level comparisons.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,4 @@
   no_std = []
 
 [dependencies]
-  clippy = { version = "0.0.122", optional = true }
+  clippy = { version = "0.0.124", optional = true }

--- a/build/main.rs
+++ b/build/main.rs
@@ -74,7 +74,6 @@ pub fn no_std() {}
 // fixme: get a warning when testing without this
 #[allow(dead_code)]
 fn main() {
-    // If you change this, change also the comments in src/consts.rs
     let highest: u64 = 1024;
 
 

--- a/build/main.rs
+++ b/build/main.rs
@@ -110,6 +110,7 @@ These alias definitions look like this:
 ```rust
 use typenum::{{B0, B1, UInt, UTerm}};
 
+# #[allow(dead_code)]
 type U6 = UInt<UInt<UInt<UTerm, B1>, B1>, B0>;
 ```
 
@@ -128,6 +129,7 @@ use typenum::{{B0, B1, UInt, UTerm, PInt, NInt}};
 
 # #[allow(dead_code)]
 type P6 = PInt<UInt<UInt<UInt<UTerm, B1>, B1>, B0>>;
+# #[allow(dead_code)]
 type N6 = NInt<UInt<UInt<UInt<UTerm, B1>, B1>, B0>>;
 ```
 

--- a/build/op.rs
+++ b/build/op.rs
@@ -232,12 +232,12 @@ fn main() {{
 Operators are evaluated based on the operator precedence outlined
 [here](https://doc.rust-lang.org/reference.html#operator-precedence).
 
-The full list of supported operators and functions is as follows. They all expand to type aliases
-defined in the `operator_aliases` module:
+The full list of supported operators and functions is as follows:
 
 {}
 
-And here is an expanded list, including examples:
+They all expand to type aliases defined in the `operator_aliases` module. Here is an expanded list,
+including examples:
 
 ",
            ops.iter()

--- a/build/op.rs
+++ b/build/op.rs
@@ -171,6 +171,14 @@ pub fn write_op_macro() -> ::std::io::Result<()> {
                     op_type: Function,
                 },
                 Op {
+                    token: "abs",
+                    operator: "AbsVal",
+                    example: ("abs(N2)", "P2"),
+                    precedence: !0,
+                    n_args: 1,
+                    op_type: Function,
+                },
+                Op {
                     token: "cube",
                     operator: "Cube",
                     example: ("cube(P2)", "P8"),

--- a/build/op.rs
+++ b/build/op.rs
@@ -155,6 +155,14 @@ pub fn write_op_macro() -> ::std::io::Result<()> {
                     op_type: Operator,
                 },
                 Op {
+                    token: "cmp",
+                    operator: "Compare",
+                    example: ("cmp(P2, P3)", "Less"),
+                    precedence: !0,
+                    n_args: 2,
+                    op_type: Function,
+                },
+                Op {
                     token: "sqr",
                     operator: "Square",
                     example: ("sqr(P2)", "P4"),
@@ -245,7 +253,7 @@ And here is an expanded list, including examples:
 
 ```rust
 # #[macro_use] extern crate typenum;
-# use typenum::consts::*;
+# use typenum::*;
 # fn main() {{
 assert_type_eq!(op!({ex0}), {ex1});
 # }}

--- a/build/tests.rs
+++ b/build/tests.rs
@@ -226,7 +226,7 @@ use std::cmp::Ordering;
 use typenum::*;
 ")?;
     use std::cmp;
-    // uint operators: BitAnd, BitOr, BitXor, Shl, Shr, Add, Sub, Mul, Div, Rem, Pow, Cmp, Min, Max
+    // uint operators:
     for (a, b) in uints {
         write!(writer, "{}", uint_binary_test(a, "BitAnd", b, a & b))?;
         write!(writer, "{}", uint_binary_test(a, "BitOr", b, a | b))?;
@@ -250,7 +250,7 @@ use typenum::*;
         write!(writer, "{}", uint_binary_test(a, "Pow", b, a.pow(b as u32)))?;
         write!(writer, "{}", uint_cmp_test(a, b))?;
     }
-    // int operators: Add, Sub, Mul, Div, Rem, Cmp, Min, Max
+    // int operators:
     for (a, b) in ints {
         write!(writer, "{}", int_binary_test(a, "Add", b, a + b))?;
         write!(writer, "{}", int_binary_test(a, "Sub", b, a - b))?;
@@ -260,15 +260,18 @@ use typenum::*;
         if b != 0 {
             write!(writer, "{}", int_binary_test(a, "Div", b, a / b))?;
             write!(writer, "{}", int_binary_test(a, "Rem", b, a % b))?;
+            if a % b == 0 {
+                write!(writer, "{}", int_binary_test(a, "PartialDiv", b, a / b))?;
+            }
         }
-        if b >= 0 || a == 1 || a == -1 {
+        if b >= 0 || a.abs() == 1 {
             let result = if b < 0 {
                 if a == 1 {
                     a
                 } else if a == -1 {
                     a.pow((-b) as u32)
                 } else {
-                    panic!("THIS CAN'T HAPPEN");
+                    unreachable!()
                 }
             } else {
                 a.pow(b as u32)

--- a/src/array.rs
+++ b/src/array.rs
@@ -37,7 +37,7 @@ impl<V, A> TypeArray for TArr<V, A> {}
 /// use typenum::consts::*;
 ///
 /// type Array = tarr![P3, N4, Z0, P38];
-/// # fn main() {}
+/// # fn main() { let _: Array; }
 #[macro_export]
 macro_rules! tarr {
     () => ( $crate::ATerm );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,3 +120,32 @@ impl Ord for Equal {
         Ordering::Equal
     }
 }
+
+/**
+Asserts that two types are the same.
+*/
+#[macro_export]
+macro_rules! assert_type_eq {
+    ($a:ty, $b:ty) => (
+        let _: <$a as $crate::Same<$b>>::Output;
+    );
+}
+
+/**
+Asserts that a type is `True`, aka `B1`.
+*/
+#[macro_export]
+macro_rules! assert_type {
+    ($a:ty) => (
+        let _: <$a as $crate::Same<True>>::Output;
+    );
+}
+
+
+// fixme: temporary
+#[test]
+fn testacular() {
+    use consts::*;
+
+    assert_type_eq!(op!(sqr(U1) == U1), True);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,12 +140,3 @@ macro_rules! assert_type {
         let _: <$a as $crate::Same<True>>::Output;
     );
 }
-
-
-// fixme: temporary
-#[test]
-fn testacular() {
-    use consts::*;
-
-    assert_type_eq!(op!(sqr(U1) == U1), True);
-}

--- a/src/operator_aliases.rs
+++ b/src/operator_aliases.rs
@@ -4,11 +4,16 @@
 //! For example, type `X` and type `Y` are the same here:
 //!
 //! ```rust
+//! # #[macro_use] extern crate typenum;
+//! # fn main() {
 //! use std::ops::Mul;
 //! use typenum::{Prod, P5, P7};
 //!
 //! type X = <P7 as Mul<P5>>::Output;
 //! type Y = Prod<P7, P5>;
+//!
+//! assert_type_eq!(X, Y);
+//! # }
 //! ```
 //!
 //!
@@ -73,3 +78,19 @@ pub type Minimum<A, B> = <A as Min<B>>::Output;
 
 /// Alias for the associated type of `Max`: `Maximum<A, B> = <A as Max<B>>::Output`
 pub type Maximum<A, B> = <A as Max<B>>::Output;
+
+
+use type_operators::{IsLess, IsEqual, IsGreater, IsGreaterOrEqual, IsLessOrEqual, IsNotEqual};
+/// Alias for the associated type of `IsLess`: `Le<A, B> = <A as IsLess<B>>::Output`
+pub type Le<A, B> = <A as IsLess<B>>::Output;
+/// Alias for the associated type of `IsEqual`: `Eq<A, B> = <A as IsEqual<B>>::Output`
+pub type Eq<A, B> = <A as IsEqual<B>>::Output;
+/// Alias for the associated type of `IsGreater`: `Gr<A, B> = <A as IsGreater<B>>::Output`
+pub type Gr<A, B> = <A as IsGreater<B>>::Output;
+/// Alias for the associated type of `IsGreaterOrEqual`:
+/// `GrEq<A, B> = <A as IsGreaterOrEqual<B>>::Output`
+pub type GrEq<A, B> = <A as IsGreaterOrEqual<B>>::Output;
+/// Alias for the associated type of `IsLessOrEqual`: `LeEq<A, B> = <A as IsLessOrEqual<B>>::Output`
+pub type LeEq<A, B> = <A as IsLessOrEqual<B>>::Output;
+/// Alias for the associated type of `IsNotEqual`: `NotEq<A, B> = <A as IsNotEqual<B>>::Output`
+pub type NotEq<A, B> = <A as IsNotEqual<B>>::Output;

--- a/src/type_operators.rs
+++ b/src/type_operators.rs
@@ -18,6 +18,7 @@
 /// assert_eq!(<U5 as Same<U5>>::Output::to_u32(), 5);
 ///
 /// // Only an error if we use it:
+/// # #[allow(dead_code)]
 /// type Undefined = <U5 as Same<U4>>::Output;
 /// // Compiler error:
 /// // Undefined::to_u32();
@@ -238,7 +239,7 @@ fn pow_test() {
 ///
 /// # Example
 /// ```rust
-/// use typenum::{Cmp, Ord, Greater, Less, Equal, N3, P2, P5};
+/// use typenum::{Cmp, Ord, N3, P2, P5};
 /// use std::cmp::Ordering;
 ///
 /// assert_eq!(<P2 as Cmp<N3>>::Output::to_ordering(), Ordering::Greater);
@@ -402,7 +403,10 @@ impl<A, B> IsGreaterOrEqual<B> for A
 
 
 /**
-A convenience macro for comparing type numbers.
+A convenience macro for comparing type numbers. **Use `op!` instead.**
+
+**NOTE**: The functionality of this macro has been merged into `op!`. Use that macro instead. This
+one will be removed at some point in the future.
 
 Due to the intricacies of the macro system, if the left-hand operand is more complex than a simple
 `ident`, you must place a comma between it and the comparison sign.
@@ -423,7 +427,8 @@ type Result = cmp!(P9 == op!(P1 + P2 * (P2 - N2)));
 assert_eq!(Result::to_bool(), true);
 }
 ```
-*/
+ */
+#[deprecated(since="1.9.0", note="use the `op!` macro instead")]
 #[macro_export]
 macro_rules! cmp {
     ($a:ident < $b:ty) => (

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -112,8 +112,9 @@ impl Unsigned for UTerm {
 ///
 /// # Example
 /// ```rust
-/// use typenum::{B0, B1, UInt, UTerm, Unsigned};
+/// use typenum::{B0, B1, UInt, UTerm};
 ///
+/// # #[allow(dead_code)]
 /// type U6 = UInt<UInt<UInt<UTerm, B1>, B1>, B0>;
 /// ```
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug, Default)]
@@ -254,7 +255,7 @@ impl<U: Unsigned> Add<B1> for UInt<U, B0> {
 /// `UInt<U, B1> + B1 = UInt<U + B1, B0>`
 impl<U: Unsigned> Add<B1> for UInt<U, B1>
     where U: Add<B1>,
-          Sum<U, B1>: Unsigned
+          Add1<U>: Unsigned
 {
     type Output = UInt<Add1<U>, B0>;
     fn add(self, _: B1) -> Self::Output {


### PR DESCRIPTION
Note: The use of the `assert_type` and `assert_type_eq` macros in doc tests added works only on Rust >= 1.17, so we'll wait until that stabilizes to merge this.

This adds functionality to the `op!` macro, making the `cmp!` macro no longer needed, and fixes a bug in it.