### PR TITLE
Add new() method to Bit trait

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+format_code_in_doc_comments = true

--- a/src/bit.rs
+++ b/src/bit.rs
@@ -8,7 +8,6 @@
 //!
 //! - From `core::ops`: `BitAnd`, `BitOr`, `BitXor`, and `Not`.
 //! - From `typenum`: `Same` and `Cmp`.
-//!
 
 use core::ops::{BitAnd, BitOr, BitXor, Not};
 use private::InternalMarker;
@@ -45,6 +44,10 @@ impl Bit for B0 {
     const BOOL: bool = false;
 
     #[inline]
+    fn new() -> Self {
+        Self
+    }
+    #[inline]
     fn to_u8() -> u8 {
         0
     }
@@ -58,6 +61,10 @@ impl Bit for B1 {
     const U8: u8 = 1;
     const BOOL: bool = true;
 
+    #[inline]
+    fn new() -> Self {
+        Self
+    }
     #[inline]
     fn to_u8() -> u8 {
         1
@@ -305,5 +312,24 @@ impl Max<B1> for B1 {
     #[inline]
     fn max(self, _: B1) -> B1 {
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn bit_creation() {
+        {
+            use crate::{B0, B1};
+            let _: B0 = B0::new();
+            let _: B1 = B1::new();
+        }
+
+        {
+            use crate::{Bit, B0, B1};
+
+            let _: B0 = <B0 as Bit>::new();
+            let _: B1 = <B1 as Bit>::new();
+        }
     }
 }

--- a/src/int.rs
+++ b/src/int.rs
@@ -16,7 +16,7 @@
 //!
 //! # Example
 //! ```rust
-//! use std::ops::{Add, Sub, Mul, Div, Rem};
+//! use std::ops::{Add, Div, Mul, Rem, Sub};
 //! use typenum::{Integer, N3, P2};
 //!
 //! assert_eq!(<N3 as Add<P2>>::Output::to_i32(), -1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 //! example,
 //!
 //! ```rust
-//! use typenum::{N4, Integer};
+//! use typenum::{Integer, N4};
 //!
 //! assert_eq!(N4::to_i32(), -4);
 //! ```
@@ -34,14 +34,13 @@
 //! could be replaced with
 //!
 //! ```rust
-//! use typenum::{Sum, Integer, P3, P4};
+//! use typenum::{Integer, Sum, P3, P4};
 //!
 //! type X = Sum<P3, P4>;
 //! assert_eq!(<X as Integer>::to_i32(), 7);
 //! ```
 //!
 //! Documented in each module is the full list of type operators implemented.
-//!
 
 #![no_std]
 #![forbid(unsafe_code)]

--- a/src/marker_traits.rs
+++ b/src/marker_traits.rs
@@ -37,6 +37,9 @@ pub trait Bit: Copy + Default {
     #[allow(missing_docs)]
     const BOOL: bool;
 
+    /// Instantiates a singleton representing this bit.
+    fn new() -> Self;
+
     #[allow(missing_docs)]
     fn to_u8() -> u8;
     #[allow(missing_docs)]

--- a/src/marker_traits.rs
+++ b/src/marker_traits.rs
@@ -9,7 +9,7 @@
 //! to_i32() -> i32` and the associated constant `I32` so that one can do this:
 //!
 //! ```
-//! use typenum::{N42, Integer};
+//! use typenum::{Integer, N42};
 //!
 //! assert_eq!(-42, N42::to_i32());
 //! assert_eq!(-42, N42::I32);
@@ -49,7 +49,7 @@ pub trait Bit: Copy + Default {
 ///
 /// # Example
 /// ```rust
-/// use typenum::{U3, Unsigned};
+/// use typenum::{Unsigned, U3};
 ///
 /// assert_eq!(U3::to_u32(), 3);
 /// assert_eq!(U3::I32, 3);
@@ -118,7 +118,7 @@ pub trait Unsigned: Copy + Default {
 ///
 /// # Example
 /// ```rust
-/// use typenum::{P3, Integer};
+/// use typenum::{Integer, P3};
 ///
 /// assert_eq!(P3::to_i32(), 3);
 /// assert_eq!(P3::I32, 3);
@@ -171,9 +171,9 @@ pub trait TypeArray {}
 /// Here's a working example:
 ///
 /// ```rust
-/// use typenum::{P4, P8, PowerOfTwo};
+/// use typenum::{PowerOfTwo, P4, P8};
 ///
-/// fn only_p2<P: PowerOfTwo>() { }
+/// fn only_p2<P: PowerOfTwo>() {}
 ///
 /// only_p2::<P4>();
 /// only_p2::<P8>();

--- a/src/type_operators.rs
+++ b/src/type_operators.rs
@@ -15,7 +15,7 @@ use {Bit, NInt, NonZero, PInt, UInt, UTerm, Unsigned, Z0};
 ///
 /// # Example
 /// ```rust
-/// use typenum::{Same, U4, U5, Unsigned};
+/// use typenum::{Same, Unsigned, U4, U5};
 ///
 /// assert_eq!(<U5 as Same<U5>>::Output::to_u32(), 5);
 ///
@@ -38,7 +38,7 @@ impl<T> Same<T> for T {
 ///
 /// # Example
 /// ```rust
-/// use typenum::{Abs, N5, Integer};
+/// use typenum::{Abs, Integer, N5};
 ///
 /// assert_eq!(<N5 as Abs>::Output::to_i32(), 5);
 /// ```
@@ -63,7 +63,7 @@ impl<U: Unsigned + NonZero> Abs for NInt<U> {
 ///
 /// # Example
 /// ```rust
-/// use typenum::{Pow, N3, P3, Integer};
+/// use typenum::{Integer, Pow, N3, P3};
 ///
 /// assert_eq!(<N3 as Pow<P3>>::Output::to_i32(), -27);
 /// ```
@@ -550,7 +550,7 @@ pub trait Logarithm2 {
 /// # Example
 ///
 /// ```rust
-/// use typenum::{Gcd, U12, U8, Unsigned};
+/// use typenum::{Gcd, Unsigned, U12, U8};
 ///
 /// assert_eq!(<U12 as Gcd<U8>>::Output::to_i32(), 4);
 /// ```

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -12,7 +12,7 @@
 //!
 //! # Example
 //! ```rust
-//! use std::ops::{BitAnd, BitOr, BitXor, Shl, Shr, Add, Sub, Mul, Div, Rem};
+//! use std::ops::{Add, BitAnd, BitOr, BitXor, Div, Mul, Rem, Shl, Shr, Sub};
 //! use typenum::{Unsigned, U1, U2, U3, U4};
 //!
 //! assert_eq!(<U3 as BitAnd<U2>>::Output::to_u32(), 2);
@@ -146,7 +146,7 @@ impl Unsigned for UTerm {
 ///
 /// # Example
 /// ```rust
-/// use typenum::{B0, B1, UInt, UTerm};
+/// use typenum::{UInt, UTerm, B0, B1};
 ///
 /// # #[allow(dead_code)]
 /// type U6 = UInt<UInt<UInt<UTerm, B1>, B1>, B0>;


### PR DESCRIPTION
This PR moves `new()` from `B0` and `B1` to `Bit` trait.
It lets the methods with `Bit` on return type generics to complete by calling `Bit::new()`.