### PR TITLE
Fix build on Rust 1.22.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,6 @@ notifications:
   email:
     recipients: paho@paholg.com
 
-before_script:
-  - rustup component add rustfmt-preview
-  - rustup component add clippy
-
 matrix:
   include:
     - rust: stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: false
 rust:
   - beta
   - nightly
+  - 1.22.0
 
 notifications:
   email:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 This project follows semantic versioning.
 
+The MSRV (Minimum Supported Rust Version) is 1.22.0, and typenum is tested against this Rust
+version. Much of typenum should work on as low a version as 1.20.0, but that is not guaranteed.
+
 ### Unreleased
+
+### 1.11.1 (2019-08-25)
+- [fixed] Builds on earlier Rust builds again and added Rust 1.22.0 to Travis to prevent future breakage.
 
 ### 1.11.0 (2019-08-25)
 - [added] Integer `log2` to the `op!` macro.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
   name = "typenum"
   build = "build/main.rs"
-  version = "1.11.0"
+  version = "1.11.1"
   authors = [
     "Paho Lurie-Gregg <paho@paholg.com>",
     "Andre Bogus <bogusandre@gmail.com>"

--- a/src/int.rs
+++ b/src/int.rs
@@ -945,7 +945,8 @@ where
 
 #[cfg(test)]
 mod tests {
-    use {consts::*, Integer};
+    use consts::*;
+    use Integer;
 
     #[test]
     fn to_ix_min() {


### PR DESCRIPTION
Also bumps the version to 1.11.1 for a deploy.

Fixes #122.