### PR TITLE
Fix cross compilation from Linux to Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ version. Much of typenum should work on as low a version as 1.20.0, but that is 
 
 ### Unreleased
 
+### 1.11.2 (2019-08-26)
+- [fixed] Cross compilation from Linux to Windows.
+
 ### 1.11.1 (2019-08-25)
 - [fixed] Builds on earlier Rust builds again and added Rust 1.22.0 to Travis to prevent future breakage.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
   name = "typenum"
   build = "build/main.rs"
-  version = "1.11.1"
+  version = "1.11.2"
   authors = [
     "Paho Lurie-Gregg <paho@paholg.com>",
     "Andre Bogus <bogusandre@gmail.com>"

--- a/build/main.rs
+++ b/build/main.rs
@@ -89,6 +89,7 @@ fn main() {
 
     let out_dir = env::var("OUT_DIR").unwrap();
     let dest = Path::new(&out_dir).join("consts.rs");
+    println!("cargo:rustc-env=TYPENUM_BUILD_OP={}", dest.display());
 
     let mut f = File::create(&dest).unwrap();
 

--- a/build/op.rs
+++ b/build/op.rs
@@ -18,6 +18,7 @@ struct Op {
 pub fn write_op_macro() -> ::std::io::Result<()> {
     let out_dir = ::std::env::var("OUT_DIR").unwrap();
     let dest = ::std::path::Path::new(&out_dir).join("op.rs");
+    println!("cargo:rustc-env=TYPENUM_BUILD_CONSTS={}", dest.display());
     let mut f = ::std::fs::File::create(&dest).unwrap();
 
     // Operator precedence is taken from

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,14 +61,9 @@
 // trace_macros!(true);
 
 use core::cmp::Ordering;
-#[cfg(not(target_os = "windows"))]
-include!(concat!(env!("OUT_DIR"), "/consts.rs"));
-#[cfg(not(target_os = "windows"))]
-include!(concat!(env!("OUT_DIR"), "/op.rs"));
-#[cfg(target_os = "windows")]
-include!(concat!(env!("OUT_DIR"), "\\consts.rs"));
-#[cfg(target_os = "windows")]
-include!(concat!(env!("OUT_DIR"), "\\op.rs"));
+
+include!(env!("TYPENUM_BUILD_OP"));
+include!(env!("TYPENUM_BUILD_CONSTS"));
 
 pub mod bit;
 pub mod int;


### PR DESCRIPTION
Use the proper path building in the build script in lib.rs by exposing
it as an environment variable.

Fixes #124.