### PR TITLE
Make all functions #[inline].

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The MSRV (Minimum Supported Rust Version) is 1.22.0, and typenum is tested again
 version. Much of typenum should work on as low a version as 1.20.0, but that is not guaranteed.
 
 ### Unreleased
+- [fixed] Make all functions #[inline].
 
 ### 1.11.2 (2019-08-26)
 - [fixed] Cross compilation from Linux to Windows.

--- a/src/array.rs
+++ b/src/array.rs
@@ -53,6 +53,7 @@ macro_rules! tarr {
 /// Length of `ATerm` by itself is 0
 impl Len for ATerm {
     type Output = U0;
+    #[inline]
     fn len(&self) -> Self::Output {
         UTerm
     }
@@ -66,6 +67,7 @@ where
     Sum<Length<A>, B1>: Unsigned,
 {
     type Output = Add1<Length<A>>;
+    #[inline]
     fn len(&self) -> Self::Output {
         unsafe { ::core::mem::uninitialized() }
     }
@@ -77,6 +79,7 @@ where
 
 impl Add<ATerm> for ATerm {
     type Output = ATerm;
+    #[inline]
     fn add(self, _: ATerm) -> Self::Output {
         ATerm
     }
@@ -88,6 +91,7 @@ where
     Vl: Add<Vr>,
 {
     type Output = TArr<Sum<Vl, Vr>, Sum<Al, Ar>>;
+    #[inline]
     fn add(self, _: TArr<Vr, Ar>) -> Self::Output {
         unsafe { ::core::mem::uninitialized() }
     }
@@ -99,6 +103,7 @@ where
 
 impl Sub<ATerm> for ATerm {
     type Output = ATerm;
+    #[inline]
     fn sub(self, _: ATerm) -> Self::Output {
         ATerm
     }
@@ -110,6 +115,7 @@ where
     Al: Sub<Ar>,
 {
     type Output = TArr<Diff<Vl, Vr>, Diff<Al, Ar>>;
+    #[inline]
     fn sub(self, _: TArr<Vr, Ar>) -> Self::Output {
         unsafe { ::core::mem::uninitialized() }
     }
@@ -120,6 +126,7 @@ where
 
 impl<Rhs> Mul<Rhs> for ATerm {
     type Output = ATerm;
+    #[inline]
     fn mul(self, _: Rhs) -> Self::Output {
         ATerm
     }
@@ -131,6 +138,7 @@ where
     A: Mul<Rhs>,
 {
     type Output = TArr<Prod<V, Rhs>, Prod<A, Rhs>>;
+    #[inline]
     fn mul(self, _: Rhs) -> Self::Output {
         unsafe { ::core::mem::uninitialized() }
     }
@@ -138,6 +146,7 @@ where
 
 impl Mul<ATerm> for Z0 {
     type Output = ATerm;
+    #[inline]
     fn mul(self, _: ATerm) -> Self::Output {
         ATerm
     }
@@ -148,6 +157,7 @@ where
     U: Unsigned + NonZero,
 {
     type Output = ATerm;
+    #[inline]
     fn mul(self, _: ATerm) -> Self::Output {
         ATerm
     }
@@ -158,6 +168,7 @@ where
     U: Unsigned + NonZero,
 {
     type Output = ATerm;
+    #[inline]
     fn mul(self, _: ATerm) -> Self::Output {
         ATerm
     }
@@ -168,6 +179,7 @@ where
     Z0: Mul<A>,
 {
     type Output = TArr<Z0, Prod<Z0, A>>;
+    #[inline]
     fn mul(self, _: TArr<V, A>) -> Self::Output {
         unsafe { ::core::mem::uninitialized() }
     }
@@ -179,6 +191,7 @@ where
     PInt<U>: Mul<A> + Mul<V>,
 {
     type Output = TArr<Prod<PInt<U>, V>, Prod<PInt<U>, A>>;
+    #[inline]
     fn mul(self, _: TArr<V, A>) -> Self::Output {
         unsafe { ::core::mem::uninitialized() }
     }
@@ -190,6 +203,7 @@ where
     NInt<U>: Mul<A> + Mul<V>,
 {
     type Output = TArr<Prod<NInt<U>, V>, Prod<NInt<U>, A>>;
+    #[inline]
     fn mul(self, _: TArr<V, A>) -> Self::Output {
         unsafe { ::core::mem::uninitialized() }
     }
@@ -200,6 +214,7 @@ where
 
 impl<Rhs> Div<Rhs> for ATerm {
     type Output = ATerm;
+    #[inline]
     fn div(self, _: Rhs) -> Self::Output {
         ATerm
     }
@@ -211,6 +226,7 @@ where
     A: Div<Rhs>,
 {
     type Output = TArr<Quot<V, Rhs>, Quot<A, Rhs>>;
+    #[inline]
     fn div(self, _: Rhs) -> Self::Output {
         unsafe { ::core::mem::uninitialized() }
     }
@@ -221,6 +237,7 @@ where
 
 impl<Rhs> PartialDiv<Rhs> for ATerm {
     type Output = ATerm;
+    #[inline]
     fn partial_div(self, _: Rhs) -> Self::Output {
         ATerm
     }
@@ -232,6 +249,7 @@ where
     A: PartialDiv<Rhs>,
 {
     type Output = TArr<PartialQuot<V, Rhs>, PartialQuot<A, Rhs>>;
+    #[inline]
     fn partial_div(self, _: Rhs) -> Self::Output {
         unsafe { ::core::mem::uninitialized() }
     }
@@ -243,6 +261,7 @@ use core::ops::Rem;
 
 impl<Rhs> Rem<Rhs> for ATerm {
     type Output = ATerm;
+    #[inline]
     fn rem(self, _: Rhs) -> Self::Output {
         ATerm
     }
@@ -254,6 +273,7 @@ where
     A: Rem<Rhs>,
 {
     type Output = TArr<Mod<V, Rhs>, Mod<A, Rhs>>;
+    #[inline]
     fn rem(self, _: Rhs) -> Self::Output {
         unsafe { ::core::mem::uninitialized() }
     }
@@ -265,6 +285,7 @@ use core::ops::Neg;
 
 impl Neg for ATerm {
     type Output = ATerm;
+    #[inline]
     fn neg(self) -> Self::Output {
         ATerm
     }
@@ -276,6 +297,7 @@ where
     A: Neg,
 {
     type Output = TArr<Negate<V>, Negate<A>>;
+    #[inline]
     fn neg(self) -> Self::Output {
         unsafe { ::core::mem::uninitialized() }
     }

--- a/src/bit.rs
+++ b/src/bit.rs
@@ -73,6 +73,7 @@ impl PowerOfTwo for B1 {}
 /// Not of 0 (!0 = 1)
 impl Not for B0 {
     type Output = B1;
+    #[inline]
     fn not(self) -> Self::Output {
         B1
     }
@@ -80,6 +81,7 @@ impl Not for B0 {
 /// Not of 1 (!1 = 0)
 impl Not for B1 {
     type Output = B0;
+    #[inline]
     fn not(self) -> Self::Output {
         B0
     }
@@ -88,6 +90,7 @@ impl Not for B1 {
 /// And with 0 ( 0 & B = 0)
 impl<Rhs: Bit> BitAnd<Rhs> for B0 {
     type Output = B0;
+    #[inline]
     fn bitand(self, _: Rhs) -> Self::Output {
         B0
     }
@@ -96,6 +99,7 @@ impl<Rhs: Bit> BitAnd<Rhs> for B0 {
 /// And with 1 ( 1 & 0 = 0)
 impl BitAnd<B0> for B1 {
     type Output = B0;
+    #[inline]
     fn bitand(self, _: B0) -> Self::Output {
         B0
     }
@@ -104,6 +108,7 @@ impl BitAnd<B0> for B1 {
 /// And with 1 ( 1 & 1 = 1)
 impl BitAnd<B1> for B1 {
     type Output = B1;
+    #[inline]
     fn bitand(self, _: B1) -> Self::Output {
         B1
     }
@@ -112,6 +117,7 @@ impl BitAnd<B1> for B1 {
 /// Or with 0 ( 0 | 0 = 0)
 impl BitOr<B0> for B0 {
     type Output = B0;
+    #[inline]
     fn bitor(self, _: B0) -> Self::Output {
         B0
     }
@@ -120,6 +126,7 @@ impl BitOr<B0> for B0 {
 /// Or with 0 ( 0 | 1 = 1)
 impl BitOr<B1> for B0 {
     type Output = B1;
+    #[inline]
     fn bitor(self, _: B1) -> Self::Output {
         B1
     }
@@ -128,6 +135,7 @@ impl BitOr<B1> for B0 {
 /// Or with 1 ( 1 | B = 1)
 impl<Rhs: Bit> BitOr<Rhs> for B1 {
     type Output = B1;
+    #[inline]
     fn bitor(self, _: Rhs) -> Self::Output {
         B1
     }
@@ -136,6 +144,7 @@ impl<Rhs: Bit> BitOr<Rhs> for B1 {
 /// Xor between 0 and 0 ( 0 ^ 0 = 0)
 impl BitXor<B0> for B0 {
     type Output = B0;
+    #[inline]
     fn bitxor(self, _: B0) -> Self::Output {
         B0
     }
@@ -143,6 +152,7 @@ impl BitXor<B0> for B0 {
 /// Xor between 1 and 0 ( 1 ^ 0 = 1)
 impl BitXor<B0> for B1 {
     type Output = B1;
+    #[inline]
     fn bitxor(self, _: B0) -> Self::Output {
         B1
     }
@@ -150,6 +160,7 @@ impl BitXor<B0> for B1 {
 /// Xor between 0 and 1 ( 0 ^ 1 = 1)
 impl BitXor<B1> for B0 {
     type Output = B1;
+    #[inline]
     fn bitxor(self, _: B1) -> Self::Output {
         B1
     }
@@ -157,6 +168,7 @@ impl BitXor<B1> for B0 {
 /// Xor between 1 and 1 ( 1 ^ 1 = 0)
 impl BitXor<B1> for B1 {
     type Output = B0;
+    #[inline]
     fn bitxor(self, _: B1) -> Self::Output {
         B0
     }
@@ -218,24 +230,28 @@ impl Cmp<B1> for B1 {
 use Min;
 impl Min<B0> for B0 {
     type Output = B0;
+    #[inline]
     fn min(self, _: B0) -> B0 {
         self
     }
 }
 impl Min<B1> for B0 {
     type Output = B0;
+    #[inline]
     fn min(self, _: B1) -> B0 {
         self
     }
 }
 impl Min<B0> for B1 {
     type Output = B0;
+    #[inline]
     fn min(self, rhs: B0) -> B0 {
         rhs
     }
 }
 impl Min<B1> for B1 {
     type Output = B1;
+    #[inline]
     fn min(self, _: B1) -> B1 {
         self
     }
@@ -244,24 +260,28 @@ impl Min<B1> for B1 {
 use Max;
 impl Max<B0> for B0 {
     type Output = B0;
+    #[inline]
     fn max(self, _: B0) -> B0 {
         self
     }
 }
 impl Max<B1> for B0 {
     type Output = B1;
+    #[inline]
     fn max(self, rhs: B1) -> B1 {
         rhs
     }
 }
 impl Max<B0> for B1 {
     type Output = B1;
+    #[inline]
     fn max(self, _: B0) -> B1 {
         self
     }
 }
 impl Max<B1> for B1 {
     type Output = B1;
+    #[inline]
     fn max(self, _: B1) -> B1 {
         self
     }

--- a/src/int.rs
+++ b/src/int.rs
@@ -203,6 +203,7 @@ impl<U: Unsigned + NonZero> Integer for NInt<U> {
 /// `-Z0 = Z0`
 impl Neg for Z0 {
     type Output = Z0;
+    #[inline]
     fn neg(self) -> Self::Output {
         Z0
     }
@@ -211,6 +212,7 @@ impl Neg for Z0 {
 /// `-PInt = NInt`
 impl<U: Unsigned + NonZero> Neg for PInt<U> {
     type Output = NInt<U>;
+    #[inline]
     fn neg(self) -> Self::Output {
         NInt::new()
     }
@@ -219,6 +221,7 @@ impl<U: Unsigned + NonZero> Neg for PInt<U> {
 /// `-NInt = PInt`
 impl<U: Unsigned + NonZero> Neg for NInt<U> {
     type Output = PInt<U>;
+    #[inline]
     fn neg(self) -> Self::Output {
         PInt::new()
     }
@@ -230,6 +233,7 @@ impl<U: Unsigned + NonZero> Neg for NInt<U> {
 /// `Z0 + I = I`
 impl<I: Integer> Add<I> for Z0 {
     type Output = I;
+    #[inline]
     fn add(self, _: I) -> Self::Output {
         unsafe { ::core::mem::uninitialized() }
     }
@@ -238,6 +242,7 @@ impl<I: Integer> Add<I> for Z0 {
 /// `PInt + Z0 = PInt`
 impl<U: Unsigned + NonZero> Add<Z0> for PInt<U> {
     type Output = PInt<U>;
+    #[inline]
     fn add(self, _: Z0) -> Self::Output {
         PInt::new()
     }
@@ -246,6 +251,7 @@ impl<U: Unsigned + NonZero> Add<Z0> for PInt<U> {
 /// `NInt + Z0 = NInt`
 impl<U: Unsigned + NonZero> Add<Z0> for NInt<U> {
     type Output = NInt<U>;
+    #[inline]
     fn add(self, _: Z0) -> Self::Output {
         NInt::new()
     }
@@ -258,6 +264,7 @@ where
     <Ul as Add<Ur>>::Output: Unsigned + NonZero,
 {
     type Output = PInt<<Ul as Add<Ur>>::Output>;
+    #[inline]
     fn add(self, _: PInt<Ur>) -> Self::Output {
         PInt::new()
     }
@@ -270,6 +277,7 @@ where
     <Ul as Add<Ur>>::Output: Unsigned + NonZero,
 {
     type Output = NInt<<Ul as Add<Ur>>::Output>;
+    #[inline]
     fn add(self, _: NInt<Ur>) -> Self::Output {
         NInt::new()
     }
@@ -281,6 +289,7 @@ where
     Ul: Cmp<Ur> + PrivateIntegerAdd<<Ul as Cmp<Ur>>::Output, Ur>,
 {
     type Output = <Ul as PrivateIntegerAdd<<Ul as Cmp<Ur>>::Output, Ur>>::Output;
+    #[inline]
     fn add(self, _: NInt<Ur>) -> Self::Output {
         unsafe { ::core::mem::uninitialized() }
     }
@@ -293,6 +302,7 @@ where
     Ur: Cmp<Ul> + PrivateIntegerAdd<<Ur as Cmp<Ul>>::Output, Ul>,
 {
     type Output = <Ur as PrivateIntegerAdd<<Ur as Cmp<Ul>>::Output, Ul>>::Output;
+    #[inline]
     fn add(self, _: PInt<Ur>) -> Self::Output {
         unsafe { ::core::mem::uninitialized() }
     }
@@ -327,6 +337,7 @@ where
 /// `Z0 - Z0 = Z0`
 impl Sub<Z0> for Z0 {
     type Output = Z0;
+    #[inline]
     fn sub(self, _: Z0) -> Self::Output {
         Z0
     }
@@ -335,6 +346,7 @@ impl Sub<Z0> for Z0 {
 /// `Z0 - P = N`
 impl<U: Unsigned + NonZero> Sub<PInt<U>> for Z0 {
     type Output = NInt<U>;
+    #[inline]
     fn sub(self, _: PInt<U>) -> Self::Output {
         NInt::new()
     }
@@ -343,6 +355,7 @@ impl<U: Unsigned + NonZero> Sub<PInt<U>> for Z0 {
 /// `Z0 - N = P`
 impl<U: Unsigned + NonZero> Sub<NInt<U>> for Z0 {
     type Output = PInt<U>;
+    #[inline]
     fn sub(self, _: NInt<U>) -> Self::Output {
         PInt::new()
     }
@@ -351,6 +364,7 @@ impl<U: Unsigned + NonZero> Sub<NInt<U>> for Z0 {
 /// `PInt - Z0 = PInt`
 impl<U: Unsigned + NonZero> Sub<Z0> for PInt<U> {
     type Output = PInt<U>;
+    #[inline]
     fn sub(self, _: Z0) -> Self::Output {
         PInt::new()
     }
@@ -359,6 +373,7 @@ impl<U: Unsigned + NonZero> Sub<Z0> for PInt<U> {
 /// `NInt - Z0 = NInt`
 impl<U: Unsigned + NonZero> Sub<Z0> for NInt<U> {
     type Output = NInt<U>;
+    #[inline]
     fn sub(self, _: Z0) -> Self::Output {
         NInt::new()
     }
@@ -371,6 +386,7 @@ where
     <Ul as Add<Ur>>::Output: Unsigned + NonZero,
 {
     type Output = PInt<<Ul as Add<Ur>>::Output>;
+    #[inline]
     fn sub(self, _: NInt<Ur>) -> Self::Output {
         PInt::new()
     }
@@ -383,6 +399,7 @@ where
     <Ul as Add<Ur>>::Output: Unsigned + NonZero,
 {
     type Output = NInt<<Ul as Add<Ur>>::Output>;
+    #[inline]
     fn sub(self, _: PInt<Ur>) -> Self::Output {
         NInt::new()
     }
@@ -394,6 +411,7 @@ where
     Ul: Cmp<Ur> + PrivateIntegerAdd<<Ul as Cmp<Ur>>::Output, Ur>,
 {
     type Output = <Ul as PrivateIntegerAdd<<Ul as Cmp<Ur>>::Output, Ur>>::Output;
+    #[inline]
     fn sub(self, _: PInt<Ur>) -> Self::Output {
         unsafe { ::core::mem::uninitialized() }
     }
@@ -406,6 +424,7 @@ where
     Ur: Cmp<Ul> + PrivateIntegerAdd<<Ur as Cmp<Ul>>::Output, Ul>,
 {
     type Output = <Ur as PrivateIntegerAdd<<Ur as Cmp<Ul>>::Output, Ul>>::Output;
+    #[inline]
     fn sub(self, _: NInt<Ur>) -> Self::Output {
         unsafe { ::core::mem::uninitialized() }
     }
@@ -417,6 +436,7 @@ where
 /// `Z0 * I = Z0`
 impl<I: Integer> Mul<I> for Z0 {
     type Output = Z0;
+    #[inline]
     fn mul(self, _: I) -> Self::Output {
         Z0
     }
@@ -425,6 +445,7 @@ impl<I: Integer> Mul<I> for Z0 {
 /// `P * Z0 = Z0`
 impl<U: Unsigned + NonZero> Mul<Z0> for PInt<U> {
     type Output = Z0;
+    #[inline]
     fn mul(self, _: Z0) -> Self::Output {
         Z0
     }
@@ -433,6 +454,7 @@ impl<U: Unsigned + NonZero> Mul<Z0> for PInt<U> {
 /// `N * Z0 = Z0`
 impl<U: Unsigned + NonZero> Mul<Z0> for NInt<U> {
     type Output = Z0;
+    #[inline]
     fn mul(self, _: Z0) -> Self::Output {
         Z0
     }
@@ -445,6 +467,7 @@ where
     <Ul as Mul<Ur>>::Output: Unsigned + NonZero,
 {
     type Output = PInt<<Ul as Mul<Ur>>::Output>;
+    #[inline]
     fn mul(self, _: PInt<Ur>) -> Self::Output {
         PInt::new()
     }
@@ -457,6 +480,7 @@ where
     <Ul as Mul<Ur>>::Output: Unsigned + NonZero,
 {
     type Output = PInt<<Ul as Mul<Ur>>::Output>;
+    #[inline]
     fn mul(self, _: NInt<Ur>) -> Self::Output {
         PInt::new()
     }
@@ -469,6 +493,7 @@ where
     <Ul as Mul<Ur>>::Output: Unsigned + NonZero,
 {
     type Output = NInt<<Ul as Mul<Ur>>::Output>;
+    #[inline]
     fn mul(self, _: NInt<Ur>) -> Self::Output {
         NInt::new()
     }
@@ -481,6 +506,7 @@ where
     <Ul as Mul<Ur>>::Output: Unsigned + NonZero,
 {
     type Output = NInt<<Ul as Mul<Ur>>::Output>;
+    #[inline]
     fn mul(self, _: PInt<Ur>) -> Self::Output {
         NInt::new()
     }
@@ -492,6 +518,7 @@ where
 /// `Z0 / I = Z0` where `I != 0`
 impl<I: Integer + NonZero> Div<I> for Z0 {
     type Output = Z0;
+    #[inline]
     fn div(self, _: I) -> Self::Output {
         Z0
     }
@@ -506,6 +533,7 @@ macro_rules! impl_int_div {
             $A<Ul>: PrivateDivInt<<Ul as Cmp<Ur>>::Output, $B<Ur>>,
         {
             type Output = <$A<Ul> as PrivateDivInt<<Ul as Cmp<Ur>>::Output, $B<Ur>>>::Output;
+            #[inline]
             fn div(self, _: $B<Ur>) -> Self::Output {
                 unsafe { ::core::mem::uninitialized() }
             }
@@ -550,6 +578,7 @@ where
     M: Integer + Div<N> + Rem<N, Output = Z0>,
 {
     type Output = Quot<M, N>;
+    #[inline]
     fn partial_div(self, _: N) -> Self::Output {
         unsafe { ::core::mem::uninitialized() }
     }
@@ -609,6 +638,7 @@ impl<Nl: Unsigned + NonZero, Nr: Cmp<Nl> + Unsigned + NonZero> Cmp<NInt<Nr>> for
 /// `Z0 % I = Z0` where `I != 0`
 impl<I: Integer + NonZero> Rem<I> for Z0 {
     type Output = Z0;
+    #[inline]
     fn rem(self, _: I) -> Self::Output {
         Z0
     }
@@ -623,6 +653,7 @@ macro_rules! impl_int_rem {
             $A<Ul>: PrivateRem<<Ul as Rem<Ur>>::Output, $B<Ur>>,
         {
             type Output = <$A<Ul> as PrivateRem<<Ul as Rem<Ur>>::Output, $B<Ur>>>::Output;
+            #[inline]
             fn rem(self, _: $B<Ur>) -> Self::Output {
                 unsafe { ::core::mem::uninitialized() }
             }
@@ -653,6 +684,7 @@ impl_int_rem!(NInt, NInt, NInt);
 /// 0^0 = 1
 impl Pow<Z0> for Z0 {
     type Output = P1;
+    #[inline]
     fn powi(self, _: Z0) -> Self::Output {
         P1::new()
     }
@@ -661,6 +693,7 @@ impl Pow<Z0> for Z0 {
 /// 0^P = 0
 impl<U: Unsigned + NonZero> Pow<PInt<U>> for Z0 {
     type Output = Z0;
+    #[inline]
     fn powi(self, _: PInt<U>) -> Self::Output {
         Z0
     }
@@ -669,6 +702,7 @@ impl<U: Unsigned + NonZero> Pow<PInt<U>> for Z0 {
 /// 0^N = 0
 impl<U: Unsigned + NonZero> Pow<NInt<U>> for Z0 {
     type Output = Z0;
+    #[inline]
     fn powi(self, _: NInt<U>) -> Self::Output {
         Z0
     }
@@ -677,6 +711,7 @@ impl<U: Unsigned + NonZero> Pow<NInt<U>> for Z0 {
 /// 1^N = 1
 impl<U: Unsigned + NonZero> Pow<NInt<U>> for P1 {
     type Output = P1;
+    #[inline]
     fn powi(self, _: NInt<U>) -> Self::Output {
         P1::new()
     }
@@ -685,6 +720,7 @@ impl<U: Unsigned + NonZero> Pow<NInt<U>> for P1 {
 /// (-1)^N = 1 if N is even
 impl<U: Unsigned> Pow<NInt<UInt<U, B0>>> for N1 {
     type Output = P1;
+    #[inline]
     fn powi(self, _: NInt<UInt<U, B0>>) -> Self::Output {
         P1::new()
     }
@@ -693,6 +729,7 @@ impl<U: Unsigned> Pow<NInt<UInt<U, B0>>> for N1 {
 /// (-1)^N = -1 if N is odd
 impl<U: Unsigned> Pow<NInt<UInt<U, B1>>> for N1 {
     type Output = N1;
+    #[inline]
     fn powi(self, _: NInt<UInt<U, B1>>) -> Self::Output {
         N1::new()
     }
@@ -701,6 +738,7 @@ impl<U: Unsigned> Pow<NInt<UInt<U, B1>>> for N1 {
 /// P^0 = 1
 impl<U: Unsigned + NonZero> Pow<Z0> for PInt<U> {
     type Output = P1;
+    #[inline]
     fn powi(self, _: Z0) -> Self::Output {
         P1::new()
     }
@@ -709,6 +747,7 @@ impl<U: Unsigned + NonZero> Pow<Z0> for PInt<U> {
 /// N^0 = 1
 impl<U: Unsigned + NonZero> Pow<Z0> for NInt<U> {
     type Output = P1;
+    #[inline]
     fn powi(self, _: Z0) -> Self::Output {
         P1::new()
     }
@@ -721,6 +760,7 @@ where
     <Ul as Pow<Ur>>::Output: Unsigned + NonZero,
 {
     type Output = PInt<<Ul as Pow<Ur>>::Output>;
+    #[inline]
     fn powi(self, _: PInt<Ur>) -> Self::Output {
         PInt::new()
     }
@@ -733,6 +773,7 @@ where
     <Ul as Pow<UInt<Ur, B0>>>::Output: Unsigned + NonZero,
 {
     type Output = PInt<<Ul as Pow<UInt<Ur, B0>>>::Output>;
+    #[inline]
     fn powi(self, _: PInt<UInt<Ur, B0>>) -> Self::Output {
         PInt::new()
     }
@@ -745,6 +786,7 @@ where
     <Ul as Pow<UInt<Ur, B1>>>::Output: Unsigned + NonZero,
 {
     type Output = NInt<<Ul as Pow<UInt<Ur, B1>>>::Output>;
+    #[inline]
     fn powi(self, _: PInt<UInt<Ur, B1>>) -> Self::Output {
         NInt::new()
     }
@@ -756,6 +798,7 @@ use {Max, Maximum, Min, Minimum};
 
 impl Min<Z0> for Z0 {
     type Output = Z0;
+    #[inline]
     fn min(self, _: Z0) -> Self::Output {
         self
     }
@@ -766,6 +809,7 @@ where
     U: Unsigned + NonZero,
 {
     type Output = Z0;
+    #[inline]
     fn min(self, _: PInt<U>) -> Self::Output {
         self
     }
@@ -776,6 +820,7 @@ where
     U: Unsigned + NonZero,
 {
     type Output = NInt<U>;
+    #[inline]
     fn min(self, rhs: NInt<U>) -> Self::Output {
         rhs
     }
@@ -786,6 +831,7 @@ where
     U: Unsigned + NonZero,
 {
     type Output = Z0;
+    #[inline]
     fn min(self, rhs: Z0) -> Self::Output {
         rhs
     }
@@ -796,6 +842,7 @@ where
     U: Unsigned + NonZero,
 {
     type Output = NInt<U>;
+    #[inline]
     fn min(self, _: Z0) -> Self::Output {
         self
     }
@@ -808,6 +855,7 @@ where
     Minimum<Ul, Ur>: Unsigned + NonZero,
 {
     type Output = PInt<Minimum<Ul, Ur>>;
+    #[inline]
     fn min(self, _: PInt<Ur>) -> Self::Output {
         unsafe { ::core::mem::uninitialized() }
     }
@@ -819,6 +867,7 @@ where
     Ur: Unsigned + NonZero,
 {
     type Output = NInt<Ul>;
+    #[inline]
     fn min(self, _: PInt<Ur>) -> Self::Output {
         self
     }
@@ -830,6 +879,7 @@ where
     Ur: Unsigned + NonZero,
 {
     type Output = NInt<Ur>;
+    #[inline]
     fn min(self, rhs: NInt<Ur>) -> Self::Output {
         rhs
     }
@@ -842,6 +892,7 @@ where
     Maximum<Ul, Ur>: Unsigned + NonZero,
 {
     type Output = NInt<Maximum<Ul, Ur>>;
+    #[inline]
     fn min(self, _: NInt<Ur>) -> Self::Output {
         unsafe { ::core::mem::uninitialized() }
     }
@@ -852,6 +903,7 @@ where
 
 impl Max<Z0> for Z0 {
     type Output = Z0;
+    #[inline]
     fn max(self, _: Z0) -> Self::Output {
         self
     }
@@ -862,6 +914,7 @@ where
     U: Unsigned + NonZero,
 {
     type Output = PInt<U>;
+    #[inline]
     fn max(self, rhs: PInt<U>) -> Self::Output {
         rhs
     }
@@ -872,6 +925,7 @@ where
     U: Unsigned + NonZero,
 {
     type Output = Z0;
+    #[inline]
     fn max(self, _: NInt<U>) -> Self::Output {
         self
     }
@@ -882,6 +936,7 @@ where
     U: Unsigned + NonZero,
 {
     type Output = PInt<U>;
+    #[inline]
     fn max(self, _: Z0) -> Self::Output {
         self
     }
@@ -892,6 +947,7 @@ where
     U: Unsigned + NonZero,
 {
     type Output = Z0;
+    #[inline]
     fn max(self, rhs: Z0) -> Self::Output {
         rhs
     }
@@ -904,6 +960,7 @@ where
     Maximum<Ul, Ur>: Unsigned + NonZero,
 {
     type Output = PInt<Maximum<Ul, Ur>>;
+    #[inline]
     fn max(self, _: PInt<Ur>) -> Self::Output {
         unsafe { ::core::mem::uninitialized() }
     }
@@ -915,6 +972,7 @@ where
     Ur: Unsigned + NonZero,
 {
     type Output = PInt<Ur>;
+    #[inline]
     fn max(self, rhs: PInt<Ur>) -> Self::Output {
         rhs
     }
@@ -926,6 +984,7 @@ where
     Ur: Unsigned + NonZero,
 {
     type Output = PInt<Ul>;
+    #[inline]
     fn max(self, _: NInt<Ur>) -> Self::Output {
         self
     }
@@ -938,6 +997,7 @@ where
     Minimum<Ul, Ur>: Unsigned + NonZero,
 {
     type Output = NInt<Minimum<Ul, Ur>>;
+    #[inline]
     fn max(self, _: NInt<Ur>) -> Self::Output {
         unsafe { ::core::mem::uninitialized() }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,12 @@
         clippy::new_without_default
     )
 )]
+#![cfg_attr(
+    feature = "cargo-clippy",
+    deny(
+        clippy::missing_inline_in_public_items
+    )
+)]
 
 // For debugging macros:
 // #![feature(trace_macros)]

--- a/src/private.rs
+++ b/src/private.rs
@@ -111,12 +111,14 @@ pub trait InvertedUnsigned {
 }
 
 impl InvertedUnsigned for InvertedUTerm {
+    #[inline]
     fn to_u64() -> u64 {
         0
     }
 }
 
 impl<IU: InvertedUnsigned, B: Bit> InvertedUnsigned for InvertedUInt<IU, B> {
+    #[inline]
     fn to_u64() -> u64 {
         u64::from(B::to_u8()) | IU::to_u64() << 1
     }

--- a/src/type_operators.rs
+++ b/src/type_operators.rs
@@ -333,6 +333,7 @@ where
 {
     type Output = <A as IsLessPrivate<B, Compare<A, B>>>::Output;
 
+    #[inline]
     fn is_less(self, _: B) -> Self::Output {
         unsafe { ::core::mem::uninitialized() }
     }
@@ -353,6 +354,7 @@ where
 {
     type Output = <A as IsEqualPrivate<B, Compare<A, B>>>::Output;
 
+    #[inline]
     fn is_equal(self, _: B) -> Self::Output {
         unsafe { ::core::mem::uninitialized() }
     }
@@ -373,6 +375,7 @@ where
 {
     type Output = <A as IsGreaterPrivate<B, Compare<A, B>>>::Output;
 
+    #[inline]
     fn is_greater(self, _: B) -> Self::Output {
         unsafe { ::core::mem::uninitialized() }
     }
@@ -393,6 +396,7 @@ where
 {
     type Output = <A as IsLessOrEqualPrivate<B, Compare<A, B>>>::Output;
 
+    #[inline]
     fn is_less_or_equal(self, _: B) -> Self::Output {
         unsafe { ::core::mem::uninitialized() }
     }
@@ -413,6 +417,7 @@ where
 {
     type Output = <A as IsNotEqualPrivate<B, Compare<A, B>>>::Output;
 
+    #[inline]
     fn is_not_equal(self, _: B) -> Self::Output {
         unsafe { ::core::mem::uninitialized() }
     }
@@ -433,6 +438,7 @@ where
 {
     type Output = <A as IsGreaterOrEqualPrivate<B, Compare<A, B>>>::Output;
 
+    #[inline]
     fn is_greater_or_equal(self, _: B) -> Self::Output {
         unsafe { ::core::mem::uninitialized() }
     }

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -243,6 +243,7 @@ impl<U: Unsigned + PowerOfTwo> PowerOfTwo for UInt<U, B0> {}
 /// Length of `UTerm` by itself is 0
 impl Len for UTerm {
     type Output = U0;
+    #[inline]
     fn len(&self) -> Self::Output {
         UTerm
     }
@@ -256,6 +257,7 @@ where
     Add1<Length<U>>: Unsigned,
 {
     type Output = Add1<Length<U>>;
+    #[inline]
     fn len(&self) -> Self::Output {
         unsafe { ::core::mem::uninitialized() }
     }
@@ -267,6 +269,7 @@ where
 /// `UTerm + B0 = UTerm`
 impl Add<B0> for UTerm {
     type Output = UTerm;
+    #[inline]
     fn add(self, _: B0) -> Self::Output {
         UTerm
     }
@@ -275,6 +278,7 @@ impl Add<B0> for UTerm {
 /// `U + B0 = U`
 impl<U: Unsigned, B: Bit> Add<B0> for UInt<U, B> {
     type Output = UInt<U, B>;
+    #[inline]
     fn add(self, _: B0) -> Self::Output {
         UInt::new()
     }
@@ -283,6 +287,7 @@ impl<U: Unsigned, B: Bit> Add<B0> for UInt<U, B> {
 /// `UTerm + B1 = UInt<UTerm, B1>`
 impl Add<B1> for UTerm {
     type Output = UInt<UTerm, B1>;
+    #[inline]
     fn add(self, _: B1) -> Self::Output {
         UInt::new()
     }
@@ -291,6 +296,7 @@ impl Add<B1> for UTerm {
 /// `UInt<U, B0> + B1 = UInt<U + B1>`
 impl<U: Unsigned> Add<B1> for UInt<U, B0> {
     type Output = UInt<U, B1>;
+    #[inline]
     fn add(self, _: B1) -> Self::Output {
         UInt::new()
     }
@@ -303,6 +309,7 @@ where
     Add1<U>: Unsigned,
 {
     type Output = UInt<Add1<U>, B0>;
+    #[inline]
     fn add(self, _: B1) -> Self::Output {
         UInt::new()
     }
@@ -314,6 +321,7 @@ where
 /// `UTerm + U = U`
 impl<U: Unsigned> Add<U> for UTerm {
     type Output = U;
+    #[inline]
     fn add(self, _: U) -> Self::Output {
         unsafe { ::core::mem::uninitialized() }
     }
@@ -322,6 +330,7 @@ impl<U: Unsigned> Add<U> for UTerm {
 /// `UInt<U, B> + UTerm = UInt<U, B>`
 impl<U: Unsigned, B: Bit> Add<UTerm> for UInt<U, B> {
     type Output = UInt<U, B>;
+    #[inline]
     fn add(self, _: UTerm) -> Self::Output {
         UInt::new()
     }
@@ -333,6 +342,7 @@ where
     Ul: Add<Ur>,
 {
     type Output = UInt<Sum<Ul, Ur>, B0>;
+    #[inline]
     fn add(self, _: UInt<Ur, B0>) -> Self::Output {
         unsafe { ::core::mem::uninitialized() }
     }
@@ -344,6 +354,7 @@ where
     Ul: Add<Ur>,
 {
     type Output = UInt<Sum<Ul, Ur>, B1>;
+    #[inline]
     fn add(self, _: UInt<Ur, B1>) -> Self::Output {
         unsafe { ::core::mem::uninitialized() }
     }
@@ -355,6 +366,7 @@ where
     Ul: Add<Ur>,
 {
     type Output = UInt<Sum<Ul, Ur>, B1>;
+    #[inline]
     fn add(self, _: UInt<Ur, B0>) -> Self::Output {
         unsafe { ::core::mem::uninitialized() }
     }
@@ -367,6 +379,7 @@ where
     Sum<Ul, Ur>: Add<B1>,
 {
     type Output = UInt<Add1<Sum<Ul, Ur>>, B0>;
+    #[inline]
     fn add(self, _: UInt<Ur, B1>) -> Self::Output {
         unsafe { ::core::mem::uninitialized() }
     }
@@ -378,6 +391,7 @@ where
 /// `UTerm - B0 = Term`
 impl Sub<B0> for UTerm {
     type Output = UTerm;
+    #[inline]
     fn sub(self, _: B0) -> Self::Output {
         UTerm
     }
@@ -386,6 +400,7 @@ impl Sub<B0> for UTerm {
 /// `UInt - B0 = UInt`
 impl<U: Unsigned, B: Bit> Sub<B0> for UInt<U, B> {
     type Output = UInt<U, B>;
+    #[inline]
     fn sub(self, _: B0) -> Self::Output {
         UInt::new()
     }
@@ -394,6 +409,7 @@ impl<U: Unsigned, B: Bit> Sub<B0> for UInt<U, B> {
 /// `UInt<U, B1> - B1 = UInt<U, B0>`
 impl<U: Unsigned, B: Bit> Sub<B1> for UInt<UInt<U, B>, B1> {
     type Output = UInt<UInt<U, B>, B0>;
+    #[inline]
     fn sub(self, _: B1) -> Self::Output {
         UInt::new()
     }
@@ -402,6 +418,7 @@ impl<U: Unsigned, B: Bit> Sub<B1> for UInt<UInt<U, B>, B1> {
 /// `UInt<UTerm, B1> - B1 = UTerm`
 impl Sub<B1> for UInt<UTerm, B1> {
     type Output = UTerm;
+    #[inline]
     fn sub(self, _: B1) -> Self::Output {
         UTerm
     }
@@ -414,6 +431,7 @@ where
     Sub1<U>: Unsigned,
 {
     type Output = UInt<Sub1<U>, B1>;
+    #[inline]
     fn sub(self, _: B1) -> Self::Output {
         UInt::new()
     }
@@ -425,6 +443,7 @@ where
 /// `UTerm - UTerm = UTerm`
 impl Sub<UTerm> for UTerm {
     type Output = UTerm;
+    #[inline]
     fn sub(self, _: UTerm) -> Self::Output {
         UTerm
     }
@@ -437,6 +456,7 @@ where
     PrivateSubOut<UInt<Ul, Bl>, Ur>: Trim,
 {
     type Output = TrimOut<PrivateSubOut<UInt<Ul, Bl>, Ur>>;
+    #[inline]
     fn sub(self, _: Ur) -> Self::Output {
         unsafe { ::core::mem::uninitialized() }
     }
@@ -486,6 +506,7 @@ where
 /// 0 & X = 0
 impl<Ur: Unsigned> BitAnd<Ur> for UTerm {
     type Output = UTerm;
+    #[inline]
     fn bitand(self, _: Ur) -> Self::Output {
         UTerm
     }
@@ -499,6 +520,7 @@ where
     PrivateAndOut<UInt<Ul, Bl>, Ur>: Trim,
 {
     type Output = TrimOut<PrivateAndOut<UInt<Ul, Bl>, Ur>>;
+    #[inline]
     fn bitand(self, _: Ur) -> Self::Output {
         unsafe { ::core::mem::uninitialized() }
     }
@@ -552,6 +574,7 @@ where
 /// `UTerm | X = X`
 impl<U: Unsigned> BitOr<U> for UTerm {
     type Output = U;
+    #[inline]
     fn bitor(self, _: U) -> Self::Output {
         unsafe { ::core::mem::uninitialized() }
     }
@@ -560,6 +583,7 @@ impl<U: Unsigned> BitOr<U> for UTerm {
 ///  `X | UTerm = X`
 impl<B: Bit, U: Unsigned> BitOr<UTerm> for UInt<U, B> {
     type Output = Self;
+    #[inline]
     fn bitor(self, _: UTerm) -> Self::Output {
         UInt::new()
     }
@@ -571,6 +595,7 @@ where
     Ul: BitOr<Ur>,
 {
     type Output = UInt<<Ul as BitOr<Ur>>::Output, B0>;
+    #[inline]
     fn bitor(self, _: UInt<Ur, B0>) -> Self::Output {
         unsafe { ::core::mem::uninitialized() }
     }
@@ -582,6 +607,7 @@ where
     Ul: BitOr<Ur>,
 {
     type Output = UInt<Or<Ul, Ur>, B1>;
+    #[inline]
     fn bitor(self, _: UInt<Ur, B1>) -> Self::Output {
         unsafe { ::core::mem::uninitialized() }
     }
@@ -593,6 +619,7 @@ where
     Ul: BitOr<Ur>,
 {
     type Output = UInt<Or<Ul, Ur>, B1>;
+    #[inline]
     fn bitor(self, _: UInt<Ur, B0>) -> Self::Output {
         unsafe { ::core::mem::uninitialized() }
     }
@@ -604,6 +631,7 @@ where
     Ul: BitOr<Ur>,
 {
     type Output = UInt<Or<Ul, Ur>, B1>;
+    #[inline]
     fn bitor(self, _: UInt<Ur, B1>) -> Self::Output {
         unsafe { ::core::mem::uninitialized() }
     }
@@ -615,6 +643,7 @@ where
 /// 0 ^ X = X
 impl<Ur: Unsigned> BitXor<Ur> for UTerm {
     type Output = Ur;
+    #[inline]
     fn bitxor(self, _: Ur) -> Self::Output {
         unsafe { ::core::mem::uninitialized() }
     }
@@ -628,6 +657,7 @@ where
     PrivateXorOut<UInt<Ul, Bl>, Ur>: Trim,
 {
     type Output = TrimOut<PrivateXorOut<UInt<Ul, Bl>, Ur>>;
+    #[inline]
     fn bitxor(self, _: Ur) -> Self::Output {
         unsafe { ::core::mem::uninitialized() }
     }
@@ -681,6 +711,7 @@ where
 /// Shifting `UTerm` by a 0 bit: `UTerm << B0 = UTerm`
 impl Shl<B0> for UTerm {
     type Output = UTerm;
+    #[inline]
     fn shl(self, _: B0) -> Self::Output {
         UTerm
     }
@@ -689,6 +720,7 @@ impl Shl<B0> for UTerm {
 /// Shifting `UTerm` by a 1 bit: `UTerm << B1 = UTerm`
 impl Shl<B1> for UTerm {
     type Output = UTerm;
+    #[inline]
     fn shl(self, _: B1) -> Self::Output {
         UTerm
     }
@@ -697,6 +729,7 @@ impl Shl<B1> for UTerm {
 /// Shifting left any unsigned by a zero bit: `U << B0 = U`
 impl<U: Unsigned, B: Bit> Shl<B0> for UInt<U, B> {
     type Output = UInt<U, B>;
+    #[inline]
     fn shl(self, _: B0) -> Self::Output {
         UInt::new()
     }
@@ -705,6 +738,7 @@ impl<U: Unsigned, B: Bit> Shl<B0> for UInt<U, B> {
 /// Shifting left a `UInt` by a one bit: `UInt<U, B> << B1 = UInt<UInt<U, B>, B0>`
 impl<U: Unsigned, B: Bit> Shl<B1> for UInt<U, B> {
     type Output = UInt<UInt<U, B>, B0>;
+    #[inline]
     fn shl(self, _: B1) -> Self::Output {
         UInt::new()
     }
@@ -713,6 +747,7 @@ impl<U: Unsigned, B: Bit> Shl<B1> for UInt<U, B> {
 /// Shifting left `UInt` by `UTerm`: `UInt<U, B> << UTerm = UInt<U, B>`
 impl<U: Unsigned, B: Bit> Shl<UTerm> for UInt<U, B> {
     type Output = UInt<U, B>;
+    #[inline]
     fn shl(self, _: UTerm) -> Self::Output {
         UInt::new()
     }
@@ -721,6 +756,7 @@ impl<U: Unsigned, B: Bit> Shl<UTerm> for UInt<U, B> {
 /// Shifting left `UTerm` by an unsigned integer: `UTerm << U = UTerm`
 impl<U: Unsigned> Shl<U> for UTerm {
     type Output = UTerm;
+    #[inline]
     fn shl(self, _: U) -> Self::Output {
         UTerm
     }
@@ -733,6 +769,7 @@ where
     UInt<UInt<U, B>, B0>: Shl<Sub1<UInt<Ur, Br>>>,
 {
     type Output = Shleft<UInt<UInt<U, B>, B0>, Sub1<UInt<Ur, Br>>>;
+    #[inline]
     fn shl(self, _: UInt<Ur, Br>) -> Self::Output {
         unsafe { ::core::mem::uninitialized() }
     }
@@ -744,6 +781,7 @@ where
 /// Shifting right a `UTerm` by an unsigned integer: `UTerm >> U = UTerm`
 impl<U: Unsigned> Shr<U> for UTerm {
     type Output = UTerm;
+    #[inline]
     fn shr(self, _: U) -> Self::Output {
         UTerm
     }
@@ -752,6 +790,7 @@ impl<U: Unsigned> Shr<U> for UTerm {
 /// Shifting right `UInt` by `UTerm`: `UInt<U, B> >> UTerm = UInt<U, B>`
 impl<U: Unsigned, B: Bit> Shr<UTerm> for UInt<U, B> {
     type Output = UInt<U, B>;
+    #[inline]
     fn shr(self, _: UTerm) -> Self::Output {
         UInt::new()
     }
@@ -760,6 +799,7 @@ impl<U: Unsigned, B: Bit> Shr<UTerm> for UInt<U, B> {
 /// Shifting right `UTerm` by a 0 bit: `UTerm >> B0 = UTerm`
 impl Shr<B0> for UTerm {
     type Output = UTerm;
+    #[inline]
     fn shr(self, _: B0) -> Self::Output {
         UTerm
     }
@@ -768,6 +808,7 @@ impl Shr<B0> for UTerm {
 /// Shifting right `UTerm` by a 1 bit: `UTerm >> B1 = UTerm`
 impl Shr<B1> for UTerm {
     type Output = UTerm;
+    #[inline]
     fn shr(self, _: B1) -> Self::Output {
         UTerm
     }
@@ -776,6 +817,7 @@ impl Shr<B1> for UTerm {
 /// Shifting right any unsigned by a zero bit: `U >> B0 = U`
 impl<U: Unsigned, B: Bit> Shr<B0> for UInt<U, B> {
     type Output = UInt<U, B>;
+    #[inline]
     fn shr(self, _: B0) -> Self::Output {
         UInt::new()
     }
@@ -784,6 +826,7 @@ impl<U: Unsigned, B: Bit> Shr<B0> for UInt<U, B> {
 /// Shifting right a `UInt` by a 1 bit: `UInt<U, B> >> B1 = U`
 impl<U: Unsigned, B: Bit> Shr<B1> for UInt<U, B> {
     type Output = U;
+    #[inline]
     fn shr(self, _: B1) -> Self::Output {
         unsafe { ::core::mem::uninitialized() }
     }
@@ -796,6 +839,7 @@ where
     U: Shr<Sub1<UInt<Ur, Br>>>,
 {
     type Output = Shright<U, Sub1<UInt<Ur, Br>>>;
+    #[inline]
     fn shr(self, _: UInt<Ur, Br>) -> Self::Output {
         unsafe { ::core::mem::uninitialized() }
     }
@@ -807,6 +851,7 @@ where
 /// `UInt * B0 = UTerm`
 impl<U: Unsigned, B: Bit> Mul<B0> for UInt<U, B> {
     type Output = UTerm;
+    #[inline]
     fn mul(self, _: B0) -> Self::Output {
         UTerm
     }
@@ -815,6 +860,7 @@ impl<U: Unsigned, B: Bit> Mul<B0> for UInt<U, B> {
 /// `UTerm * B0 = UTerm`
 impl Mul<B0> for UTerm {
     type Output = UTerm;
+    #[inline]
     fn mul(self, _: B0) -> Self::Output {
         UTerm
     }
@@ -823,6 +869,7 @@ impl Mul<B0> for UTerm {
 /// `UTerm * B1 = UTerm`
 impl Mul<B1> for UTerm {
     type Output = UTerm;
+    #[inline]
     fn mul(self, _: B1) -> Self::Output {
         UTerm
     }
@@ -831,6 +878,7 @@ impl Mul<B1> for UTerm {
 /// `UInt * B1 = UInt`
 impl<U: Unsigned, B: Bit> Mul<B1> for UInt<U, B> {
     type Output = UInt<U, B>;
+    #[inline]
     fn mul(self, _: B1) -> Self::Output {
         UInt::new()
     }
@@ -839,6 +887,7 @@ impl<U: Unsigned, B: Bit> Mul<B1> for UInt<U, B> {
 /// `UInt<U, B> * UTerm = UTerm`
 impl<U: Unsigned, B: Bit> Mul<UTerm> for UInt<U, B> {
     type Output = UTerm;
+    #[inline]
     fn mul(self, _: UTerm) -> Self::Output {
         UTerm
     }
@@ -847,6 +896,7 @@ impl<U: Unsigned, B: Bit> Mul<UTerm> for UInt<U, B> {
 /// `UTerm * U = UTerm`
 impl<U: Unsigned> Mul<U> for UTerm {
     type Output = UTerm;
+    #[inline]
     fn mul(self, _: U) -> Self::Output {
         UTerm
     }
@@ -858,6 +908,7 @@ where
     Ul: Mul<UInt<Ur, B>>,
 {
     type Output = UInt<Prod<Ul, UInt<Ur, B>>, B0>;
+    #[inline]
     fn mul(self, _: UInt<Ur, B>) -> Self::Output {
         unsafe { ::core::mem::uninitialized() }
     }
@@ -870,6 +921,7 @@ where
     UInt<Prod<Ul, UInt<Ur, B>>, B0>: Add<UInt<Ur, B>>,
 {
     type Output = Sum<UInt<Prod<Ul, UInt<Ur, B>>, B0>, UInt<Ur, B>>;
+    #[inline]
     fn mul(self, _: UInt<Ur, B>) -> Self::Output {
         unsafe { ::core::mem::uninitialized() }
     }
@@ -1029,6 +1081,7 @@ where
     X: PrivatePow<U1, N>,
 {
     type Output = PrivatePowOut<X, U1, N>;
+    #[inline]
     fn powi(self, _: N) -> Self::Output {
         unsafe { ::core::mem::uninitialized() }
     }
@@ -1239,6 +1292,7 @@ use core::ops::Div;
 // 0 // N
 impl<Ur: Unsigned, Br: Bit> Div<UInt<Ur, Br>> for UTerm {
     type Output = UTerm;
+    #[inline]
     fn div(self, _: UInt<Ur, Br>) -> Self::Output {
         UTerm
     }
@@ -1252,6 +1306,7 @@ where
     (): PrivateDiv<UInt<Ul, Bl>, UInt<Ur, Br>, U0, U0, Sub1<Length<UInt<Ul, Bl>>>>,
 {
     type Output = PrivateDivQuot<UInt<Ul, Bl>, UInt<Ur, Br>, U0, U0, Sub1<Length<UInt<Ul, Bl>>>>;
+    #[inline]
     fn div(self, _: UInt<Ur, Br>) -> Self::Output {
         unsafe { ::core::mem::uninitialized() }
     }
@@ -1264,6 +1319,7 @@ use core::ops::Rem;
 // 0 % N
 impl<Ur: Unsigned, Br: Bit> Rem<UInt<Ur, Br>> for UTerm {
     type Output = UTerm;
+    #[inline]
     fn rem(self, _: UInt<Ur, Br>) -> Self::Output {
         UTerm
     }
@@ -1277,6 +1333,7 @@ where
     (): PrivateDiv<UInt<Ul, Bl>, UInt<Ur, Br>, U0, U0, Sub1<Length<UInt<Ul, Bl>>>>,
 {
     type Output = PrivateDivRem<UInt<Ul, Bl>, UInt<Ur, Br>, U0, U0, Sub1<Length<UInt<Ul, Bl>>>>;
+    #[inline]
     fn rem(self, _: UInt<Ur, Br>) -> Self::Output {
         unsafe { ::core::mem::uninitialized() }
     }
@@ -1423,6 +1480,7 @@ where
 use {PartialDiv, Quot};
 impl<Ur: Unsigned, Br: Bit> PartialDiv<UInt<Ur, Br>> for UTerm {
     type Output = UTerm;
+    #[inline]
     fn partial_div(self, _: UInt<Ur, Br>) -> Self::Output {
         UTerm
     }
@@ -1434,6 +1492,7 @@ where
     UInt<Ul, Bl>: Div<UInt<Ur, Br>> + Rem<UInt<Ur, Br>, Output = U0>,
 {
     type Output = Quot<UInt<Ul, Bl>, UInt<Ur, Br>>;
+    #[inline]
     fn partial_div(self, _: UInt<Ur, Br>) -> Self::Output {
         unsafe { ::core::mem::uninitialized() }
     }
@@ -1450,6 +1509,7 @@ where
     B: Bit,
 {
     type Output = UInt<U, B>;
+    #[inline]
     fn private_min(self, _: Ur) -> Self::Output {
         self
     }
@@ -1462,6 +1522,7 @@ where
     B: Bit,
 {
     type Output = UInt<U, B>;
+    #[inline]
     fn private_min(self, _: Ur) -> Self::Output {
         self
     }
@@ -1474,6 +1535,7 @@ where
     B: Bit,
 {
     type Output = Ur;
+    #[inline]
     fn private_min(self, rhs: Ur) -> Self::Output {
         rhs
     }
@@ -1488,6 +1550,7 @@ where
     U: Unsigned,
 {
     type Output = UTerm;
+    #[inline]
     fn min(self, _: U) -> Self::Output {
         self
     }
@@ -1501,6 +1564,7 @@ where
     UInt<U, B>: Cmp<Ur> + PrivateMin<Ur, Compare<UInt<U, B>, Ur>>,
 {
     type Output = PrivateMinOut<UInt<U, B>, Ur, Compare<UInt<U, B>, Ur>>;
+    #[inline]
     fn min(self, rhs: Ur) -> Self::Output {
         self.private_min(rhs)
     }
@@ -1517,6 +1581,7 @@ where
     B: Bit,
 {
     type Output = UInt<U, B>;
+    #[inline]
     fn private_max(self, _: Ur) -> Self::Output {
         self
     }
@@ -1529,6 +1594,7 @@ where
     B: Bit,
 {
     type Output = Ur;
+    #[inline]
     fn private_max(self, rhs: Ur) -> Self::Output {
         rhs
     }
@@ -1541,6 +1607,7 @@ where
     B: Bit,
 {
     type Output = UInt<U, B>;
+    #[inline]
     fn private_max(self, _: Ur) -> Self::Output {
         self
     }
@@ -1555,6 +1622,7 @@ where
     U: Unsigned,
 {
     type Output = U;
+    #[inline]
     fn max(self, rhs: U) -> Self::Output {
         rhs
     }
@@ -1568,6 +1636,7 @@ where
     UInt<U, B>: Cmp<Ur> + PrivateMax<Ur, Compare<UInt<U, B>, Ur>>,
 {
     type Output = PrivateMaxOut<UInt<U, B>, Ur, Compare<UInt<U, B>, Ur>>;
+    #[inline]
     fn max(self, rhs: Ur) -> Self::Output {
         self.private_max(rhs)
     }


### PR DESCRIPTION
After compiling some embedded project I'm working on, the following functions ended up in my binary:

```rust
<typenum::private::InvertedUTerm as typenum::private::InvertedUnsigned>::to_u64
<typenum::uint::UInt<typenum::uint::UTerm,typenum::bit::B1> as core::ops::arith::Sub<typenum::bit::B1>>::sub
<typenum::uint::UTerm as typenum::type_operators::Len>::len
```

Most of typenum's functions are generic, causing the full definition of them to be used by the compiler of the final (binary) crate, making them inlineable. A few functions are not, however, like those above. Rustc doesn't inline across crates in that case.

This PR adds `#[inline]` in all places where it was missing, including all generic functions.

With the current rustc, this is technically only needed on non-generic functions as generic functions are already available for inlining. However, for consistency, all functions, even the generic ones, are marked as inline. This makes it easier to use Clippy's
missing_inline_in_public_items lint.