### PR TITLE
Use edition 2018, reduce unsafe code, replace deprecated uninitialized with MaybeUnit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: false
 rust:
   - beta
   - nightly
-  - 1.22.0
+  - 1.31.0
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: false
 rust:
   - beta
   - nightly
-  - 1.31.0
+  - 1.36.0
 
 notifications:
   email:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@
   license = "MIT/Apache-2.0"
   description = "Typenum is a Rust library for type-level numbers evaluated at compile time. It currently supports bits, unsigned integers, and signed integers. It also provides a type-level array of type-level numbers, but its implementation is incomplete."
   categories = ["no-std"]
+  edition = "2018"
 
 [lib]
   name = "typenum"

--- a/build/main.rs
+++ b/build/main.rs
@@ -152,11 +152,11 @@ We also define the aliases `False` and `True` for `B0` and `B1`, respectively.
 */
 #[allow(missing_docs)]
 pub mod consts {{
-    use uint::{{UInt, UTerm}};
-    use int::{{PInt, NInt}};
+    use crate::uint::{{UInt, UTerm}};
+    use crate::int::{{PInt, NInt}};
 
-    pub use bit::{{B0, B1}};
-    pub use int::Z0;
+    pub use crate::bit::{{B0, B1}};
+    pub use crate::int::Z0;
 
     pub type True = B1;
     pub type False = B0;

--- a/src/array.rs
+++ b/src/array.rs
@@ -67,7 +67,7 @@ where
 {
     type Output = Add1<Length<A>>;
     fn len(&self) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+        unsafe { core::mem::MaybeUninit::zeroed().assume_init() }
     }
 }
 
@@ -89,7 +89,7 @@ where
 {
     type Output = TArr<Sum<Vl, Vr>, Sum<Al, Ar>>;
     fn add(self, _: TArr<Vr, Ar>) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+        unsafe { core::mem::MaybeUninit::zeroed().assume_init() }
     }
 }
 
@@ -111,7 +111,7 @@ where
 {
     type Output = TArr<Diff<Vl, Vr>, Diff<Al, Ar>>;
     fn sub(self, _: TArr<Vr, Ar>) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+        unsafe { core::mem::MaybeUninit::zeroed().assume_init() }
     }
 }
 
@@ -132,7 +132,7 @@ where
 {
     type Output = TArr<Prod<V, Rhs>, Prod<A, Rhs>>;
     fn mul(self, _: Rhs) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+        unsafe { core::mem::MaybeUninit::zeroed().assume_init() }
     }
 }
 
@@ -169,7 +169,7 @@ where
 {
     type Output = TArr<Z0, Prod<Z0, A>>;
     fn mul(self, _: TArr<V, A>) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+        unsafe { core::mem::MaybeUninit::zeroed().assume_init() }
     }
 }
 
@@ -180,7 +180,7 @@ where
 {
     type Output = TArr<Prod<PInt<U>, V>, Prod<PInt<U>, A>>;
     fn mul(self, _: TArr<V, A>) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+        unsafe { core::mem::MaybeUninit::zeroed().assume_init() }
     }
 }
 
@@ -191,7 +191,7 @@ where
 {
     type Output = TArr<Prod<NInt<U>, V>, Prod<NInt<U>, A>>;
     fn mul(self, _: TArr<V, A>) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+        unsafe { core::mem::MaybeUninit::zeroed().assume_init() }
     }
 }
 
@@ -212,7 +212,7 @@ where
 {
     type Output = TArr<Quot<V, Rhs>, Quot<A, Rhs>>;
     fn div(self, _: Rhs) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+        unsafe { core::mem::MaybeUninit::zeroed().assume_init() }
     }
 }
 
@@ -233,7 +233,7 @@ where
 {
     type Output = TArr<PartialQuot<V, Rhs>, PartialQuot<A, Rhs>>;
     fn partial_div(self, _: Rhs) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+        unsafe { core::mem::MaybeUninit::zeroed().assume_init() }
     }
 }
 
@@ -255,7 +255,7 @@ where
 {
     type Output = TArr<Mod<V, Rhs>, Mod<A, Rhs>>;
     fn rem(self, _: Rhs) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+        unsafe { core::mem::MaybeUninit::zeroed().assume_init() }
     }
 }
 
@@ -277,6 +277,6 @@ where
 {
     type Output = TArr<Negate<V>, Negate<A>>;
     fn neg(self) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+        unsafe { core::mem::MaybeUninit::zeroed().assume_init() }
     }
 }

--- a/src/bit.rs
+++ b/src/bit.rs
@@ -10,10 +10,10 @@
 //! - From `typenum`: `Same` and `Cmp`.
 //!
 
+use crate::{Cmp, Equal, Greater, Less, NonZero, PowerOfTwo};
 use core::ops::{BitAnd, BitOr, BitXor, Not};
-use {Cmp, Equal, Greater, Less, NonZero, PowerOfTwo};
 
-pub use marker_traits::Bit;
+pub use crate::marker_traits::Bit;
 
 /// The type-level bit 0.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug, Default)]
@@ -215,7 +215,7 @@ impl Cmp<B1> for B1 {
     type Output = Equal;
 }
 
-use Min;
+use crate::Min;
 impl Min<B0> for B0 {
     type Output = B0;
     fn min(self, _: B0) -> B0 {
@@ -241,7 +241,7 @@ impl Min<B1> for B1 {
     }
 }
 
-use Max;
+use crate::Max;
 impl Max<B0> for B0 {
     type Output = B0;
     fn max(self, _: B0) -> B0 {

--- a/src/int.rs
+++ b/src/int.rs
@@ -30,13 +30,13 @@
 use core::marker::PhantomData;
 use core::ops::{Add, Div, Mul, Neg, Rem, Sub};
 
-use bit::{Bit, B0, B1};
-use consts::{N1, P1, U0, U1};
-use private::{PrivateDivInt, PrivateIntegerAdd, PrivateRem};
-use uint::{UInt, Unsigned};
-use {Cmp, Equal, Greater, Less, NonZero, Pow, PowerOfTwo};
+use crate::bit::{Bit, B0, B1};
+use crate::consts::{N1, P1, U0, U1};
+use crate::private::{PrivateDivInt, PrivateIntegerAdd, PrivateRem};
+use crate::uint::{UInt, Unsigned};
+use crate::{Cmp, Equal, Greater, Less, NonZero, Pow, PowerOfTwo};
 
-pub use marker_traits::Integer;
+pub use crate::marker_traits::Integer;
 
 /// Type-level signed integers with positive sign.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug, Default)]
@@ -231,7 +231,7 @@ impl<U: Unsigned + NonZero> Neg for NInt<U> {
 impl<I: Integer> Add<I> for Z0 {
     type Output = I;
     fn add(self, _: I) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+        unsafe { core::mem::MaybeUninit::zeroed().assume_init() }
     }
 }
 
@@ -282,7 +282,7 @@ where
 {
     type Output = <Ul as PrivateIntegerAdd<<Ul as Cmp<Ur>>::Output, Ur>>::Output;
     fn add(self, _: NInt<Ur>) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+        unsafe { core::mem::MaybeUninit::zeroed().assume_init() }
     }
 }
 
@@ -294,7 +294,7 @@ where
 {
     type Output = <Ur as PrivateIntegerAdd<<Ur as Cmp<Ul>>::Output, Ul>>::Output;
     fn add(self, _: PInt<Ur>) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+        unsafe { core::mem::MaybeUninit::zeroed().assume_init() }
     }
 }
 
@@ -395,7 +395,7 @@ where
 {
     type Output = <Ul as PrivateIntegerAdd<<Ul as Cmp<Ur>>::Output, Ur>>::Output;
     fn sub(self, _: PInt<Ur>) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+        unsafe { core::mem::MaybeUninit::zeroed().assume_init() }
     }
 }
 
@@ -407,7 +407,7 @@ where
 {
     type Output = <Ur as PrivateIntegerAdd<<Ur as Cmp<Ul>>::Output, Ul>>::Output;
     fn sub(self, _: NInt<Ur>) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+        unsafe { core::mem::MaybeUninit::zeroed().assume_init() }
     }
 }
 
@@ -507,7 +507,7 @@ macro_rules! impl_int_div {
         {
             type Output = <$A<Ul> as PrivateDivInt<<Ul as Cmp<Ur>>::Output, $B<Ur>>>::Output;
             fn div(self, _: $B<Ur>) -> Self::Output {
-                unsafe { ::core::mem::uninitialized() }
+                unsafe { core::mem::MaybeUninit::zeroed().assume_init() }
             }
         }
         impl<Ul, Ur> PrivateDivInt<Less, $B<Ur>> for $A<Ul>
@@ -543,7 +543,7 @@ impl_int_div!(NInt, NInt, PInt);
 // ---------------------------------------------------------------------------------------
 // PartialDiv
 
-use {PartialDiv, Quot};
+use crate::{PartialDiv, Quot};
 
 impl<M, N> PartialDiv<N> for M
 where
@@ -551,7 +551,7 @@ where
 {
     type Output = Quot<M, N>;
     fn partial_div(self, _: N) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+        unsafe { core::mem::MaybeUninit::zeroed().assume_init() }
     }
 }
 
@@ -624,7 +624,7 @@ macro_rules! impl_int_rem {
         {
             type Output = <$A<Ul> as PrivateRem<<Ul as Rem<Ur>>::Output, $B<Ur>>>::Output;
             fn rem(self, _: $B<Ur>) -> Self::Output {
-                unsafe { ::core::mem::uninitialized() }
+                unsafe { core::mem::MaybeUninit::zeroed().assume_init() }
             }
         }
         impl<Ul: Unsigned + NonZero, Ur: Unsigned + NonZero> PrivateRem<U0, $B<Ur>> for $A<Ul> {
@@ -752,7 +752,7 @@ where
 
 // ---------------------------------------------------------------------------------------
 // Min
-use {Max, Maximum, Min, Minimum};
+use crate::{Max, Maximum, Min, Minimum};
 
 impl Min<Z0> for Z0 {
     type Output = Z0;
@@ -809,7 +809,7 @@ where
 {
     type Output = PInt<Minimum<Ul, Ur>>;
     fn min(self, _: PInt<Ur>) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+        unsafe { core::mem::MaybeUninit::zeroed().assume_init() }
     }
 }
 
@@ -843,7 +843,7 @@ where
 {
     type Output = NInt<Maximum<Ul, Ur>>;
     fn min(self, _: NInt<Ur>) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+        NInt::new()
     }
 }
 
@@ -905,7 +905,7 @@ where
 {
     type Output = PInt<Maximum<Ul, Ur>>;
     fn max(self, _: PInt<Ur>) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+        PInt::new()
     }
 }
 
@@ -939,14 +939,14 @@ where
 {
     type Output = NInt<Minimum<Ul, Ur>>;
     fn max(self, _: NInt<Ur>) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+        NInt::new()
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use consts::*;
-    use Integer;
+    use crate::consts::*;
+    use crate::Integer;
 
     #[test]
     fn to_ix_min() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,14 +75,14 @@ pub mod uint;
 
 pub mod array;
 
-pub use consts::*;
-pub use marker_traits::*;
-pub use operator_aliases::*;
-pub use type_operators::*;
+pub use crate::consts::*;
+pub use crate::marker_traits::*;
+pub use crate::operator_aliases::*;
+pub use crate::type_operators::*;
 
-pub use array::{ATerm, TArr};
-pub use int::{NInt, PInt};
-pub use uint::{UInt, UTerm};
+pub use crate::array::{ATerm, TArr};
+pub use crate::int::{NInt, PInt};
+pub use crate::uint::{UInt, UTerm};
 
 /// A potential output from `Cmp`, this is the type equivalent to the enum variant
 /// `core::cmp::Ordering::Greater`.

--- a/src/operator_aliases.rs
+++ b/src/operator_aliases.rs
@@ -7,7 +7,6 @@
 //!
 //! ```rust
 //! # #[macro_use] extern crate typenum;
-//! # fn main() {
 //! use std::ops::Mul;
 //! use typenum::{Prod, P5, P7};
 //!
@@ -15,7 +14,6 @@
 //! type Y = Prod<P7, P5>;
 //!
 //! assert_type_eq!(X, Y);
-//! # }
 //! ```
 //!
 //!

--- a/src/operator_aliases.rs
+++ b/src/operator_aliases.rs
@@ -21,8 +21,8 @@
 //!
 
 // Aliases!!!
+use crate::type_operators::{Abs, Cmp, Len, Logarithm2, Max, Min, PartialDiv, Pow, SquareRoot};
 use core::ops::{Add, BitAnd, BitOr, BitXor, Div, Mul, Neg, Rem, Shl, Shr, Sub};
-use type_operators::{Abs, Cmp, Len, Logarithm2, Max, Min, PartialDiv, Pow, SquareRoot};
 
 /// Alias for the associated type of `BitAnd`: `And<A, B> = <A as BitAnd<B>>::Output`
 pub type And<A, B> = <A as BitAnd<B>>::Output;
@@ -61,12 +61,12 @@ pub type AbsVal<A> = <A as Abs>::Output;
 pub type Exp<A, B> = <A as Pow<B>>::Output;
 
 /// Alias to make it easy to add 1: `Add1<A> = <A as Add<B1>>::Output`
-pub type Add1<A> = <A as Add<::bit::B1>>::Output;
+pub type Add1<A> = <A as Add<crate::bit::B1>>::Output;
 /// Alias to make it easy to subtract 1: `Sub1<A> = <A as Sub<B1>>::Output`
-pub type Sub1<A> = <A as Sub<::bit::B1>>::Output;
+pub type Sub1<A> = <A as Sub<crate::bit::B1>>::Output;
 
 /// Alias to make it easy to multiply by 2. `Double<A> = Shleft<A, B1>`
-pub type Double<A> = Shleft<A, ::bit::B1>;
+pub type Double<A> = Shleft<A, crate::bit::B1>;
 
 /// Alias to make it easy to square. `Square<A> = <A as Mul<A>>::Output`
 pub type Square<A> = <A as Mul>::Output;
@@ -88,7 +88,9 @@ pub type Minimum<A, B> = <A as Min<B>>::Output;
 /// Alias for the associated type of `Max`: `Maximum<A, B> = <A as Max<B>>::Output`
 pub type Maximum<A, B> = <A as Max<B>>::Output;
 
-use type_operators::{IsEqual, IsGreater, IsGreaterOrEqual, IsLess, IsLessOrEqual, IsNotEqual};
+use crate::type_operators::{
+    IsEqual, IsGreater, IsGreaterOrEqual, IsLess, IsLessOrEqual, IsNotEqual,
+};
 /// Alias for the associated type of `IsLess`: `Le<A, B> = <A as IsLess<B>>::Output`
 pub type Le<A, B> = <A as IsLess<B>>::Output;
 /// Alias for the associated type of `IsEqual`: `Eq<A, B> = <A as IsEqual<B>>::Output`

--- a/src/private.rs
+++ b/src/private.rs
@@ -22,8 +22,8 @@
 #![doc(hidden)]
 
 // use ::{Sub};
-use bit::{Bit, B0, B1};
-use uint::{UInt, UTerm, Unsigned};
+use crate::bit::{Bit, B0, B1};
+use crate::uint::{UInt, UTerm, Unsigned};
 
 /// Convenience trait. Calls `Invert` -> `TrimTrailingZeros` -> `Invert`
 pub trait Trim {
@@ -146,10 +146,10 @@ where
 
 #[test]
 fn test_inversion() {
-    type Test4 = <::consts::U4 as Invert>::Output;
-    type Test5 = <::consts::U5 as Invert>::Output;
-    type Test12 = <::consts::U12 as Invert>::Output;
-    type Test16 = <::consts::U16 as Invert>::Output;
+    type Test4 = <crate::consts::U4 as Invert>::Output;
+    type Test5 = <crate::consts::U5 as Invert>::Output;
+    type Test12 = <crate::consts::U12 as Invert>::Output;
+    type Test16 = <crate::consts::U16 as Invert>::Output;
 
     assert_eq!(1, <Test4 as InvertedUnsigned>::to_u64());
     assert_eq!(5, <Test5 as InvertedUnsigned>::to_u64());
@@ -181,10 +181,10 @@ where
 
 #[test]
 fn test_double_inversion() {
-    type Test4 = <<::consts::U4 as Invert>::Output as Invert>::Output;
-    type Test5 = <<::consts::U5 as Invert>::Output as Invert>::Output;
-    type Test12 = <<::consts::U12 as Invert>::Output as Invert>::Output;
-    type Test16 = <<::consts::U16 as Invert>::Output as Invert>::Output;
+    type Test4 = <<crate::consts::U4 as Invert>::Output as Invert>::Output;
+    type Test5 = <<crate::consts::U5 as Invert>::Output as Invert>::Output;
+    type Test12 = <<crate::consts::U12 as Invert>::Output as Invert>::Output;
+    type Test16 = <<crate::consts::U16 as Invert>::Output as Invert>::Output;
 
     assert_eq!(4, <Test4 as Unsigned>::to_u64());
     assert_eq!(5, <Test5 as Unsigned>::to_u64());
@@ -274,7 +274,7 @@ pub type PrivateMaxOut<A, B, CmpResult> = <A as PrivateMax<B, CmpResult>>::Outpu
 
 // Comparisons
 
-use {Equal, False, Greater, Less, True};
+use crate::{Equal, False, Greater, Less, True};
 
 pub trait IsLessPrivate<Rhs, Cmp> {
     type Output: Bit;

--- a/src/type_operators.rs
+++ b/src/type_operators.rs
@@ -1,7 +1,7 @@
 //! Useful **type operators** that are not defined in `core::ops`.
 //!
 
-use {Bit, NInt, NonZero, PInt, UInt, UTerm, Unsigned, Z0};
+use crate::{Bit, NInt, NonZero, PInt, UInt, UTerm, Unsigned, Z0};
 
 /// A **type operator** that ensures that `Rhs` is the same as `Self`, it is mainly useful
 /// for writing macros that can take arbitrary binary or unary operators.
@@ -221,7 +221,7 @@ impl_pow_i!(u128, i128);
 
 #[test]
 fn pow_test() {
-    use consts::*;
+    use crate::consts::*;
     let z0 = Z0::new();
     let p3 = P3::new();
 
@@ -286,7 +286,7 @@ pub trait Cmp<Rhs = Self> {
 /// A **type operator** that gives the length of an `Array` or the number of bits in a `UInt`.
 pub trait Len {
     /// The length as a type-level unsigned integer.
-    type Output: ::Unsigned;
+    type Output: crate::Unsigned;
     /// This function isn't used in this crate, but may be useful for others.
     fn len(&self) -> Self::Output;
 }
@@ -316,7 +316,7 @@ pub trait Max<Rhs = Self> {
     fn max(self, rhs: Rhs) -> Self::Output;
 }
 
-use Compare;
+use crate::Compare;
 
 /// A **type operator** that returns `True` if `Self < Rhs`, otherwise returns `False`.
 pub trait IsLess<Rhs = Self> {
@@ -326,7 +326,7 @@ pub trait IsLess<Rhs = Self> {
     fn is_less(self, rhs: Rhs) -> Self::Output;
 }
 
-use private::IsLessPrivate;
+use crate::private::IsLessPrivate;
 impl<A, B> IsLess<B> for A
 where
     A: Cmp<B> + IsLessPrivate<B, Compare<A, B>>,
@@ -334,7 +334,7 @@ where
     type Output = <A as IsLessPrivate<B, Compare<A, B>>>::Output;
 
     fn is_less(self, _: B) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+        unsafe { core::mem::MaybeUninit::zeroed().assume_init() }
     }
 }
 
@@ -346,7 +346,7 @@ pub trait IsEqual<Rhs = Self> {
     fn is_equal(self, rhs: Rhs) -> Self::Output;
 }
 
-use private::IsEqualPrivate;
+use crate::private::IsEqualPrivate;
 impl<A, B> IsEqual<B> for A
 where
     A: Cmp<B> + IsEqualPrivate<B, Compare<A, B>>,
@@ -354,7 +354,7 @@ where
     type Output = <A as IsEqualPrivate<B, Compare<A, B>>>::Output;
 
     fn is_equal(self, _: B) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+        unsafe { core::mem::MaybeUninit::zeroed().assume_init() }
     }
 }
 
@@ -366,7 +366,7 @@ pub trait IsGreater<Rhs = Self> {
     fn is_greater(self, rhs: Rhs) -> Self::Output;
 }
 
-use private::IsGreaterPrivate;
+use crate::private::IsGreaterPrivate;
 impl<A, B> IsGreater<B> for A
 where
     A: Cmp<B> + IsGreaterPrivate<B, Compare<A, B>>,
@@ -374,7 +374,7 @@ where
     type Output = <A as IsGreaterPrivate<B, Compare<A, B>>>::Output;
 
     fn is_greater(self, _: B) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+        unsafe { core::mem::MaybeUninit::zeroed().assume_init() }
     }
 }
 
@@ -386,7 +386,7 @@ pub trait IsLessOrEqual<Rhs = Self> {
     fn is_less_or_equal(self, rhs: Rhs) -> Self::Output;
 }
 
-use private::IsLessOrEqualPrivate;
+use crate::private::IsLessOrEqualPrivate;
 impl<A, B> IsLessOrEqual<B> for A
 where
     A: Cmp<B> + IsLessOrEqualPrivate<B, Compare<A, B>>,
@@ -394,7 +394,7 @@ where
     type Output = <A as IsLessOrEqualPrivate<B, Compare<A, B>>>::Output;
 
     fn is_less_or_equal(self, _: B) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+        unsafe { core::mem::MaybeUninit::zeroed().assume_init() }
     }
 }
 
@@ -406,7 +406,7 @@ pub trait IsNotEqual<Rhs = Self> {
     fn is_not_equal(self, rhs: Rhs) -> Self::Output;
 }
 
-use private::IsNotEqualPrivate;
+use crate::private::IsNotEqualPrivate;
 impl<A, B> IsNotEqual<B> for A
 where
     A: Cmp<B> + IsNotEqualPrivate<B, Compare<A, B>>,
@@ -414,7 +414,7 @@ where
     type Output = <A as IsNotEqualPrivate<B, Compare<A, B>>>::Output;
 
     fn is_not_equal(self, _: B) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+        unsafe { core::mem::MaybeUninit::zeroed().assume_init() }
     }
 }
 
@@ -426,7 +426,7 @@ pub trait IsGreaterOrEqual<Rhs = Self> {
     fn is_greater_or_equal(self, rhs: Rhs) -> Self::Output;
 }
 
-use private::IsGreaterOrEqualPrivate;
+use crate::private::IsGreaterOrEqualPrivate;
 impl<A, B> IsGreaterOrEqual<B> for A
 where
     A: Cmp<B> + IsGreaterOrEqualPrivate<B, Compare<A, B>>,
@@ -434,7 +434,7 @@ where
     type Output = <A as IsGreaterOrEqualPrivate<B, Compare<A, B>>>::Output;
 
     fn is_greater_or_equal(self, _: B) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+        unsafe { core::mem::MaybeUninit::zeroed().assume_init() }
     }
 }
 

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -3,7 +3,7 @@
 //!
 //! **Type operators** implemented:
 //!
-//! From `core::ops`: `BitAnd`, `BitOr`, `BitXor`, `Shl`, `Shr`, `Add`, `Sub`,
+//! From `::core::ops`: `BitAnd`, `BitOr`, `BitXor`, `Shl`, `Shr`, `Add`, `Sub`,
 //!                 `Mul`, `Div`, and `Rem`.
 //! From `typenum`: `Same`, `Cmp`, and `Pow`.
 //!
@@ -28,25 +28,27 @@
 //! ```
 //!
 
+use crate::{
+    Cmp, Equal, Greater, IsGreaterOrEqual, Len, Less, Logarithm2, NonZero, Ord, Pow, SquareRoot,
+};
 use core::marker::PhantomData;
 use core::ops::{Add, BitAnd, BitOr, BitXor, Mul, Shl, Shr, Sub};
-use {Cmp, Equal, Greater, IsGreaterOrEqual, Len, Less, Logarithm2, NonZero, Ord, Pow, SquareRoot};
 
-use bit::{Bit, B0, B1};
+use crate::bit::{Bit, B0, B1};
 
-use private::{
+use crate::private::{
     BitDiff, PrivateAnd, PrivateCmp, PrivateLogarithm2, PrivatePow, PrivateSquareRoot, PrivateSub,
     PrivateXor, Trim,
 };
 
-use private::{
+use crate::private::{
     BitDiffOut, PrivateAndOut, PrivateCmpOut, PrivatePowOut, PrivateSubOut, PrivateXorOut, TrimOut,
 };
 
-use consts::{U0, U1};
-use {Add1, Double, GrEq, Length, Log2, Or, Prod, Shleft, Shright, Sqrt, Square, Sub1, Sum};
+use crate::consts::{U0, U1};
+use crate::{Add1, Double, GrEq, Length, Log2, Or, Prod, Shleft, Shright, Sqrt, Square, Sub1, Sum};
 
-pub use marker_traits::{PowerOfTwo, Unsigned};
+pub use crate::marker_traits::{PowerOfTwo, Unsigned};
 
 /// The terminating type for `UInt`; it always comes after the most significant
 /// bit. `UTerm` by itself represents zero, which is aliased to `U0`.
@@ -257,7 +259,7 @@ where
 {
     type Output = Add1<Length<U>>;
     fn len(&self) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+        unsafe { ::core::mem::MaybeUninit::zeroed().assume_init() }
     }
 }
 
@@ -314,8 +316,8 @@ where
 /// `UTerm + U = U`
 impl<U: Unsigned> Add<U> for UTerm {
     type Output = U;
-    fn add(self, _: U) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+    fn add(self, rhs: U) -> Self::Output {
+        rhs
     }
 }
 
@@ -334,7 +336,9 @@ where
 {
     type Output = UInt<Sum<Ul, Ur>, B0>;
     fn add(self, _: UInt<Ur, B0>) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+        UInt {
+            _marker: PhantomData,
+        }
     }
 }
 
@@ -345,7 +349,9 @@ where
 {
     type Output = UInt<Sum<Ul, Ur>, B1>;
     fn add(self, _: UInt<Ur, B1>) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+        UInt {
+            _marker: PhantomData,
+        }
     }
 }
 
@@ -356,7 +362,9 @@ where
 {
     type Output = UInt<Sum<Ul, Ur>, B1>;
     fn add(self, _: UInt<Ur, B0>) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+        UInt {
+            _marker: PhantomData,
+        }
     }
 }
 
@@ -368,7 +376,9 @@ where
 {
     type Output = UInt<Add1<Sum<Ul, Ur>>, B0>;
     fn add(self, _: UInt<Ur, B1>) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+        UInt {
+            _marker: PhantomData,
+        }
     }
 }
 
@@ -438,7 +448,7 @@ where
 {
     type Output = TrimOut<PrivateSubOut<UInt<Ul, Bl>, Ur>>;
     fn sub(self, _: Ur) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+        unsafe { ::core::mem::MaybeUninit::zeroed().assume_init() }
     }
 }
 
@@ -500,7 +510,7 @@ where
 {
     type Output = TrimOut<PrivateAndOut<UInt<Ul, Bl>, Ur>>;
     fn bitand(self, _: Ur) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+        unsafe { ::core::mem::MaybeUninit::zeroed().assume_init() }
     }
 }
 
@@ -552,8 +562,8 @@ where
 /// `UTerm | X = X`
 impl<U: Unsigned> BitOr<U> for UTerm {
     type Output = U;
-    fn bitor(self, _: U) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+    fn bitor(self, rhs: U) -> Self::Output {
+        rhs
     }
 }
 
@@ -572,7 +582,9 @@ where
 {
     type Output = UInt<<Ul as BitOr<Ur>>::Output, B0>;
     fn bitor(self, _: UInt<Ur, B0>) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+        UInt {
+            _marker: PhantomData,
+        }
     }
 }
 
@@ -583,7 +595,9 @@ where
 {
     type Output = UInt<Or<Ul, Ur>, B1>;
     fn bitor(self, _: UInt<Ur, B1>) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+        UInt {
+            _marker: PhantomData,
+        }
     }
 }
 
@@ -594,7 +608,9 @@ where
 {
     type Output = UInt<Or<Ul, Ur>, B1>;
     fn bitor(self, _: UInt<Ur, B0>) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+        UInt {
+            _marker: PhantomData,
+        }
     }
 }
 
@@ -605,7 +621,9 @@ where
 {
     type Output = UInt<Or<Ul, Ur>, B1>;
     fn bitor(self, _: UInt<Ur, B1>) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+        UInt {
+            _marker: PhantomData,
+        }
     }
 }
 
@@ -615,8 +633,8 @@ where
 /// 0 ^ X = X
 impl<Ur: Unsigned> BitXor<Ur> for UTerm {
     type Output = Ur;
-    fn bitxor(self, _: Ur) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+    fn bitxor(self, rhs: Ur) -> Self::Output {
+        rhs
     }
 }
 
@@ -629,7 +647,7 @@ where
 {
     type Output = TrimOut<PrivateXorOut<UInt<Ul, Bl>, Ur>>;
     fn bitxor(self, _: Ur) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+        unsafe { ::core::mem::MaybeUninit::zeroed().assume_init() }
     }
 }
 
@@ -734,7 +752,7 @@ where
 {
     type Output = Shleft<UInt<UInt<U, B>, B0>, Sub1<UInt<Ur, Br>>>;
     fn shl(self, _: UInt<Ur, Br>) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+        unsafe { ::core::mem::MaybeUninit::zeroed().assume_init() }
     }
 }
 
@@ -785,7 +803,7 @@ impl<U: Unsigned, B: Bit> Shr<B0> for UInt<U, B> {
 impl<U: Unsigned, B: Bit> Shr<B1> for UInt<U, B> {
     type Output = U;
     fn shr(self, _: B1) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+        unsafe { ::core::mem::MaybeUninit::zeroed().assume_init() }
     }
 }
 
@@ -797,7 +815,7 @@ where
 {
     type Output = Shright<U, Sub1<UInt<Ur, Br>>>;
     fn shr(self, _: UInt<Ur, Br>) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+        unsafe { ::core::mem::MaybeUninit::zeroed().assume_init() }
     }
 }
 
@@ -859,7 +877,9 @@ where
 {
     type Output = UInt<Prod<Ul, UInt<Ur, B>>, B0>;
     fn mul(self, _: UInt<Ur, B>) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+        UInt {
+            _marker: PhantomData,
+        }
     }
 }
 
@@ -871,7 +891,7 @@ where
 {
     type Output = Sum<UInt<Prod<Ul, UInt<Ur, B>>, B0>, UInt<Ur, B>>;
     fn mul(self, _: UInt<Ur, B>) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+        unsafe { ::core::mem::MaybeUninit::zeroed().assume_init() }
     }
 }
 
@@ -1011,7 +1031,7 @@ where
 
 // ---------------------------------------------------------------------------------------
 // Shifting one number until it's the size of another
-use private::ShiftDiff;
+use crate::private::ShiftDiff;
 impl<Ul: Unsigned, Ur: Unsigned> ShiftDiff<Ur> for Ul
 where
     Ur: BitDiff<Ul>,
@@ -1030,7 +1050,7 @@ where
 {
     type Output = PrivatePowOut<X, U1, N>;
     fn powi(self, _: N) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+        unsafe { ::core::mem::MaybeUninit::zeroed().assume_init() }
     }
 }
 
@@ -1096,8 +1116,8 @@ impl<I> GetBit<I> for UTerm {
 
 #[test]
 fn test_get_bit() {
-    use consts::*;
-    use Same;
+    use crate::consts::*;
+    use crate::Same;
     type T1 = <GetBitOut<U2, U0> as Same<B0>>::Output;
     type T2 = <GetBitOut<U2, U1> as Same<B1>>::Output;
     type T3 = <GetBitOut<U2, U2> as Same<B0>>::Output;
@@ -1119,7 +1139,7 @@ pub trait SetBit<I, B> {
 /// Alias for the result of calling `SetBit`: `SetBitOut<N, I, B> = <N as SetBit<I, B>>::Output`.
 pub type SetBitOut<N, I, B> = <N as SetBit<I, B>>::Output;
 
-use private::{PrivateSetBit, PrivateSetBitOut};
+use crate::private::{PrivateSetBit, PrivateSetBitOut};
 
 // Call private one then trim it
 impl<N, I, B> SetBit<I, B> for N
@@ -1159,8 +1179,8 @@ where
 
 #[test]
 fn test_set_bit() {
-    use consts::*;
-    use Same;
+    use crate::consts::*;
+    use crate::Same;
     type T1 = <SetBitOut<U2, U0, B0> as Same<U2>>::Output;
     type T2 = <SetBitOut<U2, U0, B1> as Same<U3>>::Output;
     type T3 = <SetBitOut<U2, U1, B0> as Same<U0>>::Output;
@@ -1211,8 +1231,8 @@ mod tests {
     }
     #[test]
     fn test_div() {
-        use consts::*;
-        use {Quot, Same};
+        use crate::consts::*;
+        use crate::{Quot, Same};
 
         test_div!(U0 / U1 = U0);
         test_div!(U1 / U1 = U1);
@@ -1234,7 +1254,7 @@ mod tests {
 }
 // -----------------------------------------
 // Div
-use core::ops::Div;
+use ::core::ops::Div;
 
 // 0 // N
 impl<Ur: Unsigned, Br: Bit> Div<UInt<Ur, Br>> for UTerm {
@@ -1253,13 +1273,13 @@ where
 {
     type Output = PrivateDivQuot<UInt<Ul, Bl>, UInt<Ur, Br>, U0, U0, Sub1<Length<UInt<Ul, Bl>>>>;
     fn div(self, _: UInt<Ur, Br>) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+        unsafe { ::core::mem::MaybeUninit::zeroed().assume_init() }
     }
 }
 
 // -----------------------------------------
 // Rem
-use core::ops::Rem;
+use ::core::ops::Rem;
 
 // 0 % N
 impl<Ur: Unsigned, Br: Bit> Rem<UInt<Ur, Br>> for UTerm {
@@ -1278,15 +1298,15 @@ where
 {
     type Output = PrivateDivRem<UInt<Ul, Bl>, UInt<Ur, Br>, U0, U0, Sub1<Length<UInt<Ul, Bl>>>>;
     fn rem(self, _: UInt<Ur, Br>) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+        unsafe { ::core::mem::MaybeUninit::zeroed().assume_init() }
     }
 }
 
 // -----------------------------------------
 // PrivateDiv
-use private::{PrivateDiv, PrivateDivQuot, PrivateDivRem};
+use crate::private::{PrivateDiv, PrivateDivQuot, PrivateDivRem};
 
-use Compare;
+use crate::Compare;
 // R == 0: We set R = UInt<UTerm, N[i]>, then call out to PrivateDivIf for the if statement
 impl<N, D, Q, I> PrivateDiv<N, D, Q, U0, I> for ()
 where
@@ -1355,7 +1375,7 @@ where
 // -----------------------------------------
 // PrivateDivIf
 
-use private::{PrivateDivIf, PrivateDivIfQuot, PrivateDivIfRem};
+use crate::private::{PrivateDivIf, PrivateDivIfQuot, PrivateDivIfRem};
 
 // R < D, I > 0, we do nothing and recurse
 impl<N, D, Q, R, Ui, Bi> PrivateDivIf<N, D, Q, R, UInt<Ui, Bi>, Less> for ()
@@ -1378,7 +1398,7 @@ where
     type Remainder = PrivateDivRem<N, D, SetBitOut<Q, UInt<Ui, Bi>, B1>, U0, Sub1<UInt<Ui, Bi>>>;
 }
 
-use Diff;
+use crate::Diff;
 // R > D, I > 0, we set R -= D, Q[I] = 1 and recurse
 impl<N, D, Q, R, Ui, Bi> PrivateDivIf<N, D, Q, R, UInt<Ui, Bi>, Greater> for ()
 where
@@ -1420,7 +1440,7 @@ where
 
 // -----------------------------------------
 // PartialDiv
-use {PartialDiv, Quot};
+use crate::{PartialDiv, Quot};
 impl<Ur: Unsigned, Br: Bit> PartialDiv<UInt<Ur, Br>> for UTerm {
     type Output = UTerm;
     fn partial_div(self, _: UInt<Ur, Br>) -> Self::Output {
@@ -1435,13 +1455,13 @@ where
 {
     type Output = Quot<UInt<Ul, Bl>, UInt<Ur, Br>>;
     fn partial_div(self, _: UInt<Ur, Br>) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+        unsafe { ::core::mem::MaybeUninit::zeroed().assume_init() }
     }
 }
 
 // -----------------------------------------
 // PrivateMin
-use private::{PrivateMin, PrivateMinOut};
+use crate::private::{PrivateMin, PrivateMinOut};
 
 impl<U, B, Ur> PrivateMin<Ur, Equal> for UInt<U, B>
 where
@@ -1481,7 +1501,7 @@ where
 
 // -----------------------------------------
 // Min
-use Min;
+use crate::Min;
 
 impl<U> Min<U> for UTerm
 where
@@ -1508,7 +1528,7 @@ where
 
 // -----------------------------------------
 // PrivateMax
-use private::{PrivateMax, PrivateMaxOut};
+use crate::private::{PrivateMax, PrivateMaxOut};
 
 impl<U, B, Ur> PrivateMax<Ur, Equal> for UInt<U, B>
 where
@@ -1548,7 +1568,7 @@ where
 
 // -----------------------------------------
 // Max
-use Max;
+use crate::Max;
 
 impl<U> Max<U> for UTerm
 where
@@ -1621,7 +1641,7 @@ where
 
 #[test]
 fn sqrt_test() {
-    use consts::*;
+    use crate::consts::*;
 
     assert_eq!(0, <Sqrt<U0>>::to_u32());
 
@@ -1685,7 +1705,7 @@ where
 
 #[test]
 fn log2_test() {
-    use consts::*;
+    use crate::consts::*;
 
     assert_eq!(0, <Log2<U1>>::to_u32());
 


### PR DESCRIPTION
I was trying to add `#![forbid(unsafe_code)]` but couldn't figure out how to eliminate all the `unsafe { core::mem::uninitialized() }`.

I know these are all ZSTs and eliminating these calls should not help with anything; but I'd like to see them gone. Any ideas?

In the meantime I have updated typenum to 2018 edition, reduced a little of the unsafe code and replaced the deprecated `uninitialized()`s with `MaybeUninit::zeroed().assume_init()`.