### PR TITLE
Introduce ToInt type operator to return integer values without explicit type annotations (resolve #133)

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+format_code_in_doc_comments = true

--- a/src/int.rs
+++ b/src/int.rs
@@ -16,7 +16,7 @@
 //!
 //! # Example
 //! ```rust
-//! use std::ops::{Add, Sub, Mul, Div, Rem};
+//! use std::ops::{Add, Div, Mul, Rem, Sub};
 //! use typenum::{Integer, N3, P2};
 //!
 //! assert_eq!(<N3 as Add<P2>>::Output::to_i32(), -1);

--- a/src/int.rs
+++ b/src/int.rs
@@ -34,7 +34,7 @@ use consts::{N1, P1, U0, U1};
 use private::{Internal, InternalMarker};
 use private::{PrivateDivInt, PrivateIntegerAdd, PrivateRem};
 use uint::{UInt, Unsigned};
-use {Cmp, Equal, Greater, Less, NonZero, Pow, PowerOfTwo};
+use {Cmp, Equal, Greater, Less, NonZero, Pow, PowerOfTwo, ToInt};
 
 pub use marker_traits::Integer;
 
@@ -1177,14 +1177,165 @@ where
     }
 }
 
+// -----------------------------------------
+// ToInt
+
+impl ToInt<i8> for Z0 {
+    fn to_int() -> i8 {
+        Self::I8
+    }
+}
+
+impl ToInt<i16> for Z0 {
+    fn to_int() -> i16 {
+        Self::I16
+    }
+}
+
+impl ToInt<i32> for Z0 {
+    fn to_int() -> i32 {
+        Self::I32
+    }
+}
+
+impl ToInt<i64> for Z0 {
+    fn to_int() -> i64 {
+        Self::I64
+    }
+}
+
+// negative numbers
+
+impl<U> ToInt<i8> for NInt<U>
+where
+    U: Unsigned + NonZero,
+{
+    fn to_int() -> i8 {
+        Self::I8
+    }
+}
+
+impl<U> ToInt<i16> for NInt<U>
+where
+    U: Unsigned + NonZero,
+{
+    fn to_int() -> i16 {
+        Self::I16
+    }
+}
+
+impl<U> ToInt<i32> for NInt<U>
+where
+    U: Unsigned + NonZero,
+{
+    fn to_int() -> i32 {
+        Self::I32
+    }
+}
+
+impl<U> ToInt<i64> for NInt<U>
+where
+    U: Unsigned + NonZero,
+{
+    fn to_int() -> i64 {
+        Self::I64
+    }
+}
+
+// positive numbers
+
+impl<U> ToInt<i8> for PInt<U>
+where
+    U: Unsigned + NonZero,
+{
+    fn to_int() -> i8 {
+        Self::I8
+    }
+}
+
+impl<U> ToInt<i16> for PInt<U>
+where
+    U: Unsigned + NonZero,
+{
+    fn to_int() -> i16 {
+        Self::I16
+    }
+}
+
+impl<U> ToInt<i32> for PInt<U>
+where
+    U: Unsigned + NonZero,
+{
+    fn to_int() -> i32 {
+        Self::I32
+    }
+}
+
+impl<U> ToInt<i64> for PInt<U>
+where
+    U: Unsigned + NonZero,
+{
+    fn to_int() -> i64 {
+        Self::I64
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use consts::*;
+    use type_operators::ToInt;
     use Integer;
 
     #[test]
     fn to_ix_min() {
         assert_eq!(N128::to_i8(), ::core::i8::MIN);
         assert_eq!(N32768::to_i16(), ::core::i16::MIN);
+    }
+
+    #[test]
+    fn int_toint_test() {
+        // i8
+        assert_eq!(0_i8, Z0::to_int());
+        assert_eq!(1_i8, P1::to_int());
+        assert_eq!(2_i8, P2::to_int());
+        assert_eq!(3_i8, P3::to_int());
+        assert_eq!(4_i8, P4::to_int());
+        assert_eq!(-1_i8, N1::to_int());
+        assert_eq!(-2_i8, N2::to_int());
+        assert_eq!(-3_i8, N3::to_int());
+        assert_eq!(-4_i8, N4::to_int());
+
+        // i16
+        assert_eq!(0_i16, Z0::to_int());
+        assert_eq!(1_i16, P1::to_int());
+        assert_eq!(2_i16, P2::to_int());
+        assert_eq!(3_i16, P3::to_int());
+        assert_eq!(4_i16, P4::to_int());
+        assert_eq!(-1_i16, N1::to_int());
+        assert_eq!(-2_i16, N2::to_int());
+        assert_eq!(-3_i16, N3::to_int());
+        assert_eq!(-4_i16, N4::to_int());
+
+        // i32
+        assert_eq!(0_i32, Z0::to_int());
+        assert_eq!(1_i32, P1::to_int());
+        assert_eq!(2_i32, P2::to_int());
+        assert_eq!(3_i32, P3::to_int());
+        assert_eq!(4_i32, P4::to_int());
+        assert_eq!(-1_i32, N1::to_int());
+        assert_eq!(-2_i32, N2::to_int());
+        assert_eq!(-3_i32, N3::to_int());
+        assert_eq!(-4_i32, N4::to_int());
+
+        // i64
+        assert_eq!(0_i64, Z0::to_int());
+        assert_eq!(1_i64, P1::to_int());
+        assert_eq!(2_i64, P2::to_int());
+        assert_eq!(3_i64, P3::to_int());
+        assert_eq!(4_i64, P4::to_int());
+        assert_eq!(-1_i64, N1::to_int());
+        assert_eq!(-2_i64, N2::to_int());
+        assert_eq!(-3_i64, N3::to_int());
+        assert_eq!(-4_i64, N4::to_int());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 //! example,
 //!
 //! ```rust
-//! use typenum::{N4, Integer};
+//! use typenum::{Integer, N4};
 //!
 //! assert_eq!(N4::to_i32(), -4);
 //! ```
@@ -34,14 +34,13 @@
 //! could be replaced with
 //!
 //! ```rust
-//! use typenum::{Sum, Integer, P3, P4};
+//! use typenum::{Integer, Sum, P3, P4};
 //!
 //! type X = Sum<P3, P4>;
 //! assert_eq!(<X as Integer>::to_i32(), 7);
 //! ```
 //!
 //! Documented in each module is the full list of type operators implemented.
-//!
 
 #![no_std]
 #![forbid(unsafe_code)]

--- a/src/marker_traits.rs
+++ b/src/marker_traits.rs
@@ -9,7 +9,7 @@
 //! to_i32() -> i32` and the associated constant `I32` so that one can do this:
 //!
 //! ```
-//! use typenum::{N42, Integer};
+//! use typenum::{Integer, N42};
 //!
 //! assert_eq!(-42, N42::to_i32());
 //! assert_eq!(-42, N42::I32);
@@ -49,7 +49,7 @@ pub trait Bit: Copy + Default {
 ///
 /// # Example
 /// ```rust
-/// use typenum::{U3, Unsigned};
+/// use typenum::{Unsigned, U3};
 ///
 /// assert_eq!(U3::to_u32(), 3);
 /// assert_eq!(U3::I32, 3);
@@ -118,7 +118,7 @@ pub trait Unsigned: Copy + Default {
 ///
 /// # Example
 /// ```rust
-/// use typenum::{P3, Integer};
+/// use typenum::{Integer, P3};
 ///
 /// assert_eq!(P3::to_i32(), 3);
 /// assert_eq!(P3::I32, 3);
@@ -171,9 +171,9 @@ pub trait TypeArray {}
 /// Here's a working example:
 ///
 /// ```rust
-/// use typenum::{P4, P8, PowerOfTwo};
+/// use typenum::{PowerOfTwo, P4, P8};
 ///
-/// fn only_p2<P: PowerOfTwo>() { }
+/// fn only_p2<P: PowerOfTwo>() {}
 ///
 /// only_p2::<P4>();
 /// only_p2::<P8>();

--- a/src/type_operators.rs
+++ b/src/type_operators.rs
@@ -1,5 +1,4 @@
 //! Useful **type operators** that are not defined in `core::ops`.
-//!
 
 use private::{Internal, InternalMarker};
 use {Bit, NInt, NonZero, PInt, UInt, UTerm, Unsigned, Z0};
@@ -557,4 +556,14 @@ pub trait Logarithm2 {
 pub trait Gcd<Rhs> {
     /// The greatest common divisor.
     type Output;
+}
+
+/// A **type operator** for taking a concrete integer value from a type.
+///
+/// It returns arbitrary integer value without explicitly specifying the
+/// type. It is useful when you pass the values to methods that accept
+/// distinct types without runtime casting.
+pub trait ToInt<T> {
+    /// Method returning the concrete value for the type.
+    fn to_int() -> T;
 }

--- a/src/type_operators.rs
+++ b/src/type_operators.rs
@@ -15,7 +15,7 @@ use {Bit, NInt, NonZero, PInt, UInt, UTerm, Unsigned, Z0};
 ///
 /// # Example
 /// ```rust
-/// use typenum::{Same, U4, U5, Unsigned};
+/// use typenum::{Same, Unsigned, U4, U5};
 ///
 /// assert_eq!(<U5 as Same<U5>>::Output::to_u32(), 5);
 ///
@@ -38,7 +38,7 @@ impl<T> Same<T> for T {
 ///
 /// # Example
 /// ```rust
-/// use typenum::{Abs, N5, Integer};
+/// use typenum::{Abs, Integer, N5};
 ///
 /// assert_eq!(<N5 as Abs>::Output::to_i32(), 5);
 /// ```
@@ -63,7 +63,7 @@ impl<U: Unsigned + NonZero> Abs for NInt<U> {
 ///
 /// # Example
 /// ```rust
-/// use typenum::{Pow, N3, P3, Integer};
+/// use typenum::{Integer, Pow, N3, P3};
 ///
 /// assert_eq!(<N3 as Pow<P3>>::Output::to_i32(), -27);
 /// ```
@@ -550,7 +550,7 @@ pub trait Logarithm2 {
 /// # Example
 ///
 /// ```rust
-/// use typenum::{Gcd, U12, U8, Unsigned};
+/// use typenum::{Gcd, Unsigned, U12, U8};
 ///
 /// assert_eq!(<U12 as Gcd<U8>>::Output::to_i32(), 4);
 /// ```

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -12,7 +12,7 @@
 //!
 //! # Example
 //! ```rust
-//! use std::ops::{BitAnd, BitOr, BitXor, Shl, Shr, Add, Sub, Mul, Div, Rem};
+//! use std::ops::{Add, BitAnd, BitOr, BitXor, Div, Mul, Rem, Shl, Shr, Sub};
 //! use typenum::{Unsigned, U1, U2, U3, U4};
 //!
 //! assert_eq!(<U3 as BitAnd<U2>>::Output::to_u32(), 2);
@@ -146,7 +146,7 @@ impl Unsigned for UTerm {
 ///
 /// # Example
 /// ```rust
-/// use typenum::{B0, B1, UInt, UTerm};
+/// use typenum::{UInt, UTerm, B0, B1};
 ///
 /// # #[allow(dead_code)]
 /// type U6 = UInt<UInt<UInt<UTerm, B1>, B1>, B0>;

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -31,7 +31,7 @@
 use core::ops::{Add, BitAnd, BitOr, BitXor, Mul, Shl, Shr, Sub};
 use {
     Cmp, Equal, Gcd, Greater, IsGreaterOrEqual, Len, Less, Logarithm2, Maximum, Minimum, NonZero,
-    Ord, Pow, SquareRoot,
+    Ord, Pow, SquareRoot, ToInt,
 };
 
 use bit::{Bit, B0, B1};
@@ -2324,47 +2324,265 @@ where
     type Output = Add1<Log2<U>>;
 }
 
-#[test]
-fn log2_test() {
+// -----------------------------------------
+// ToInt
+
+impl ToInt<i8> for UTerm {
+    fn to_int() -> i8 {
+        Self::I8
+    }
+}
+
+impl ToInt<i16> for UTerm {
+    fn to_int() -> i16 {
+        Self::I16
+    }
+}
+
+impl ToInt<i32> for UTerm {
+    fn to_int() -> i32 {
+        Self::I32
+    }
+}
+
+impl ToInt<i64> for UTerm {
+    fn to_int() -> i64 {
+        Self::I64
+    }
+}
+
+impl ToInt<u8> for UTerm {
+    fn to_int() -> u8 {
+        Self::U8
+    }
+}
+
+impl ToInt<u16> for UTerm {
+    fn to_int() -> u16 {
+        Self::U16
+    }
+}
+
+impl ToInt<u32> for UTerm {
+    fn to_int() -> u32 {
+        Self::U32
+    }
+}
+
+impl ToInt<u64> for UTerm {
+    fn to_int() -> u64 {
+        Self::U64
+    }
+}
+
+impl ToInt<usize> for UTerm {
+    fn to_int() -> usize {
+        Self::USIZE
+    }
+}
+
+impl<U, B> ToInt<i8> for UInt<U, B>
+where
+    U: Unsigned,
+    B: Bit,
+{
+    fn to_int() -> i8 {
+        Self::I8
+    }
+}
+
+impl<U, B> ToInt<i16> for UInt<U, B>
+where
+    U: Unsigned,
+    B: Bit,
+{
+    fn to_int() -> i16 {
+        Self::I16
+    }
+}
+
+impl<U, B> ToInt<i32> for UInt<U, B>
+where
+    U: Unsigned,
+    B: Bit,
+{
+    fn to_int() -> i32 {
+        Self::I32
+    }
+}
+
+impl<U, B> ToInt<i64> for UInt<U, B>
+where
+    U: Unsigned,
+    B: Bit,
+{
+    fn to_int() -> i64 {
+        Self::I64
+    }
+}
+
+impl<U, B> ToInt<u8> for UInt<U, B>
+where
+    U: Unsigned,
+    B: Bit,
+{
+    fn to_int() -> u8 {
+        Self::U8
+    }
+}
+
+impl<U, B> ToInt<u16> for UInt<U, B>
+where
+    U: Unsigned,
+    B: Bit,
+{
+    fn to_int() -> u16 {
+        Self::U16
+    }
+}
+
+impl<U, B> ToInt<u32> for UInt<U, B>
+where
+    U: Unsigned,
+    B: Bit,
+{
+    fn to_int() -> u32 {
+        Self::U32
+    }
+}
+
+impl<U, B> ToInt<u64> for UInt<U, B>
+where
+    U: Unsigned,
+    B: Bit,
+{
+    fn to_int() -> u64 {
+        Self::U64
+    }
+}
+
+impl<U, B> ToInt<usize> for UInt<U, B>
+where
+    U: Unsigned,
+    B: Bit,
+{
+    fn to_int() -> usize {
+        Self::USIZE
+    }
+}
+
+#[cfg(test)]
+mod tests {
     use consts::*;
+    use {Log2, ToInt, Unsigned};
 
-    assert_eq!(0, <Log2<U1>>::to_u32());
+    #[test]
+    fn log2_test() {
+        assert_eq!(0, <Log2<U1>>::to_u32());
 
-    assert_eq!(1, <Log2<U2>>::to_u32());
-    assert_eq!(1, <Log2<U3>>::to_u32());
+        assert_eq!(1, <Log2<U2>>::to_u32());
+        assert_eq!(1, <Log2<U3>>::to_u32());
 
-    assert_eq!(2, <Log2<U4>>::to_u32());
-    assert_eq!(2, <Log2<U5>>::to_u32());
-    assert_eq!(2, <Log2<U6>>::to_u32());
-    assert_eq!(2, <Log2<U7>>::to_u32());
+        assert_eq!(2, <Log2<U4>>::to_u32());
+        assert_eq!(2, <Log2<U5>>::to_u32());
+        assert_eq!(2, <Log2<U6>>::to_u32());
+        assert_eq!(2, <Log2<U7>>::to_u32());
 
-    assert_eq!(3, <Log2<U8>>::to_u32());
-    assert_eq!(3, <Log2<U9>>::to_u32());
-    assert_eq!(3, <Log2<U10>>::to_u32());
-    assert_eq!(3, <Log2<U11>>::to_u32());
-    assert_eq!(3, <Log2<U12>>::to_u32());
-    assert_eq!(3, <Log2<U13>>::to_u32());
-    assert_eq!(3, <Log2<U14>>::to_u32());
-    assert_eq!(3, <Log2<U15>>::to_u32());
+        assert_eq!(3, <Log2<U8>>::to_u32());
+        assert_eq!(3, <Log2<U9>>::to_u32());
+        assert_eq!(3, <Log2<U10>>::to_u32());
+        assert_eq!(3, <Log2<U11>>::to_u32());
+        assert_eq!(3, <Log2<U12>>::to_u32());
+        assert_eq!(3, <Log2<U13>>::to_u32());
+        assert_eq!(3, <Log2<U14>>::to_u32());
+        assert_eq!(3, <Log2<U15>>::to_u32());
 
-    assert_eq!(4, <Log2<U16>>::to_u32());
-    assert_eq!(4, <Log2<U17>>::to_u32());
-    assert_eq!(4, <Log2<U18>>::to_u32());
-    assert_eq!(4, <Log2<U19>>::to_u32());
-    assert_eq!(4, <Log2<U20>>::to_u32());
-    assert_eq!(4, <Log2<U21>>::to_u32());
-    assert_eq!(4, <Log2<U22>>::to_u32());
-    assert_eq!(4, <Log2<U23>>::to_u32());
-    assert_eq!(4, <Log2<U24>>::to_u32());
-    assert_eq!(4, <Log2<U25>>::to_u32());
-    assert_eq!(4, <Log2<U26>>::to_u32());
-    assert_eq!(4, <Log2<U27>>::to_u32());
-    assert_eq!(4, <Log2<U28>>::to_u32());
-    assert_eq!(4, <Log2<U29>>::to_u32());
-    assert_eq!(4, <Log2<U30>>::to_u32());
-    assert_eq!(4, <Log2<U31>>::to_u32());
+        assert_eq!(4, <Log2<U16>>::to_u32());
+        assert_eq!(4, <Log2<U17>>::to_u32());
+        assert_eq!(4, <Log2<U18>>::to_u32());
+        assert_eq!(4, <Log2<U19>>::to_u32());
+        assert_eq!(4, <Log2<U20>>::to_u32());
+        assert_eq!(4, <Log2<U21>>::to_u32());
+        assert_eq!(4, <Log2<U22>>::to_u32());
+        assert_eq!(4, <Log2<U23>>::to_u32());
+        assert_eq!(4, <Log2<U24>>::to_u32());
+        assert_eq!(4, <Log2<U25>>::to_u32());
+        assert_eq!(4, <Log2<U26>>::to_u32());
+        assert_eq!(4, <Log2<U27>>::to_u32());
+        assert_eq!(4, <Log2<U28>>::to_u32());
+        assert_eq!(4, <Log2<U29>>::to_u32());
+        assert_eq!(4, <Log2<U30>>::to_u32());
+        assert_eq!(4, <Log2<U31>>::to_u32());
 
-    assert_eq!(5, <Log2<U32>>::to_u32());
-    assert_eq!(5, <Log2<U33>>::to_u32());
-    // ...
+        assert_eq!(5, <Log2<U32>>::to_u32());
+        assert_eq!(5, <Log2<U33>>::to_u32());
+
+        // ...
+    }
+
+    #[test]
+    fn uint_toint_test() {
+        // i8
+        assert_eq!(0_i8, U0::to_int());
+        assert_eq!(1_i8, U1::to_int());
+        assert_eq!(2_i8, U2::to_int());
+        assert_eq!(3_i8, U3::to_int());
+        assert_eq!(4_i8, U4::to_int());
+
+        // i16
+        assert_eq!(0_i16, U0::to_int());
+        assert_eq!(1_i16, U1::to_int());
+        assert_eq!(2_i16, U2::to_int());
+        assert_eq!(3_i16, U3::to_int());
+        assert_eq!(4_i16, U4::to_int());
+
+        // i32
+        assert_eq!(0_i32, U0::to_int());
+        assert_eq!(1_i32, U1::to_int());
+        assert_eq!(2_i32, U2::to_int());
+        assert_eq!(3_i32, U3::to_int());
+        assert_eq!(4_i32, U4::to_int());
+
+        // i64
+        assert_eq!(0_i64, U0::to_int());
+        assert_eq!(1_i64, U1::to_int());
+        assert_eq!(2_i64, U2::to_int());
+        assert_eq!(3_i64, U3::to_int());
+        assert_eq!(4_i64, U4::to_int());
+
+        // u8
+        assert_eq!(0_u8, U0::to_int());
+        assert_eq!(1_u8, U1::to_int());
+        assert_eq!(2_u8, U2::to_int());
+        assert_eq!(3_u8, U3::to_int());
+        assert_eq!(4_u8, U4::to_int());
+
+        // u16
+        assert_eq!(0_u16, U0::to_int());
+        assert_eq!(1_u16, U1::to_int());
+        assert_eq!(2_u16, U2::to_int());
+        assert_eq!(3_u16, U3::to_int());
+        assert_eq!(4_u16, U4::to_int());
+
+        // u32
+        assert_eq!(0_u32, U0::to_int());
+        assert_eq!(1_u32, U1::to_int());
+        assert_eq!(2_u32, U2::to_int());
+        assert_eq!(3_u32, U3::to_int());
+        assert_eq!(4_u32, U4::to_int());
+
+        // u64
+        assert_eq!(0_u64, U0::to_int());
+        assert_eq!(1_u64, U1::to_int());
+        assert_eq!(2_u64, U2::to_int());
+        assert_eq!(3_u64, U3::to_int());
+        assert_eq!(4_u64, U4::to_int());
+
+        // usize
+        assert_eq!(0_usize, U0::to_int());
+        assert_eq!(1_usize, U1::to_int());
+        assert_eq!(2_usize, U2::to_int());
+        assert_eq!(3_usize, U3::to_int());
+        assert_eq!(4_usize, U4::to_int());
+    }
 }


### PR DESCRIPTION
The `ToInt` type operator return arbitrary integer types, including {i,u}{8,16,32,64} types. Below is the example usage of `ToInt`. It is useful when passing concrete values to methods with distinct argument types from typed numbers without runtime casting,   or when you build a type operator upon arbitrary integer types.

```rust
use typenum::{type_operators::ToInt, consts::*};

fn accept_i8(n: i8) { /* ... */ }
fn accept_usize(n: usize) { /* ... */ }

type Value = U7;

fn main() {
    accept_i8(Value::to_int());
    accept_usize(Value::to_int());
}
```

EDIT 1:
This PR resolves #133. 

EDIT 2:
Fix typo