### PR TITLE
Remove uses of `unsafe`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The MSRV (Minimum Supported Rust Version) is 1.22.0, and typenum is tested again
 version. Much of typenum should work on as low a version as 1.20.0, but that is not guaranteed.
 
 ### Unreleased
+- [changed] Added `Copy` bound to `Rhs` of `Mul<Rhs>` impl for `<TArr<V, A>`.
+- [changed] Added `Copy` bound to `Rhs` of `Div<Rhs>` impl for `<TArr<V, A>`.
+- [changed] Added `Copy` bound to `Rhs` of `PartialDiv<Rhs>` impl for `<TArr<V, A>`.
+- [changed] Added `Copy` bound to `Rhs` of `Rem<Rhs>` impl for `<TArr<V, A>`.
 
 ### 1.11.2 (2019-08-26)
 - [fixed] Cross compilation from Linux to Windows.

--- a/build/main.rs
+++ b/build/main.rs
@@ -58,12 +58,12 @@ pub fn gen_uint(u: u64) -> UIntCode {
 }
 
 pub fn gen_int(i: i64) -> IntCode {
-    if i > 0 {
-        IntCode::Pos(Box::new(gen_uint(i as u64)))
-    } else if i < 0 {
-        IntCode::Neg(Box::new(gen_uint(i.abs() as u64)))
-    } else {
-        IntCode::Zero
+    use std::cmp::Ordering::{Equal, Greater, Less};
+
+    match i.cmp(&0) {
+        Greater => IntCode::Pos(Box::new(gen_uint(i as u64))),
+        Less => IntCode::Neg(Box::new(gen_uint(i.abs() as u64))),
+        Equal => IntCode::Zero,
     }
 }
 
@@ -166,12 +166,12 @@ pub mod consts {{
     .unwrap();
 
     for u in uints {
-        write!(f, "    pub type U{} = {};\n", u, gen_uint(u)).unwrap();
+        writeln!(f, "    pub type U{} = {};", u, gen_uint(u)).unwrap();
         if u <= ::std::i64::MAX as u64 && u != 0 {
             let i = u as i64;
-            write!(
+            writeln!(
                 f,
-                "    pub type P{i} = PInt<U{i}>; pub type N{i} = NInt<U{i}>;\n",
+                "    pub type P{i} = PInt<U{i}>; pub type N{i} = NInt<U{i}>;",
                 i = i
             )
             .unwrap();

--- a/src/array.rs
+++ b/src/array.rs
@@ -90,8 +90,8 @@ where
     type Output = TArr<Sum<Vl, Vr>, Sum<Al, Ar>>;
     fn add(self, rhs: TArr<Vr, Ar>) -> Self::Output {
         TArr {
-            first:  self.first + rhs.first,
-            rest:   self.rest  + rhs.rest,
+            first: self.first + rhs.first,
+            rest: self.rest + rhs.rest,
         }
     }
 }
@@ -115,8 +115,8 @@ where
     type Output = TArr<Diff<Vl, Vr>, Diff<Al, Ar>>;
     fn sub(self, rhs: TArr<Vr, Ar>) -> Self::Output {
         TArr {
-            first:  self.first - rhs.first,
-            rest:   self.rest  - rhs.rest,
+            first: self.first - rhs.first,
+            rest: self.rest - rhs.rest,
         }
     }
 }
@@ -140,8 +140,8 @@ where
     type Output = TArr<Prod<V, Rhs>, Prod<A, Rhs>>;
     fn mul(self, rhs: Rhs) -> Self::Output {
         TArr {
-            first:  self.first * rhs,
-            rest:   self.rest  * rhs,
+            first: self.first * rhs,
+            rest: self.rest * rhs,
         }
     }
 }
@@ -180,8 +180,8 @@ where
     type Output = TArr<Z0, Prod<Z0, A>>;
     fn mul(self, rhs: TArr<V, A>) -> Self::Output {
         TArr {
-            first:  Z0,
-            rest:   self * rhs.rest,
+            first: Z0,
+            rest: self * rhs.rest,
         }
     }
 }
@@ -194,8 +194,8 @@ where
     type Output = TArr<Prod<PInt<U>, V>, Prod<PInt<U>, A>>;
     fn mul(self, rhs: TArr<V, A>) -> Self::Output {
         TArr {
-            first:  self * rhs.first,
-            rest:   self * rhs.rest,
+            first: self * rhs.first,
+            rest: self * rhs.rest,
         }
     }
 }
@@ -208,8 +208,8 @@ where
     type Output = TArr<Prod<NInt<U>, V>, Prod<NInt<U>, A>>;
     fn mul(self, rhs: TArr<V, A>) -> Self::Output {
         TArr {
-            first:  self * rhs.first,
-            rest:   self * rhs.rest,
+            first: self * rhs.first,
+            rest: self * rhs.rest,
         }
     }
 }
@@ -233,8 +233,8 @@ where
     type Output = TArr<Quot<V, Rhs>, Quot<A, Rhs>>;
     fn div(self, rhs: Rhs) -> Self::Output {
         TArr {
-            first:  self.first / rhs,
-            rest:   self.rest  / rhs,
+            first: self.first / rhs,
+            rest: self.rest / rhs,
         }
     }
 }
@@ -258,8 +258,8 @@ where
     type Output = TArr<PartialQuot<V, Rhs>, PartialQuot<A, Rhs>>;
     fn partial_div(self, rhs: Rhs) -> Self::Output {
         TArr {
-            first:  self.first.partial_div(rhs),
-            rest:   self.rest.partial_div(rhs),
+            first: self.first.partial_div(rhs),
+            rest: self.rest.partial_div(rhs),
         }
     }
 }
@@ -284,8 +284,8 @@ where
     type Output = TArr<Mod<V, Rhs>, Mod<A, Rhs>>;
     fn rem(self, rhs: Rhs) -> Self::Output {
         TArr {
-            first:  self.first % rhs,
-            rest:   self.rest  % rhs,
+            first: self.first % rhs,
+            rest: self.rest % rhs,
         }
     }
 }
@@ -309,8 +309,8 @@ where
     type Output = TArr<Negate<V>, Negate<A>>;
     fn neg(self) -> Self::Output {
         TArr {
-            first:  -self.first,
-            rest:   -self.rest,
+            first: -self.first,
+            rest: -self.rest,
         }
     }
 }

--- a/src/array.rs
+++ b/src/array.rs
@@ -2,7 +2,6 @@
 //!
 //! It is not very featureful right now, and should be considered a work in progress.
 
-use core::marker::PhantomData;
 use core::ops::{Add, Div, Mul, Sub};
 
 use super::*;
@@ -21,7 +20,8 @@ impl TypeArray for ATerm {}
 /// may find it lacking functionality.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug)]
 pub struct TArr<V, A> {
-    _marker: PhantomData<(V, A)>,
+    first: V,
+    rest: A,
 }
 
 impl<V, A> TypeArray for TArr<V, A> {}
@@ -67,7 +67,7 @@ where
 {
     type Output = Add1<Length<A>>;
     fn len(&self) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+        self.rest.len() + B1
     }
 }
 
@@ -88,8 +88,11 @@ where
     Vl: Add<Vr>,
 {
     type Output = TArr<Sum<Vl, Vr>, Sum<Al, Ar>>;
-    fn add(self, _: TArr<Vr, Ar>) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+    fn add(self, rhs: TArr<Vr, Ar>) -> Self::Output {
+        TArr {
+            first:  self.first + rhs.first,
+            rest:   self.rest  + rhs.rest,
+        }
     }
 }
 
@@ -110,8 +113,11 @@ where
     Al: Sub<Ar>,
 {
     type Output = TArr<Diff<Vl, Vr>, Diff<Al, Ar>>;
-    fn sub(self, _: TArr<Vr, Ar>) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+    fn sub(self, rhs: TArr<Vr, Ar>) -> Self::Output {
+        TArr {
+            first:  self.first - rhs.first,
+            rest:   self.rest  - rhs.rest,
+        }
     }
 }
 
@@ -129,10 +135,14 @@ impl<V, A, Rhs> Mul<Rhs> for TArr<V, A>
 where
     V: Mul<Rhs>,
     A: Mul<Rhs>,
+    Rhs: Copy,
 {
     type Output = TArr<Prod<V, Rhs>, Prod<A, Rhs>>;
-    fn mul(self, _: Rhs) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+    fn mul(self, rhs: Rhs) -> Self::Output {
+        TArr {
+            first:  self.first * rhs,
+            rest:   self.rest  * rhs,
+        }
     }
 }
 
@@ -168,8 +178,11 @@ where
     Z0: Mul<A>,
 {
     type Output = TArr<Z0, Prod<Z0, A>>;
-    fn mul(self, _: TArr<V, A>) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+    fn mul(self, rhs: TArr<V, A>) -> Self::Output {
+        TArr {
+            first:  Z0,
+            rest:   self * rhs.rest,
+        }
     }
 }
 
@@ -179,8 +192,11 @@ where
     PInt<U>: Mul<A> + Mul<V>,
 {
     type Output = TArr<Prod<PInt<U>, V>, Prod<PInt<U>, A>>;
-    fn mul(self, _: TArr<V, A>) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+    fn mul(self, rhs: TArr<V, A>) -> Self::Output {
+        TArr {
+            first:  self * rhs.first,
+            rest:   self * rhs.rest,
+        }
     }
 }
 
@@ -190,8 +206,11 @@ where
     NInt<U>: Mul<A> + Mul<V>,
 {
     type Output = TArr<Prod<NInt<U>, V>, Prod<NInt<U>, A>>;
-    fn mul(self, _: TArr<V, A>) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+    fn mul(self, rhs: TArr<V, A>) -> Self::Output {
+        TArr {
+            first:  self * rhs.first,
+            rest:   self * rhs.rest,
+        }
     }
 }
 
@@ -209,10 +228,14 @@ impl<V, A, Rhs> Div<Rhs> for TArr<V, A>
 where
     V: Div<Rhs>,
     A: Div<Rhs>,
+    Rhs: Copy,
 {
     type Output = TArr<Quot<V, Rhs>, Quot<A, Rhs>>;
-    fn div(self, _: Rhs) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+    fn div(self, rhs: Rhs) -> Self::Output {
+        TArr {
+            first:  self.first / rhs,
+            rest:   self.rest  / rhs,
+        }
     }
 }
 
@@ -230,10 +253,14 @@ impl<V, A, Rhs> PartialDiv<Rhs> for TArr<V, A>
 where
     V: PartialDiv<Rhs>,
     A: PartialDiv<Rhs>,
+    Rhs: Copy,
 {
     type Output = TArr<PartialQuot<V, Rhs>, PartialQuot<A, Rhs>>;
-    fn partial_div(self, _: Rhs) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+    fn partial_div(self, rhs: Rhs) -> Self::Output {
+        TArr {
+            first:  self.first.partial_div(rhs),
+            rest:   self.rest.partial_div(rhs),
+        }
     }
 }
 
@@ -252,10 +279,14 @@ impl<V, A, Rhs> Rem<Rhs> for TArr<V, A>
 where
     V: Rem<Rhs>,
     A: Rem<Rhs>,
+    Rhs: Copy,
 {
     type Output = TArr<Mod<V, Rhs>, Mod<A, Rhs>>;
-    fn rem(self, _: Rhs) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+    fn rem(self, rhs: Rhs) -> Self::Output {
+        TArr {
+            first:  self.first % rhs,
+            rest:   self.rest  % rhs,
+        }
     }
 }
 
@@ -277,6 +308,9 @@ where
 {
     type Output = TArr<Negate<V>, Negate<A>>;
     fn neg(self) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+        TArr {
+            first:  -self.first,
+            rest:   -self.rest,
+        }
     }
 }

--- a/src/bit.rs
+++ b/src/bit.rs
@@ -11,8 +11,8 @@
 //!
 
 use core::ops::{BitAnd, BitOr, BitXor, Not};
-use {Cmp, Equal, Greater, Less, NonZero, PowerOfTwo};
 use private::InternalMarker;
+use {Cmp, Equal, Greater, Less, NonZero, PowerOfTwo};
 
 pub use marker_traits::Bit;
 

--- a/src/bit.rs
+++ b/src/bit.rs
@@ -12,6 +12,7 @@
 
 use core::ops::{BitAnd, BitOr, BitXor, Not};
 use {Cmp, Equal, Greater, Less, NonZero, PowerOfTwo};
+use private::InternalMarker;
 
 pub use marker_traits::Bit;
 
@@ -201,18 +202,34 @@ mod tests {
 
 impl Cmp<B0> for B0 {
     type Output = Equal;
+
+    fn compare<P: InternalMarker>(&self, _: &B0) -> Self::Output {
+        Equal
+    }
 }
 
 impl Cmp<B1> for B0 {
     type Output = Less;
+
+    fn compare<P: InternalMarker>(&self, _: &B1) -> Self::Output {
+        Less
+    }
 }
 
 impl Cmp<B0> for B1 {
     type Output = Greater;
+
+    fn compare<P: InternalMarker>(&self, _: &B0) -> Self::Output {
+        Greater
+    }
 }
 
 impl Cmp<B1> for B1 {
     type Output = Equal;
+
+    fn compare<P: InternalMarker>(&self, _: &B1) -> Self::Output {
+        Equal
+    }
 }
 
 use Min;

--- a/src/int.rs
+++ b/src/int.rs
@@ -27,12 +27,12 @@
 //! ```
 //!
 
-use core::marker::PhantomData;
 use core::ops::{Add, Div, Mul, Neg, Rem, Sub};
 
 use bit::{Bit, B0, B1};
 use consts::{N1, P1, U0, U1};
 use private::{PrivateDivInt, PrivateIntegerAdd, PrivateRem};
+use private::{Internal, InternalMarker};
 use uint::{UInt, Unsigned};
 use {Cmp, Equal, Greater, Less, NonZero, Pow, PowerOfTwo};
 
@@ -41,22 +41,20 @@ pub use marker_traits::Integer;
 /// Type-level signed integers with positive sign.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug, Default)]
 pub struct PInt<U: Unsigned + NonZero> {
-    _marker: PhantomData<U>,
+    pub(crate) n: U
 }
 
 /// Type-level signed integers with negative sign.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug, Default)]
 pub struct NInt<U: Unsigned + NonZero> {
-    _marker: PhantomData<U>,
+    pub(crate) n: U
 }
 
 impl<U: Unsigned + NonZero> PInt<U> {
     /// Instantiates a singleton representing this strictly positive integer.
     #[inline]
     pub fn new() -> PInt<U> {
-        PInt {
-            _marker: PhantomData,
-        }
+        PInt::default()
     }
 }
 
@@ -64,9 +62,7 @@ impl<U: Unsigned + NonZero> NInt<U> {
     /// Instantiates a singleton representing this strictly negative integer.
     #[inline]
     pub fn new() -> NInt<U> {
-        NInt {
-            _marker: PhantomData,
-        }
+        NInt::default()
     }
 }
 
@@ -230,8 +226,8 @@ impl<U: Unsigned + NonZero> Neg for NInt<U> {
 /// `Z0 + I = I`
 impl<I: Integer> Add<I> for Z0 {
     type Output = I;
-    fn add(self, _: I) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+    fn add(self, rhs: I) -> Self::Output {
+        rhs
     }
 }
 
@@ -281,8 +277,11 @@ where
     Ul: Cmp<Ur> + PrivateIntegerAdd<<Ul as Cmp<Ur>>::Output, Ur>,
 {
     type Output = <Ul as PrivateIntegerAdd<<Ul as Cmp<Ur>>::Output, Ur>>::Output;
-    fn add(self, _: NInt<Ur>) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+    fn add(self, rhs: NInt<Ur>) -> Self::Output {
+        let lhs = self.n;
+        let rhs = rhs.n;
+        let lhs_cmp_rhs = lhs.compare::<Internal>(&rhs);
+        lhs.private_integer_add(lhs_cmp_rhs, rhs)
     }
 }
 
@@ -293,14 +292,21 @@ where
     Ur: Cmp<Ul> + PrivateIntegerAdd<<Ur as Cmp<Ul>>::Output, Ul>,
 {
     type Output = <Ur as PrivateIntegerAdd<<Ur as Cmp<Ul>>::Output, Ul>>::Output;
-    fn add(self, _: PInt<Ur>) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+    fn add(self, rhs: PInt<Ur>) -> Self::Output {
+        let lhs = self.n;
+        let rhs = rhs.n;
+        let rhs_cmp_lhs = rhs.compare::<Internal>(&lhs);
+        rhs.private_integer_add(rhs_cmp_lhs, lhs)
     }
 }
 
 /// `P + N = 0` where `P == N`
 impl<N: Unsigned, P: Unsigned> PrivateIntegerAdd<Equal, N> for P {
     type Output = Z0;
+
+    fn private_integer_add(self, _: Equal, _: N) -> Self::Output {
+        Z0
+    }
 }
 
 /// `P + N = Positive` where `P > N`
@@ -310,6 +316,10 @@ where
     <P as Sub<N>>::Output: Unsigned + NonZero,
 {
     type Output = PInt<<P as Sub<N>>::Output>;
+
+    fn private_integer_add(self, _: Greater, n: N) -> Self::Output {
+        PInt { n: self - n }
+    }
 }
 
 /// `P + N = Negative` where `P < N`
@@ -319,6 +329,10 @@ where
     <N as Sub<P>>::Output: Unsigned + NonZero,
 {
     type Output = NInt<<N as Sub<P>>::Output>;
+
+    fn private_integer_add(self, _: Less, n: N) -> Self::Output {
+        NInt { n: n - self }
+    }
 }
 
 // ---------------------------------------------------------------------------------------
@@ -394,8 +408,11 @@ where
     Ul: Cmp<Ur> + PrivateIntegerAdd<<Ul as Cmp<Ur>>::Output, Ur>,
 {
     type Output = <Ul as PrivateIntegerAdd<<Ul as Cmp<Ur>>::Output, Ur>>::Output;
-    fn sub(self, _: PInt<Ur>) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+    fn sub(self, rhs: PInt<Ur>) -> Self::Output {
+        let lhs = self.n;
+        let rhs = rhs.n;
+        let lhs_cmp_rhs = lhs.compare::<Internal>(&rhs);
+        lhs.private_integer_add(lhs_cmp_rhs, rhs)
     }
 }
 
@@ -406,8 +423,11 @@ where
     Ur: Cmp<Ul> + PrivateIntegerAdd<<Ur as Cmp<Ul>>::Output, Ul>,
 {
     type Output = <Ur as PrivateIntegerAdd<<Ur as Cmp<Ul>>::Output, Ul>>::Output;
-    fn sub(self, _: NInt<Ur>) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+    fn sub(self, rhs: NInt<Ur>) -> Self::Output {
+        let lhs = self.n;
+        let rhs = rhs.n;
+        let rhs_cmp_lhs = rhs.compare::<Internal>(&lhs);
+        rhs.private_integer_add(rhs_cmp_lhs, lhs)
     }
 }
 
@@ -506,8 +526,9 @@ macro_rules! impl_int_div {
             $A<Ul>: PrivateDivInt<<Ul as Cmp<Ur>>::Output, $B<Ur>>,
         {
             type Output = <$A<Ul> as PrivateDivInt<<Ul as Cmp<Ur>>::Output, $B<Ur>>>::Output;
-            fn div(self, _: $B<Ur>) -> Self::Output {
-                unsafe { ::core::mem::uninitialized() }
+            fn div(self, rhs: $B<Ur>) -> Self::Output {
+                let lhs_cmp_rhs = self.n.compare::<Internal>(&rhs.n);
+                self.private_div_int(lhs_cmp_rhs, rhs)
             }
         }
         impl<Ul, Ur> PrivateDivInt<Less, $B<Ur>> for $A<Ul>
@@ -516,6 +537,10 @@ macro_rules! impl_int_div {
             Ur: Unsigned + NonZero,
         {
             type Output = Z0;
+
+            fn private_div_int(self, _: Less, _: $B<Ur>) -> Self::Output {
+                Z0
+            }
         }
         impl<Ul, Ur> PrivateDivInt<Equal, $B<Ur>> for $A<Ul>
         where
@@ -523,6 +548,10 @@ macro_rules! impl_int_div {
             Ur: Unsigned + NonZero,
         {
             type Output = $R<U1>;
+
+            fn private_div_int(self, _: Equal, _: $B<Ur>) -> Self::Output {
+                $R { n: U1::new() }
+            }
         }
         impl<Ul, Ur> PrivateDivInt<Greater, $B<Ur>> for $A<Ul>
         where
@@ -531,6 +560,10 @@ macro_rules! impl_int_div {
             <Ul as Div<Ur>>::Output: Unsigned + NonZero,
         {
             type Output = $R<<Ul as Div<Ur>>::Output>;
+
+            fn private_div_int(self, _: Greater, d: $B<Ur>) -> Self::Output {
+                $R { n: self.n / d.n }
+            }
         }
     };
 }
@@ -550,8 +583,8 @@ where
     M: Integer + Div<N> + Rem<N, Output = Z0>,
 {
     type Output = Quot<M, N>;
-    fn partial_div(self, _: N) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+    fn partial_div(self, rhs: N) -> Self::Output {
+        self / rhs
     }
 }
 
@@ -561,46 +594,82 @@ where
 /// 0 == 0
 impl Cmp<Z0> for Z0 {
     type Output = Equal;
+
+    fn compare<IM: InternalMarker>(&self, _: &Z0) -> Self::Output {
+        Equal
+    }
 }
 
 /// 0 > -X
 impl<U: Unsigned + NonZero> Cmp<NInt<U>> for Z0 {
     type Output = Greater;
+
+    fn compare<IM: InternalMarker>(&self, _: &NInt<U>) -> Self::Output {
+        Greater
+    }
 }
 
 /// 0 < X
 impl<U: Unsigned + NonZero> Cmp<PInt<U>> for Z0 {
     type Output = Less;
+
+    fn compare<IM: InternalMarker>(&self, _: &PInt<U>) -> Self::Output {
+        Less
+    }
 }
 
 /// X > 0
 impl<U: Unsigned + NonZero> Cmp<Z0> for PInt<U> {
     type Output = Greater;
+
+    fn compare<IM: InternalMarker>(&self, _: &Z0) -> Self::Output {
+        Greater
+    }
 }
 
 /// -X < 0
 impl<U: Unsigned + NonZero> Cmp<Z0> for NInt<U> {
     type Output = Less;
+
+    fn compare<IM: InternalMarker>(&self, _: &Z0) -> Self::Output {
+        Less
+    }
 }
 
 /// -X < Y
 impl<P: Unsigned + NonZero, N: Unsigned + NonZero> Cmp<PInt<P>> for NInt<N> {
     type Output = Less;
+
+    fn compare<IM: InternalMarker>(&self, _: &PInt<P>) -> Self::Output {
+        Less
+    }
 }
 
 /// X > - Y
 impl<P: Unsigned + NonZero, N: Unsigned + NonZero> Cmp<NInt<N>> for PInt<P> {
     type Output = Greater;
+
+    fn compare<IM: InternalMarker>(&self, _: &NInt<N>) -> Self::Output {
+        Greater
+    }
 }
 
 /// X <==> Y
 impl<Pl: Cmp<Pr> + Unsigned + NonZero, Pr: Unsigned + NonZero> Cmp<PInt<Pr>> for PInt<Pl> {
     type Output = <Pl as Cmp<Pr>>::Output;
+
+    fn compare<IM: InternalMarker>(&self, rhs: &PInt<Pr>) -> Self::Output {
+        self.n.compare::<Internal>(&rhs.n)
+    }
 }
 
 /// -X <==> -Y
 impl<Nl: Unsigned + NonZero, Nr: Cmp<Nl> + Unsigned + NonZero> Cmp<NInt<Nr>> for NInt<Nl> {
     type Output = <Nr as Cmp<Nl>>::Output;
+
+    fn compare<IM: InternalMarker>(&self, rhs: &NInt<Nr>) -> Self::Output {
+        rhs.n.compare::<Internal>(&self.n)
+    }
 }
 
 // ---------------------------------------------------------------------------------------
@@ -623,12 +692,16 @@ macro_rules! impl_int_rem {
             $A<Ul>: PrivateRem<<Ul as Rem<Ur>>::Output, $B<Ur>>,
         {
             type Output = <$A<Ul> as PrivateRem<<Ul as Rem<Ur>>::Output, $B<Ur>>>::Output;
-            fn rem(self, _: $B<Ur>) -> Self::Output {
-                unsafe { ::core::mem::uninitialized() }
+            fn rem(self, rhs: $B<Ur>) -> Self::Output {
+                self.private_rem(self.n % rhs.n, rhs)
             }
         }
         impl<Ul: Unsigned + NonZero, Ur: Unsigned + NonZero> PrivateRem<U0, $B<Ur>> for $A<Ul> {
             type Output = Z0;
+
+            fn private_rem(self, _: U0, _: $B<Ur>) -> Self::Output {
+                Z0
+            }
         }
         impl<Ul, Ur, U, B> PrivateRem<UInt<U, B>, $B<Ur>> for $A<Ul>
         where
@@ -638,6 +711,10 @@ macro_rules! impl_int_rem {
             B: Bit,
         {
             type Output = $R<UInt<U, B>>;
+
+            fn private_rem(self, urem: UInt<U, B>, _: $B<Ur>) -> Self::Output {
+                $R { n: urem }
+            }
         }
     };
 }
@@ -808,8 +885,8 @@ where
     Minimum<Ul, Ur>: Unsigned + NonZero,
 {
     type Output = PInt<Minimum<Ul, Ur>>;
-    fn min(self, _: PInt<Ur>) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+    fn min(self, rhs: PInt<Ur>) -> Self::Output {
+        PInt { n: self.n.min(rhs.n) }
     }
 }
 
@@ -842,8 +919,8 @@ where
     Maximum<Ul, Ur>: Unsigned + NonZero,
 {
     type Output = NInt<Maximum<Ul, Ur>>;
-    fn min(self, _: NInt<Ur>) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+    fn min(self, rhs: NInt<Ur>) -> Self::Output {
+        NInt { n: self.n.max(rhs.n) }
     }
 }
 
@@ -904,8 +981,8 @@ where
     Maximum<Ul, Ur>: Unsigned + NonZero,
 {
     type Output = PInt<Maximum<Ul, Ur>>;
-    fn max(self, _: PInt<Ur>) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+    fn max(self, rhs: PInt<Ur>) -> Self::Output {
+        PInt { n: self.n.max(rhs.n) }
     }
 }
 
@@ -938,8 +1015,8 @@ where
     Minimum<Ul, Ur>: Unsigned + NonZero,
 {
     type Output = NInt<Minimum<Ul, Ur>>;
-    fn max(self, _: NInt<Ur>) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+    fn max(self, rhs: NInt<Ur>) -> Self::Output {
+        NInt { n: self.n.min(rhs.n) }
     }
 }
 

--- a/src/int.rs
+++ b/src/int.rs
@@ -31,8 +31,8 @@ use core::ops::{Add, Div, Mul, Neg, Rem, Sub};
 
 use bit::{Bit, B0, B1};
 use consts::{N1, P1, U0, U1};
-use private::{PrivateDivInt, PrivateIntegerAdd, PrivateRem};
 use private::{Internal, InternalMarker};
+use private::{PrivateDivInt, PrivateIntegerAdd, PrivateRem};
 use uint::{UInt, Unsigned};
 use {Cmp, Equal, Greater, Less, NonZero, Pow, PowerOfTwo};
 
@@ -41,13 +41,13 @@ pub use marker_traits::Integer;
 /// Type-level signed integers with positive sign.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug, Default)]
 pub struct PInt<U: Unsigned + NonZero> {
-    pub(crate) n: U
+    pub(crate) n: U,
 }
 
 /// Type-level signed integers with negative sign.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug, Default)]
 pub struct NInt<U: Unsigned + NonZero> {
-    pub(crate) n: U
+    pub(crate) n: U,
 }
 
 impl<U: Unsigned + NonZero> PInt<U> {
@@ -886,7 +886,9 @@ where
 {
     type Output = PInt<Minimum<Ul, Ur>>;
     fn min(self, rhs: PInt<Ur>) -> Self::Output {
-        PInt { n: self.n.min(rhs.n) }
+        PInt {
+            n: self.n.min(rhs.n),
+        }
     }
 }
 
@@ -920,7 +922,9 @@ where
 {
     type Output = NInt<Maximum<Ul, Ur>>;
     fn min(self, rhs: NInt<Ur>) -> Self::Output {
-        NInt { n: self.n.max(rhs.n) }
+        NInt {
+            n: self.n.max(rhs.n),
+        }
     }
 }
 
@@ -982,7 +986,9 @@ where
 {
     type Output = PInt<Maximum<Ul, Ur>>;
     fn max(self, rhs: PInt<Ur>) -> Self::Output {
-        PInt { n: self.n.max(rhs.n) }
+        PInt {
+            n: self.n.max(rhs.n),
+        }
     }
 }
 
@@ -1016,7 +1022,9 @@ where
 {
     type Output = NInt<Minimum<Ul, Ur>>;
     fn max(self, rhs: NInt<Ur>) -> Self::Output {
-        NInt { n: self.n.min(rhs.n) }
+        NInt {
+            n: self.n.min(rhs.n),
+        }
     }
 }
 

--- a/src/marker_traits.rs
+++ b/src/marker_traits.rs
@@ -31,7 +31,7 @@ pub trait Ord {
 /// The **marker trait** for compile time bits.
 ///
 /// This trait should not be implemented for anything outside this crate.
-pub trait Bit {
+pub trait Bit: Copy + Default {
     #[allow(missing_docs)]
     const U8: u8;
     #[allow(missing_docs)]
@@ -54,7 +54,7 @@ pub trait Bit {
 /// assert_eq!(U3::to_u32(), 3);
 /// assert_eq!(U3::I32, 3);
 /// ```
-pub trait Unsigned {
+pub trait Unsigned: Copy + Default {
     #[allow(missing_docs)]
     const U8: u8;
     #[allow(missing_docs)]

--- a/src/private.rs
+++ b/src/private.rs
@@ -21,13 +21,21 @@
 
 #![doc(hidden)]
 
-// use ::{Sub};
 use bit::{Bit, B0, B1};
 use uint::{UInt, UTerm, Unsigned};
+
+/// A marker for restricting a method on a public trait to internal use only.
+pub(crate) enum Internal {}
+
+pub trait InternalMarker {}
+
+impl InternalMarker for Internal {}
 
 /// Convenience trait. Calls `Invert` -> `TrimTrailingZeros` -> `Invert`
 pub trait Trim {
     type Output;
+
+    fn trim(self) -> Self::Output;
 }
 pub type TrimOut<A> = <A as Trim>::Output;
 
@@ -36,6 +44,8 @@ pub type TrimOut<A> = <A as Trim>::Output;
 // ONLY IMPLEMENT FOR INVERTED NUMBERS!
 pub trait TrimTrailingZeros {
     type Output;
+
+    fn trim_trailing_zeros(self) -> Self::Output;
 }
 pub type TrimTrailingZerosOut<A> = <A as TrimTrailingZeros>::Output;
 
@@ -43,6 +53,8 @@ pub type TrimTrailingZerosOut<A> = <A as TrimTrailingZeros>::Output;
 /// digit on the outside.
 pub trait Invert {
     type Output;
+
+    fn invert(self) -> Self::Output;
 }
 pub type InvertOut<A> = <A as Invert>::Output;
 
@@ -50,32 +62,41 @@ pub type InvertOut<A> = <A as Invert>::Output;
 /// The Rhs is what we've got so far.
 pub trait PrivateInvert<Rhs> {
     type Output;
+
+    fn private_invert(self, Rhs) -> Self::Output;
 }
 pub type PrivateInvertOut<A, Rhs> = <A as PrivateInvert<Rhs>>::Output;
 
 /// Terminating character for `InvertedUInt`s
-pub enum InvertedUTerm {}
+pub struct InvertedUTerm;
 
 /// Inverted `UInt` (has most significant digit on the outside)
 pub struct InvertedUInt<IU: InvertedUnsigned, B: Bit> {
-    _marker: (IU, B),
+    msb: IU,
+    lsb: B,
 }
 
 /// Does the real anding for `UInt`s; `And` just calls this and then `Trim`.
 pub trait PrivateAnd<Rhs = Self> {
     type Output;
+
+    fn private_and(self, Rhs) -> Self::Output;
 }
 pub type PrivateAndOut<A, Rhs> = <A as PrivateAnd<Rhs>>::Output;
 
 /// Does the real xoring for `UInt`s; `Xor` just calls this and then `Trim`.
 pub trait PrivateXor<Rhs = Self> {
     type Output;
+
+    fn private_xor(self, Rhs) -> Self::Output;
 }
 pub type PrivateXorOut<A, Rhs> = <A as PrivateXor<Rhs>>::Output;
 
 /// Does the real subtraction for `UInt`s; `Sub` just calls this and then `Trim`.
 pub trait PrivateSub<Rhs = Self> {
     type Output;
+
+    fn private_sub(self, Rhs) -> Self::Output;
 }
 pub type PrivateSubOut<A, Rhs> = <A as PrivateSub<Rhs>>::Output;
 
@@ -84,11 +105,15 @@ pub type PrivateSubOut<A, Rhs> = <A as PrivateSub<Rhs>>::Output;
 /// where `P` and `N` are both passed as unsigned integers
 pub trait PrivateIntegerAdd<C, N> {
     type Output;
+
+    fn private_integer_add(self, C, N) -> Self::Output;
 }
 pub type PrivateIntegerAddOut<P, C, N> = <P as PrivateIntegerAdd<C, N>>::Output;
 
 pub trait PrivatePow<Y, N> {
     type Output;
+
+    fn private_pow(self, Y, N) -> Self::Output;
 }
 pub type PrivatePowOut<A, Y, N> = <A as PrivatePow<Y, N>>::Output;
 
@@ -124,6 +149,10 @@ impl<IU: InvertedUnsigned, B: Bit> InvertedUnsigned for InvertedUInt<IU, B> {
 
 impl Invert for UTerm {
     type Output = InvertedUTerm;
+
+    fn invert(self) -> Self::Output {
+       InvertedUTerm
+    }
 }
 
 impl<U: Unsigned, B: Bit> Invert for UInt<U, B>
@@ -131,10 +160,18 @@ where
     U: PrivateInvert<InvertedUInt<InvertedUTerm, B>>,
 {
     type Output = PrivateInvertOut<U, InvertedUInt<InvertedUTerm, B>>;
+
+    fn invert(self) -> Self::Output {
+        self.msb.private_invert(InvertedUInt { msb: InvertedUTerm, lsb: self.lsb })
+    }
 }
 
 impl<IU: InvertedUnsigned> PrivateInvert<IU> for UTerm {
     type Output = IU;
+
+    fn private_invert(self, rhs: IU) -> Self::Output {
+        rhs
+    }
 }
 
 impl<IU: InvertedUnsigned, U: Unsigned, B: Bit> PrivateInvert<IU> for UInt<U, B>
@@ -142,6 +179,10 @@ where
     U: PrivateInvert<InvertedUInt<IU, B>>,
 {
     type Output = PrivateInvertOut<U, InvertedUInt<IU, B>>;
+
+    fn private_invert(self, rhs: IU) -> Self::Output {
+        self.msb.private_invert(InvertedUInt { msb: rhs, lsb: self.lsb })
+    }
 }
 
 #[test]
@@ -159,6 +200,10 @@ fn test_inversion() {
 
 impl Invert for InvertedUTerm {
     type Output = UTerm;
+
+    fn invert(self) -> Self::Output {
+        UTerm
+    }
 }
 
 impl<IU: InvertedUnsigned, B: Bit> Invert for InvertedUInt<IU, B>
@@ -166,10 +211,18 @@ where
     IU: PrivateInvert<UInt<UTerm, B>>,
 {
     type Output = <IU as PrivateInvert<UInt<UTerm, B>>>::Output;
+
+    fn invert(self) -> Self::Output {
+        self.msb.private_invert(UInt { msb: UTerm, lsb: self.lsb })
+    }
 }
 
 impl<U: Unsigned> PrivateInvert<U> for InvertedUTerm {
     type Output = U;
+
+    fn private_invert(self, rhs: U) -> Self::Output {
+        rhs
+    }
 }
 
 impl<U: Unsigned, IU: InvertedUnsigned, B: Bit> PrivateInvert<U> for InvertedUInt<IU, B>
@@ -177,6 +230,10 @@ where
     IU: PrivateInvert<UInt<U, B>>,
 {
     type Output = <IU as PrivateInvert<UInt<U, B>>>::Output;
+
+    fn private_invert(self, rhs: U) -> Self::Output {
+        self.msb.private_invert(UInt { msb: rhs, lsb: self.lsb })
+    }
 }
 
 #[test]
@@ -194,10 +251,18 @@ fn test_double_inversion() {
 
 impl TrimTrailingZeros for InvertedUTerm {
     type Output = InvertedUTerm;
+
+    fn trim_trailing_zeros(self) -> Self::Output {
+        InvertedUTerm
+    }
 }
 
 impl<IU: InvertedUnsigned> TrimTrailingZeros for InvertedUInt<IU, B1> {
     type Output = Self;
+
+    fn trim_trailing_zeros(self) -> Self::Output {
+        self
+    }
 }
 
 impl<IU: InvertedUnsigned> TrimTrailingZeros for InvertedUInt<IU, B0>
@@ -205,6 +270,10 @@ where
     IU: TrimTrailingZeros,
 {
     type Output = <IU as TrimTrailingZeros>::Output;
+
+    fn trim_trailing_zeros(self) -> Self::Output {
+        self.msb.trim_trailing_zeros()
+    }
 }
 
 impl<U: Unsigned> Trim for U
@@ -214,18 +283,26 @@ where
     <<U as Invert>::Output as TrimTrailingZeros>::Output: Invert,
 {
     type Output = <<<U as Invert>::Output as TrimTrailingZeros>::Output as Invert>::Output;
+
+    fn trim(self) -> Self::Output {
+        self.invert().trim_trailing_zeros().invert()
+    }
 }
 
 // Note: Trimming is tested when we do subtraction.
 
 pub trait PrivateCmp<Rhs, SoFar> {
     type Output;
+
+    fn private_cmp(&self, &Rhs, SoFar) -> Self::Output;
 }
 pub type PrivateCmpOut<A, Rhs, SoFar> = <A as PrivateCmp<Rhs, SoFar>>::Output;
 
 // Set Bit
 pub trait PrivateSetBit<I, B> {
     type Output;
+
+    fn private_set_bit(self, I, B) -> Self::Output;
 }
 pub type PrivateSetBitOut<N, I, B> = <N as PrivateSetBit<I, B>>::Output;
 
@@ -233,6 +310,10 @@ pub type PrivateSetBitOut<N, I, B> = <N as PrivateSetBit<I, B>>::Output;
 pub trait PrivateDiv<N, D, Q, R, I> {
     type Quotient;
     type Remainder;
+
+    fn private_div_quotient(self, N, D, Q, R, I) -> Self::Quotient;
+
+    fn private_div_remainder(self, N, D, Q, R, I) -> Self::Remainder;
 }
 
 pub type PrivateDivQuot<N, D, Q, R, I> = <() as PrivateDiv<N, D, Q, R, I>>::Quotient;
@@ -241,6 +322,10 @@ pub type PrivateDivRem<N, D, Q, R, I> = <() as PrivateDiv<N, D, Q, R, I>>::Remai
 pub trait PrivateDivIf<N, D, Q, R, I, RcmpD> {
     type Quotient;
     type Remainder;
+
+    fn private_div_if_quotient(self, N, D, Q, R, I, RcmpD) -> Self::Quotient;
+
+    fn private_div_if_remainder(self, N, D, Q, R, I, RcmpD) -> Self::Remainder;
 }
 
 pub type PrivateDivIfQuot<N, D, Q, R, I, RcmpD> =
@@ -251,24 +336,28 @@ pub type PrivateDivIfRem<N, D, Q, R, I, RcmpD> =
 // Div for signed ints
 pub trait PrivateDivInt<C, Divisor> {
     type Output;
+
+    fn private_div_int(self, C, Divisor) -> Self::Output;
 }
 pub type PrivateDivIntOut<A, C, Divisor> = <A as PrivateDivInt<C, Divisor>>::Output;
 
 pub trait PrivateRem<URem, Divisor> {
     type Output;
+
+    fn private_rem(self, URem, Divisor) -> Self::Output;
 }
 pub type PrivateRemOut<A, URem, Divisor> = <A as PrivateRem<URem, Divisor>>::Output;
 
 // min max
 pub trait PrivateMin<Rhs, CmpResult> {
     type Output;
-    fn private_min(self, rhs: Rhs) -> Self::Output;
+    fn private_min(self, Rhs) -> Self::Output;
 }
 pub type PrivateMinOut<A, B, CmpResult> = <A as PrivateMin<B, CmpResult>>::Output;
 
 pub trait PrivateMax<Rhs, CmpResult> {
     type Output;
-    fn private_max(self, rhs: Rhs) -> Self::Output;
+    fn private_max(self, Rhs) -> Self::Output;
 }
 pub type PrivateMaxOut<A, B, CmpResult> = <A as PrivateMax<B, CmpResult>>::Output;
 
@@ -278,86 +367,170 @@ use {Equal, False, Greater, Less, True};
 
 pub trait IsLessPrivate<Rhs, Cmp> {
     type Output: Bit;
+
+    fn is_less_private(self, Rhs, Cmp) -> Self::Output;
 }
 
 impl<A, B> IsLessPrivate<B, Less> for A {
     type Output = True;
+
+    fn is_less_private(self, _: B, _: Less) -> Self::Output {
+        B1
+    }
 }
 impl<A, B> IsLessPrivate<B, Equal> for A {
     type Output = False;
+
+    fn is_less_private(self, _: B, _: Equal) -> Self::Output {
+        B0
+    }
 }
 impl<A, B> IsLessPrivate<B, Greater> for A {
     type Output = False;
+
+    fn is_less_private(self, _: B, _: Greater) -> Self::Output {
+        B0
+    }
 }
 
 pub trait IsEqualPrivate<Rhs, Cmp> {
     type Output: Bit;
+
+    fn is_equal_private(self, Rhs, Cmp) -> Self::Output;
 }
 
 impl<A, B> IsEqualPrivate<B, Less> for A {
     type Output = False;
+
+    fn is_equal_private(self, _: B, _: Less) -> Self::Output {
+        B0
+    }
 }
 impl<A, B> IsEqualPrivate<B, Equal> for A {
     type Output = True;
+
+    fn is_equal_private(self, _: B, _: Equal) -> Self::Output {
+        B1
+    }
 }
 impl<A, B> IsEqualPrivate<B, Greater> for A {
     type Output = False;
+
+    fn is_equal_private(self, _: B, _: Greater) -> Self::Output {
+        B0
+    }
 }
 
 pub trait IsGreaterPrivate<Rhs, Cmp> {
     type Output: Bit;
+
+    fn is_greater_private(self, Rhs, Cmp) -> Self::Output;
 }
 
 impl<A, B> IsGreaterPrivate<B, Less> for A {
     type Output = False;
+
+    fn is_greater_private(self, _: B, _: Less) -> Self::Output {
+        B0
+    }
 }
 impl<A, B> IsGreaterPrivate<B, Equal> for A {
     type Output = False;
+
+    fn is_greater_private(self, _: B, _: Equal) -> Self::Output {
+        B0
+    }
 }
 impl<A, B> IsGreaterPrivate<B, Greater> for A {
     type Output = True;
+
+    fn is_greater_private(self, _: B, _: Greater) -> Self::Output {
+        B1
+    }
 }
 
 pub trait IsLessOrEqualPrivate<Rhs, Cmp> {
     type Output: Bit;
+
+    fn is_less_or_equal_private(self, Rhs, Cmp) -> Self::Output;
 }
 
 impl<A, B> IsLessOrEqualPrivate<B, Less> for A {
     type Output = True;
+
+    fn is_less_or_equal_private(self, _: B, _: Less) -> Self::Output {
+        B1
+    }
 }
 impl<A, B> IsLessOrEqualPrivate<B, Equal> for A {
     type Output = True;
+
+    fn is_less_or_equal_private(self, _: B, _: Equal) -> Self::Output {
+        B1
+    }
 }
 impl<A, B> IsLessOrEqualPrivate<B, Greater> for A {
     type Output = False;
+
+    fn is_less_or_equal_private(self, _: B, _: Greater) -> Self::Output {
+        B0
+    }
 }
 
 pub trait IsNotEqualPrivate<Rhs, Cmp> {
     type Output: Bit;
+
+    fn is_not_equal_private(self, Rhs, Cmp) -> Self::Output;
 }
 
 impl<A, B> IsNotEqualPrivate<B, Less> for A {
     type Output = True;
+
+    fn is_not_equal_private(self, _: B, _: Less) -> Self::Output {
+        B1
+    }
 }
 impl<A, B> IsNotEqualPrivate<B, Equal> for A {
     type Output = False;
+
+    fn is_not_equal_private(self, _: B, _: Equal) -> Self::Output {
+        B0
+    }
 }
 impl<A, B> IsNotEqualPrivate<B, Greater> for A {
     type Output = True;
+
+    fn is_not_equal_private(self, _: B, _: Greater) -> Self::Output {
+        B1
+    }
 }
 
 pub trait IsGreaterOrEqualPrivate<Rhs, Cmp> {
     type Output: Bit;
+
+    fn is_greater_or_equal_private(self, Rhs, Cmp) -> Self::Output;
 }
 
 impl<A, B> IsGreaterOrEqualPrivate<B, Less> for A {
     type Output = False;
+
+    fn is_greater_or_equal_private(self, _: B, _: Less) -> Self::Output {
+        B0
+    }
 }
 impl<A, B> IsGreaterOrEqualPrivate<B, Equal> for A {
     type Output = True;
+
+    fn is_greater_or_equal_private(self, _: B, _: Equal) -> Self::Output {
+        B1
+    }
 }
 impl<A, B> IsGreaterOrEqualPrivate<B, Greater> for A {
     type Output = True;
+
+    fn is_greater_or_equal_private(self, _: B, _: Greater) -> Self::Output {
+        B1
+    }
 }
 
 pub trait PrivateSquareRoot {

--- a/src/private.rs
+++ b/src/private.rs
@@ -151,7 +151,7 @@ impl Invert for UTerm {
     type Output = InvertedUTerm;
 
     fn invert(self) -> Self::Output {
-       InvertedUTerm
+        InvertedUTerm
     }
 }
 
@@ -162,7 +162,10 @@ where
     type Output = PrivateInvertOut<U, InvertedUInt<InvertedUTerm, B>>;
 
     fn invert(self) -> Self::Output {
-        self.msb.private_invert(InvertedUInt { msb: InvertedUTerm, lsb: self.lsb })
+        self.msb.private_invert(InvertedUInt {
+            msb: InvertedUTerm,
+            lsb: self.lsb,
+        })
     }
 }
 
@@ -181,7 +184,10 @@ where
     type Output = PrivateInvertOut<U, InvertedUInt<IU, B>>;
 
     fn private_invert(self, rhs: IU) -> Self::Output {
-        self.msb.private_invert(InvertedUInt { msb: rhs, lsb: self.lsb })
+        self.msb.private_invert(InvertedUInt {
+            msb: rhs,
+            lsb: self.lsb,
+        })
     }
 }
 
@@ -213,7 +219,10 @@ where
     type Output = <IU as PrivateInvert<UInt<UTerm, B>>>::Output;
 
     fn invert(self) -> Self::Output {
-        self.msb.private_invert(UInt { msb: UTerm, lsb: self.lsb })
+        self.msb.private_invert(UInt {
+            msb: UTerm,
+            lsb: self.lsb,
+        })
     }
 }
 
@@ -232,7 +241,10 @@ where
     type Output = <IU as PrivateInvert<UInt<U, B>>>::Output;
 
     fn private_invert(self, rhs: U) -> Self::Output {
-        self.msb.private_invert(UInt { msb: rhs, lsb: self.lsb })
+        self.msb.private_invert(UInt {
+            msb: rhs,
+            lsb: self.lsb,
+        })
     }
 }
 

--- a/src/type_operators.rs
+++ b/src/type_operators.rs
@@ -1,8 +1,8 @@
 //! Useful **type operators** that are not defined in `core::ops`.
 //!
 
-use {Bit, NInt, NonZero, PInt, UInt, UTerm, Unsigned, Z0};
 use private::{Internal, InternalMarker};
+use {Bit, NInt, NonZero, PInt, UInt, UTerm, Unsigned, Z0};
 
 /// A **type operator** that ensures that `Rhs` is the same as `Self`, it is mainly useful
 /// for writing macros that can take arbitrary binary or unary operators.

--- a/src/type_operators.rs
+++ b/src/type_operators.rs
@@ -2,6 +2,7 @@
 //!
 
 use {Bit, NInt, NonZero, PInt, UInt, UTerm, Unsigned, Z0};
+use private::{Internal, InternalMarker};
 
 /// A **type operator** that ensures that `Rhs` is the same as `Self`, it is mainly useful
 /// for writing macros that can take arbitrary binary or unary operators.
@@ -281,6 +282,9 @@ fn pow_test() {
 pub trait Cmp<Rhs = Self> {
     /// The result of the comparison. It should only ever be one of `Greater`, `Less`, or `Equal`.
     type Output;
+
+    #[doc(hidden)]
+    fn compare<IM: InternalMarker>(&self, &Rhs) -> Self::Output;
 }
 
 /// A **type operator** that gives the length of an `Array` or the number of bits in a `UInt`.
@@ -333,8 +337,9 @@ where
 {
     type Output = <A as IsLessPrivate<B, Compare<A, B>>>::Output;
 
-    fn is_less(self, _: B) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+    fn is_less(self, rhs: B) -> Self::Output {
+        let lhs_cmp_rhs = self.compare::<Internal>(&rhs);
+        self.is_less_private(rhs, lhs_cmp_rhs)
     }
 }
 
@@ -353,8 +358,9 @@ where
 {
     type Output = <A as IsEqualPrivate<B, Compare<A, B>>>::Output;
 
-    fn is_equal(self, _: B) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+    fn is_equal(self, rhs: B) -> Self::Output {
+        let lhs_cmp_rhs = self.compare::<Internal>(&rhs);
+        self.is_equal_private(rhs, lhs_cmp_rhs)
     }
 }
 
@@ -373,8 +379,9 @@ where
 {
     type Output = <A as IsGreaterPrivate<B, Compare<A, B>>>::Output;
 
-    fn is_greater(self, _: B) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+    fn is_greater(self, rhs: B) -> Self::Output {
+        let lhs_cmp_rhs = self.compare::<Internal>(&rhs);
+        self.is_greater_private(rhs, lhs_cmp_rhs)
     }
 }
 
@@ -393,8 +400,9 @@ where
 {
     type Output = <A as IsLessOrEqualPrivate<B, Compare<A, B>>>::Output;
 
-    fn is_less_or_equal(self, _: B) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+    fn is_less_or_equal(self, rhs: B) -> Self::Output {
+        let lhs_cmp_rhs = self.compare::<Internal>(&rhs);
+        self.is_less_or_equal_private(rhs, lhs_cmp_rhs)
     }
 }
 
@@ -413,8 +421,9 @@ where
 {
     type Output = <A as IsNotEqualPrivate<B, Compare<A, B>>>::Output;
 
-    fn is_not_equal(self, _: B) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+    fn is_not_equal(self, rhs: B) -> Self::Output {
+        let lhs_cmp_rhs = self.compare::<Internal>(&rhs);
+        self.is_not_equal_private(rhs, lhs_cmp_rhs)
     }
 }
 
@@ -433,8 +442,9 @@ where
 {
     type Output = <A as IsGreaterOrEqualPrivate<B, Compare<A, B>>>::Output;
 
-    fn is_greater_or_equal(self, _: B) -> Self::Output {
-        unsafe { ::core::mem::uninitialized() }
+    fn is_greater_or_equal(self, rhs: B) -> Self::Output {
+        let lhs_cmp_rhs = self.compare::<Internal>(&rhs);
+        self.is_greater_or_equal_private(rhs, lhs_cmp_rhs)
     }
 }
 

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::many_single_char_names, clippy::suspicious_arithmetic_impl)]
+
 //! Type-level unsigned integers.
 //!
 //!
@@ -336,7 +338,10 @@ where
 {
     type Output = UInt<Sum<Ul, Ur>, B0>;
     fn add(self, rhs: UInt<Ur, B0>) -> Self::Output {
-        UInt { msb: self.msb + rhs.msb, lsb: B0 }
+        UInt {
+            msb: self.msb + rhs.msb,
+            lsb: B0,
+        }
     }
 }
 
@@ -347,7 +352,10 @@ where
 {
     type Output = UInt<Sum<Ul, Ur>, B1>;
     fn add(self, rhs: UInt<Ur, B1>) -> Self::Output {
-        UInt { msb: self.msb + rhs.msb, lsb: B1 }
+        UInt {
+            msb: self.msb + rhs.msb,
+            lsb: B1,
+        }
     }
 }
 
@@ -358,7 +366,10 @@ where
 {
     type Output = UInt<Sum<Ul, Ur>, B1>;
     fn add(self, rhs: UInt<Ur, B0>) -> Self::Output {
-        UInt { msb: self.msb + rhs.msb, lsb: B1 }
+        UInt {
+            msb: self.msb + rhs.msb,
+            lsb: B1,
+        }
     }
 }
 
@@ -370,7 +381,10 @@ where
 {
     type Output = UInt<Add1<Sum<Ul, Ur>>, B0>;
     fn add(self, rhs: UInt<Ur, B1>) -> Self::Output {
-        UInt { msb: self.msb + rhs.msb + B1, lsb: B0 }
+        UInt {
+            msb: self.msb + rhs.msb + B1,
+            lsb: B0,
+        }
     }
 }
 
@@ -461,7 +475,10 @@ where
     type Output = UInt<PrivateSubOut<Ul, Ur>, B0>;
 
     fn private_sub(self, rhs: UInt<Ur, B0>) -> Self::Output {
-        UInt { msb: self.msb.private_sub(rhs.msb), lsb: B0 }
+        UInt {
+            msb: self.msb.private_sub(rhs.msb),
+            lsb: B0,
+        }
     }
 }
 
@@ -474,7 +491,10 @@ where
     type Output = UInt<Sub1<PrivateSubOut<Ul, Ur>>, B1>;
 
     fn private_sub(self, rhs: UInt<Ur, B1>) -> Self::Output {
-        UInt { msb: self.msb.private_sub(rhs.msb) - B1, lsb: B1 }
+        UInt {
+            msb: self.msb.private_sub(rhs.msb) - B1,
+            lsb: B1,
+        }
     }
 }
 
@@ -486,7 +506,10 @@ where
     type Output = UInt<PrivateSubOut<Ul, Ur>, B1>;
 
     fn private_sub(self, rhs: UInt<Ur, B0>) -> Self::Output {
-        UInt { msb: self.msb.private_sub(rhs.msb), lsb: B1 }
+        UInt {
+            msb: self.msb.private_sub(rhs.msb),
+            lsb: B1,
+        }
     }
 }
 
@@ -498,7 +521,10 @@ where
     type Output = UInt<PrivateSubOut<Ul, Ur>, B0>;
 
     fn private_sub(self, rhs: UInt<Ur, B1>) -> Self::Output {
-        UInt { msb: self.msb.private_sub(rhs.msb), lsb: B0 }
+        UInt {
+            msb: self.msb.private_sub(rhs.msb),
+            lsb: B0,
+        }
     }
 }
 
@@ -552,7 +578,10 @@ where
     type Output = UInt<PrivateAndOut<Ul, Ur>, B0>;
 
     fn private_and(self, rhs: UInt<Ur, B0>) -> Self::Output {
-        UInt { msb: self.msb.private_and(rhs.msb), lsb: B0 }
+        UInt {
+            msb: self.msb.private_and(rhs.msb),
+            lsb: B0,
+        }
     }
 }
 
@@ -564,7 +593,10 @@ where
     type Output = UInt<PrivateAndOut<Ul, Ur>, B0>;
 
     fn private_and(self, rhs: UInt<Ur, B1>) -> Self::Output {
-        UInt { msb: self.msb.private_and(rhs.msb), lsb: B0 }
+        UInt {
+            msb: self.msb.private_and(rhs.msb),
+            lsb: B0,
+        }
     }
 }
 
@@ -576,7 +608,10 @@ where
     type Output = UInt<PrivateAndOut<Ul, Ur>, B0>;
 
     fn private_and(self, rhs: UInt<Ur, B0>) -> Self::Output {
-        UInt { msb: self.msb.private_and(rhs.msb), lsb: B0 }
+        UInt {
+            msb: self.msb.private_and(rhs.msb),
+            lsb: B0,
+        }
     }
 }
 
@@ -588,7 +623,10 @@ where
     type Output = UInt<PrivateAndOut<Ul, Ur>, B1>;
 
     fn private_and(self, rhs: UInt<Ur, B1>) -> Self::Output {
-        UInt { msb: self.msb.private_and(rhs.msb), lsb: B1 }
+        UInt {
+            msb: self.msb.private_and(rhs.msb),
+            lsb: B1,
+        }
     }
 }
 
@@ -618,7 +656,10 @@ where
 {
     type Output = UInt<<Ul as BitOr<Ur>>::Output, B0>;
     fn bitor(self, rhs: UInt<Ur, B0>) -> Self::Output {
-        UInt { msb: self.msb.bitor(rhs.msb), lsb: B0 }
+        UInt {
+            msb: self.msb.bitor(rhs.msb),
+            lsb: B0,
+        }
     }
 }
 
@@ -629,7 +670,10 @@ where
 {
     type Output = UInt<Or<Ul, Ur>, B1>;
     fn bitor(self, rhs: UInt<Ur, B1>) -> Self::Output {
-        UInt { msb: self.msb.bitor(rhs.msb), lsb: self.lsb.bitor(rhs.lsb) }
+        UInt {
+            msb: self.msb.bitor(rhs.msb),
+            lsb: self.lsb.bitor(rhs.lsb),
+        }
     }
 }
 
@@ -640,7 +684,10 @@ where
 {
     type Output = UInt<Or<Ul, Ur>, B1>;
     fn bitor(self, rhs: UInt<Ur, B0>) -> Self::Output {
-        UInt { msb: self.msb.bitor(rhs.msb), lsb: self.lsb.bitor(rhs.lsb) }
+        UInt {
+            msb: self.msb.bitor(rhs.msb),
+            lsb: self.lsb.bitor(rhs.lsb),
+        }
     }
 }
 
@@ -651,7 +698,10 @@ where
 {
     type Output = UInt<Or<Ul, Ur>, B1>;
     fn bitor(self, rhs: UInt<Ur, B1>) -> Self::Output {
-        UInt { msb: self.msb.bitor(rhs.msb), lsb: self.lsb.bitor(rhs.lsb) }
+        UInt {
+            msb: self.msb.bitor(rhs.msb),
+            lsb: self.lsb.bitor(rhs.lsb),
+        }
     }
 }
 
@@ -705,7 +755,10 @@ where
     type Output = UInt<PrivateXorOut<Ul, Ur>, B0>;
 
     fn private_xor(self, rhs: UInt<Ur, B0>) -> Self::Output {
-        UInt { msb: self.msb.private_xor(rhs.msb), lsb: B0 }
+        UInt {
+            msb: self.msb.private_xor(rhs.msb),
+            lsb: B0,
+        }
     }
 }
 
@@ -717,7 +770,10 @@ where
     type Output = UInt<PrivateXorOut<Ul, Ur>, B1>;
 
     fn private_xor(self, rhs: UInt<Ur, B1>) -> Self::Output {
-        UInt { msb: self.msb.private_xor(rhs.msb), lsb: B1 }
+        UInt {
+            msb: self.msb.private_xor(rhs.msb),
+            lsb: B1,
+        }
     }
 }
 
@@ -729,7 +785,10 @@ where
     type Output = UInt<PrivateXorOut<Ul, Ur>, B1>;
 
     fn private_xor(self, rhs: UInt<Ur, B0>) -> Self::Output {
-        UInt { msb: self.msb.private_xor(rhs.msb), lsb: B1 }
+        UInt {
+            msb: self.msb.private_xor(rhs.msb),
+            lsb: B1,
+        }
     }
 }
 
@@ -741,7 +800,10 @@ where
     type Output = UInt<PrivateXorOut<Ul, Ur>, B0>;
 
     fn private_xor(self, rhs: UInt<Ur, B1>) -> Self::Output {
-        UInt { msb: self.msb.private_xor(rhs.msb), lsb: B0 }
+        UInt {
+            msb: self.msb.private_xor(rhs.msb),
+            lsb: B0,
+        }
     }
 }
 
@@ -929,7 +991,10 @@ where
 {
     type Output = UInt<Prod<Ul, UInt<Ur, B>>, B0>;
     fn mul(self, rhs: UInt<Ur, B>) -> Self::Output {
-        UInt { msb: self.msb * rhs, lsb: B0 }
+        UInt {
+            msb: self.msb * rhs,
+            lsb: B0,
+        }
     }
 }
 
@@ -941,7 +1006,10 @@ where
 {
     type Output = Sum<UInt<Prod<Ul, UInt<Ur, B>>, B0>, UInt<Ur, B>>;
     fn mul(self, rhs: UInt<Ur, B>) -> Self::Output {
-        UInt { msb: self.msb * rhs, lsb: B0 } + rhs
+        UInt {
+            msb: self.msb * rhs,
+            lsb: B0,
+        } + rhs
     }
 }
 
@@ -1223,7 +1291,7 @@ pub type GetBitOut<N, I> = <N as GetBit<I>>::Output;
 // Base case
 impl<Un, Bn> GetBit<U0> for UInt<Un, Bn>
 where
-    Bn: Copy
+    Bn: Copy,
 {
     type Output = Bn;
 
@@ -1302,7 +1370,10 @@ impl<Un, Bn, B> PrivateSetBit<U0, B> for UInt<Un, Bn> {
     type Output = UInt<Un, B>;
 
     fn private_set_bit(self, _: U0, b: B) -> Self::Output {
-        UInt { msb: self.msb, lsb: b }
+        UInt {
+            msb: self.msb,
+            lsb: b,
+        }
     }
 }
 
@@ -1315,7 +1386,10 @@ where
     type Output = UInt<PrivateSetBitOut<Un, Sub1<UInt<Ui, Bi>>, B>, Bn>;
 
     fn private_set_bit(self, i: UInt<Ui, Bi>, b: B) -> Self::Output {
-        UInt { msb: self.msb.private_set_bit(i - B1, b), lsb: self.lsb }
+        UInt {
+            msb: self.msb.private_set_bit(i - B1, b),
+            lsb: self.lsb,
+        }
     }
 }
 
@@ -1436,13 +1510,7 @@ where
 {
     type Output = PrivateDivQuot<UInt<Ul, Bl>, UInt<Ur, Br>, U0, U0, Sub1<Length<UInt<Ul, Bl>>>>;
     fn div(self, rhs: UInt<Ur, Br>) -> Self::Output {
-        ().private_div_quotient(
-            self,
-            rhs,
-            U0::new(),
-            U0::new(),
-            self.len() - B1,
-        )
+        ().private_div_quotient(self, rhs, U0::new(), U0::new(), self.len() - B1)
     }
 }
 
@@ -1509,32 +1577,24 @@ where
     >;
 
     fn private_div_quotient(self, n: N, d: D, q: Q, _: U0, i: I) -> Self::Quotient
-    where
-    {
-        let r = (UInt { msb: UTerm, lsb: n.get_bit::<Internal>(&i) }).trim();
+where {
+        let r = (UInt {
+            msb: UTerm,
+            lsb: n.get_bit::<Internal>(&i),
+        })
+        .trim();
         let r_cmp_d = r.compare::<Internal>(&d);
-        ().private_div_if_quotient(
-            n,
-            d,
-            q,
-            r,
-            i,
-            r_cmp_d
-        )
+        ().private_div_if_quotient(n, d, q, r, i, r_cmp_d)
     }
 
-    fn private_div_remainder(self, n: N, d: D, q: Q, _: U0, i: I) -> Self::Remainder
-    {
-        let r = (UInt { msb: UTerm, lsb: n.get_bit::<Internal>(&i) }).trim();
+    fn private_div_remainder(self, n: N, d: D, q: Q, _: U0, i: I) -> Self::Remainder {
+        let r = (UInt {
+            msb: UTerm,
+            lsb: n.get_bit::<Internal>(&i),
+        })
+        .trim();
         let r_cmp_d = r.compare::<Internal>(&d);
-        ().private_div_if_remainder(
-            n,
-            d,
-            q,
-            r,
-            i,
-            r_cmp_d
-        )
+        ().private_div_if_remainder(n, d, q, r, i, r_cmp_d)
     }
 }
 
@@ -1570,29 +1630,21 @@ where
     >;
 
     fn private_div_quotient(self, n: N, d: D, q: Q, r: UInt<Ur, Br>, i: I) -> Self::Quotient {
-        let r = UInt { msb: r, lsb: n.get_bit::<Internal>(&i) };
+        let r = UInt {
+            msb: r,
+            lsb: n.get_bit::<Internal>(&i),
+        };
         let r_cmp_d = r.compare::<Internal>(&d);
-        ().private_div_if_quotient(
-            n,
-            d,
-            q,
-            r,
-            i,
-            r_cmp_d
-        )
+        ().private_div_if_quotient(n, d, q, r, i, r_cmp_d)
     }
 
     fn private_div_remainder(self, n: N, d: D, q: Q, r: UInt<Ur, Br>, i: I) -> Self::Remainder {
-        let r = UInt { msb: r, lsb: n.get_bit::<Internal>(&i) };
+        let r = UInt {
+            msb: r,
+            lsb: n.get_bit::<Internal>(&i),
+        };
         let r_cmp_d = r.compare::<Internal>(&d);
-        ().private_div_if_remainder(
-            n,
-            d,
-            q,
-            r,
-            i,
-            r_cmp_d
-        )
+        ().private_div_if_remainder(n, d, q, r, i, r_cmp_d)
     }
 }
 
@@ -1610,15 +1662,29 @@ where
     type Quotient = PrivateDivQuot<N, D, Q, R, Sub1<UInt<Ui, Bi>>>;
     type Remainder = PrivateDivRem<N, D, Q, R, Sub1<UInt<Ui, Bi>>>;
 
-    fn private_div_if_quotient(self, n: N, d: D, q: Q, r: R, i: UInt<Ui, Bi>, _: Less) -> Self::Quotient
-    where
-    {
+    fn private_div_if_quotient(
+        self,
+        n: N,
+        d: D,
+        q: Q,
+        r: R,
+        i: UInt<Ui, Bi>,
+        _: Less,
+    ) -> Self::Quotient
+where {
         ().private_div_quotient(n, d, q, r, i - B1)
     }
 
-    fn private_div_if_remainder(self, n: N, d: D, q: Q, r: R, i: UInt<Ui, Bi>, _: Less) -> Self::Remainder
-    where
-    {
+    fn private_div_if_remainder(
+        self,
+        n: N,
+        d: D,
+        q: Q,
+        r: R,
+        i: UInt<Ui, Bi>,
+        _: Less,
+    ) -> Self::Remainder
+where {
         ().private_div_remainder(n, d, q, r, i - B1)
     }
 }
@@ -1633,15 +1699,29 @@ where
     type Quotient = PrivateDivQuot<N, D, SetBitOut<Q, UInt<Ui, Bi>, B1>, U0, Sub1<UInt<Ui, Bi>>>;
     type Remainder = PrivateDivRem<N, D, SetBitOut<Q, UInt<Ui, Bi>, B1>, U0, Sub1<UInt<Ui, Bi>>>;
 
-    fn private_div_if_quotient(self, n: N, d: D, q: Q, _: R, i: UInt<Ui, Bi>, _: Equal) -> Self::Quotient
-    where
-    {
+    fn private_div_if_quotient(
+        self,
+        n: N,
+        d: D,
+        q: Q,
+        _: R,
+        i: UInt<Ui, Bi>,
+        _: Equal,
+    ) -> Self::Quotient
+where {
         ().private_div_quotient(n, d, q.set_bit::<Internal>(i, B1), U0::new(), i - B1)
     }
 
-    fn private_div_if_remainder(self, n: N, d: D, q: Q, _: R, i: UInt<Ui, Bi>, _: Equal) -> Self::Remainder
-    where
-    {
+    fn private_div_if_remainder(
+        self,
+        n: N,
+        d: D,
+        q: Q,
+        _: R,
+        i: UInt<Ui, Bi>,
+        _: Equal,
+    ) -> Self::Remainder
+where {
         ().private_div_remainder(n, d, q.set_bit::<Internal>(i, B1), U0::new(), i - B1)
     }
 }
@@ -1661,15 +1741,29 @@ where
     type Remainder =
         PrivateDivRem<N, D, SetBitOut<Q, UInt<Ui, Bi>, B1>, Diff<R, D>, Sub1<UInt<Ui, Bi>>>;
 
-    fn private_div_if_quotient(self, n: N, d: D, q: Q, r: R, i: UInt<Ui, Bi>, _: Greater) -> Self::Quotient
-    where
-    {
+    fn private_div_if_quotient(
+        self,
+        n: N,
+        d: D,
+        q: Q,
+        r: R,
+        i: UInt<Ui, Bi>,
+        _: Greater,
+    ) -> Self::Quotient
+where {
         ().private_div_quotient(n, d, q.set_bit::<Internal>(i, B1), r - d, i - B1)
     }
 
-    fn private_div_if_remainder(self, n: N, d: D, q: Q, r: R, i: UInt<Ui, Bi>, _: Greater) -> Self::Remainder
-    where
-    {
+    fn private_div_if_remainder(
+        self,
+        n: N,
+        d: D,
+        q: Q,
+        r: R,
+        i: UInt<Ui, Bi>,
+        _: Greater,
+    ) -> Self::Remainder
+where {
         ().private_div_remainder(n, d, q.set_bit::<Internal>(i, B1), r - d, i - B1)
     }
 }
@@ -1718,7 +1812,15 @@ where
         q.set_bit::<Internal>(i, B1)
     }
 
-    fn private_div_if_remainder(self, _: N, d: D, _: Q, r: R, _: U0, _: Greater) -> Self::Remainder {
+    fn private_div_if_remainder(
+        self,
+        _: N,
+        d: D,
+        _: Q,
+        r: R,
+        _: U0,
+        _: Greater,
+    ) -> Self::Remainder {
         r - d
     }
 }

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -1,4 +1,7 @@
-#![allow(clippy::many_single_char_names, clippy::suspicious_arithmetic_impl)]
+#![cfg_attr(
+    feature = "cargo-clippy",
+    allow(clippy::many_single_char_names, clippy::suspicious_arithmetic_impl)
+)]
 
 //! Type-level unsigned integers.
 //!


### PR DESCRIPTION
Fixes #126 by completely removing all instances of `unsafe`. Instead, `Unsigned` values are flowed through the methods `core::ops` and `type_operator` traits. The appropriate methods have been added to the `Private*` traits, as needed.

This pull request takes an aggressive approach, but it may not be desirable to remove _all_ instances of `unsafe`. This pull request:
 - makes a breaking<sup>?</sup> change to `TArr`
 - introduces a small number of internal type bounds, which _could_ impact performance.

I'll spotlight where these changes occur with pull-request comments.