### PR TITLE
PowerOfTwo marker trait for Bit and PInt

### DIFF
--- a/src/bit.rs
+++ b/src/bit.rs
@@ -11,7 +11,7 @@
 //!
 
 use core::ops::{BitAnd, BitOr, BitXor, Not};
-use {NonZero, Cmp, Greater, Less, Equal};
+use {NonZero, Cmp, Greater, Less, Equal, PowerOfTwo};
 
 pub use marker_traits::Bit;
 
@@ -62,6 +62,7 @@ impl Bit for B1 {
 }
 
 impl NonZero for B1 {}
+impl PowerOfTwo for B1 {}
 
 // macro for testing operation results. Uses `Same` to ensure the types are equal and
 // not just the values they evaluate to.

--- a/src/int.rs
+++ b/src/int.rs
@@ -30,7 +30,7 @@
 use core::ops::{Neg, Add, Sub, Mul, Div, Rem};
 use core::marker::PhantomData;
 
-use {NonZero, Pow, Cmp, Greater, Equal, Less};
+use {NonZero, Pow, Cmp, Greater, Equal, Less, PowerOfTwo};
 use uint::{Unsigned, UInt};
 use bit::{Bit, B0, B1};
 use private::{PrivateIntegerAdd, PrivateDivInt, PrivateRem};
@@ -66,7 +66,6 @@ impl<U: Unsigned + NonZero> NInt<U> {
     }
 }
 
-
 /// The type-level signed integer 0.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug, Default)]
 pub struct Z0;
@@ -81,6 +80,8 @@ impl Z0 {
 
 impl<U: Unsigned + NonZero> NonZero for PInt<U> {}
 impl<U: Unsigned + NonZero> NonZero for NInt<U> {}
+
+impl<U: Unsigned + NonZero + PowerOfTwo> PowerOfTwo for PInt<U> {}
 
 impl Integer for Z0 {
     #[inline]

--- a/src/marker_traits.rs
+++ b/src/marker_traits.rs
@@ -115,14 +115,29 @@ pub trait TypeArray {}
 ///
 /// This trait should not be implemented for anything outside this crate.
 ///
-/// # Example
+/// # Examples
+///
+/// Here's a working example:
+///
 /// ```rust
-/// use typenum::{P4, P8, P9, PowerOfTwo};
+/// use typenum::{P4, P8, PowerOfTwo};
 ///
 /// fn only_p2<P: PowerOfTwo>() { }
 ///
 /// only_p2::<P4>();
 /// only_p2::<P8>();
-/// // only_p2::<P9>(); // does not compile.
 /// ```
+///
+/// Numbers which are not a power of two will fail to compile in this example:
+///
+/// ```rust,compile_fail
+/// use typenum::{P9, P511, P6372, PowerOfTwo};
+///
+/// fn only_p2<P: PowerOfTwo>() { }
+///
+/// only_p2::<P9>();
+/// only_p2::<P511>();
+/// only_p2::<P6372>();
+/// ```
+
 pub trait PowerOfTwo {}

--- a/src/marker_traits.rs
+++ b/src/marker_traits.rs
@@ -110,3 +110,19 @@ pub trait Integer {
 /// other marker traits here. However, that requires stabilization of associated consts or of
 /// const functions.
 pub trait TypeArray {}
+
+/// The **marker trait** for type-level numbers which are a power of two.
+///
+/// This trait should not be implemented for anything outside this crate.
+///
+/// # Example
+/// ```rust
+/// use typenum::{P4, P8, P9, PowerOfTwo};
+///
+/// fn only_p2<P: PowerOfTwo>() { }
+///
+/// only_p2::<P4>();
+/// only_p2::<P8>();
+/// // only_p2::<P9>(); // does not compile.
+/// ```
+pub trait PowerOfTwo {}

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -42,7 +42,7 @@ use private::{TrimOut, PrivateAndOut, PrivateXorOut, PrivateSubOut, PrivateCmpOu
 use consts::{U0, U1};
 use {Or, Shleft, Shright, Sum, Prod, Add1, Sub1, Square, Length};
 
-pub use marker_traits::Unsigned;
+pub use marker_traits::{Unsigned, PowerOfTwo};
 
 /// The terminating type for `UInt`; it always comes after the most significant
 /// bit. `UTerm` by itself represents zero, which is aliased to `U0`.
@@ -196,6 +196,9 @@ impl<U: Unsigned, B: Bit> Unsigned for UInt<U, B> {
 }
 
 impl<U: Unsigned, B: Bit> NonZero for UInt<U, B> {}
+
+impl PowerOfTwo for UInt<UTerm, B1> {}
+impl<U: Unsigned + PowerOfTwo> PowerOfTwo for UInt<U, B0> {}
 
 // macro for testing operation results. Uses `Same` to ensure the types are equal and
 // not just the values they evaluate to.


### PR DESCRIPTION
Follows from the observation that `b1` is a power of two and shifting a binary value to the left is the same as multiplying it by two.