### PR TITLE
Added configuration flag to force Unix file separator

### DIFF
--- a/build/main.rs
+++ b/build/main.rs
@@ -89,7 +89,7 @@ fn main() {
 
     let out_dir = env::var("OUT_DIR").unwrap();
     let dest = Path::new(&out_dir).join("consts.rs");
-    println!("cargo:rustc-env=TYPENUM_BUILD_OP={}", dest.display());
+    println!("cargo:rustc-env=TYPENUM_BUILD_CONSTS={}", dest.display());
 
     let mut f = File::create(&dest).unwrap();
 

--- a/build/op.rs
+++ b/build/op.rs
@@ -18,7 +18,7 @@ struct Op {
 pub fn write_op_macro() -> ::std::io::Result<()> {
     let out_dir = ::std::env::var("OUT_DIR").unwrap();
     let dest = ::std::path::Path::new(&out_dir).join("op.rs");
-    println!("cargo:rustc-env=TYPENUM_BUILD_CONSTS={}", dest.display());
+    println!("cargo:rustc-env=TYPENUM_BUILD_OP={}", dest.display());
     let mut f = ::std::fs::File::create(&dest).unwrap();
 
     // Operator precedence is taken from

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,8 +62,16 @@
 
 use core::cmp::Ordering;
 
-include!(env!("TYPENUM_BUILD_OP"));
-include!(env!("TYPENUM_BUILD_CONSTS"));
+#[cfg(force_unix_path_separator)]
+mod generated {
+    include!(concat!(env!("OUT_DIR"), "/op.rs"));
+    include!(concat!(env!("OUT_DIR"), "/consts.rs"));
+}
+#[cfg(not(force_unix_path_separator))]
+mod generated {
+    include!(env!("TYPENUM_BUILD_OP"));
+    include!(env!("TYPENUM_BUILD_CONSTS"));
+}
 
 pub mod bit;
 pub mod int;
@@ -75,6 +83,7 @@ pub mod uint;
 
 pub mod array;
 
+pub use generated::consts as consts;
 pub use consts::*;
 pub use marker_traits::*;
 pub use operator_aliases::*;


### PR DESCRIPTION
Added `force_unix_path_separator` configuration flag for use by build systems that invoke rustc directly (such as Bazel).