### PR TITLE
Add i128 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@
 
 [features]
   no_std = []
+  i128 = []
 
 [dependencies]
   clippy = { version = "0.0.122", optional = true }

--- a/src/int.rs
+++ b/src/int.rs
@@ -99,6 +99,11 @@ impl Integer for Z0 {
     fn to_i64() -> i64 {
         0
     }
+    #[cfg(feature="i128")]
+    #[inline]
+    fn to_i128() -> i128 {
+        0
+    }
     #[inline]
     fn to_isize() -> isize {
         0
@@ -122,6 +127,11 @@ impl<U: Unsigned + NonZero> Integer for PInt<U> {
     fn to_i64() -> i64 {
         <U as Unsigned>::to_i64()
     }
+    #[cfg(feature="i128")]
+    #[inline]
+    fn to_i128() -> i128 {
+        <U as Unsigned>::to_i128()
+    }
     #[inline]
     fn to_isize() -> isize {
         <U as Unsigned>::to_isize()
@@ -144,6 +154,11 @@ impl<U: Unsigned + NonZero> Integer for NInt<U> {
     #[inline]
     fn to_i64() -> i64 {
         -<U as Unsigned>::to_i64()
+    }
+    #[cfg(feature="i128")]
+    #[inline]
+    fn to_i128() -> i128 {
+        -<U as Unsigned>::to_i128()
     }
     #[inline]
     fn to_isize() -> isize {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@
 #![no_std]
 #![warn(missing_docs)]
 
+#![cfg_attr(feature="i128", feature(i128_type))]
 
 // For clippy:
 #![cfg_attr(feature="clippy", feature(plugin))]

--- a/src/marker_traits.rs
+++ b/src/marker_traits.rs
@@ -54,6 +54,9 @@ pub trait Unsigned {
     fn to_u32() -> u32;
     #[allow(missing_docs)]
     fn to_u64() -> u64;
+    #[cfg(feature="i128")]
+    #[allow(missing_docs)]
+    fn to_u128() -> u128;
     #[allow(missing_docs)]
     fn to_usize() -> usize;
 
@@ -65,6 +68,9 @@ pub trait Unsigned {
     fn to_i32() -> i32;
     #[allow(missing_docs)]
     fn to_i64() -> i64;
+    #[cfg(feature="i128")]
+    #[allow(missing_docs)]
+    fn to_i128() -> i128;
     #[allow(missing_docs)]
     fn to_isize() -> isize;
 }
@@ -88,6 +94,9 @@ pub trait Integer {
     fn to_i32() -> i32;
     #[allow(missing_docs)]
     fn to_i64() -> i64;
+    #[cfg(feature="i128")]
+    #[allow(missing_docs)]
+    fn to_i128() -> i128;
     #[allow(missing_docs)]
     fn to_isize() -> isize;
 }

--- a/src/type_operators.rs
+++ b/src/type_operators.rs
@@ -183,6 +183,8 @@ macro_rules! impl_pow_i {
 }
 
 impl_pow_i!(u8, u16, u32, u64, usize, i8, i16, i32, i64, isize);
+#[cfg(feature="i128")]
+impl_pow_i!(u128, i128);
 
 #[test]
 fn pow_test() {

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -74,6 +74,11 @@ impl Unsigned for UTerm {
     fn to_u64() -> u64 {
         0
     }
+    #[cfg(feature="i128")]
+    #[inline]
+    fn to_u128() -> u128 {
+        0
+    }
     #[inline]
     fn to_usize() -> usize {
         0
@@ -93,6 +98,11 @@ impl Unsigned for UTerm {
     }
     #[inline]
     fn to_i64() -> i64 {
+        0
+    }
+    #[cfg(feature="i128")]
+    #[inline]
+    fn to_i128() -> i128 {
         0
     }
     #[inline]
@@ -147,6 +157,11 @@ impl<U: Unsigned, B: Bit> Unsigned for UInt<U, B> {
     fn to_u64() -> u64 {
         B::to_u8() as u64 | U::to_u64() << 1
     }
+    #[cfg(feature="i128")]
+    #[inline]
+    fn to_u128() -> u128 {
+        B::to_u8() as u128 | U::to_u128() << 1
+    }
     #[inline]
     fn to_usize() -> usize {
         B::to_u8() as usize | U::to_usize() << 1
@@ -167,6 +182,11 @@ impl<U: Unsigned, B: Bit> Unsigned for UInt<U, B> {
     #[inline]
     fn to_i64() -> i64 {
         B::to_u8() as i64 | U::to_i64() << 1
+    }
+    #[cfg(feature="i128")]
+    #[inline]
+    fn to_i128() -> i128 {
+        B::to_u8() as i128 | U::to_i128() << 1
     }
     #[inline]
     fn to_isize() -> isize {


### PR DESCRIPTION
Add `i128` support behind `i128` cargo feature.

Note: CI should be configured to run tests with and without this feature enabled on nightly.