### PR TITLE
round result of (highest as f64).log(2.0)

### DIFF
--- a/build/main.rs
+++ b/build/main.rs
@@ -81,7 +81,7 @@ pub fn no_std() {}
 fn main() {
     let highest: u64 = 1024;
 
-    let first2: u32 = (highest as f64).log(2.0) as u32 + 1;
+    let first2: u32 = (highest as f64).log(2.0).round() as u32 + 1;
     let first10: u32 = (highest as f64).log(10.0) as u32 + 1;
     let uints = (0..(highest + 1))
         .chain((first2..64).map(|i| 2u64.pow(i)))


### PR DESCRIPTION
Even though (1024f64).log(2.0) has an exact, representable, value, with rustc 1.32 on i386 it comes out as +9.999999999999999985 with optimization enabled. And then rustc doesn't like having two defintions for U1024 etc.