### PR TITLE
Add greatest common divisor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The MSRV (Minimum Supported Rust Version) is 1.22.0, and typenum is tested again
 version. Much of typenum should work on as low a version as 1.20.0, but that is not guaranteed.
 
 ### Unreleased
+- [added] Greatest common divisor operator `Gcd` with alias `Gcf`.
+- [added] `gcd` to the `op!` macro.
 - [changed] Added `Copy` bound to `Rhs` of `Mul<Rhs>` impl for `<TArr<V, A>`.
 - [changed] Added `Copy` bound to `Rhs` of `Div<Rhs>` impl for `<TArr<V, A>`.
 - [changed] Added `Copy` bound to `Rhs` of `PartialDiv<Rhs>` impl for `<TArr<V, A>`.

--- a/build/op.rs
+++ b/build/op.rs
@@ -228,6 +228,14 @@ pub fn write_op_macro() -> ::std::io::Result<()> {
             n_args: 1,
             op_type: Function,
         },
+        Op {
+            token: "gcd",
+            operator: "Gcf",
+            example: ("gcd(U9, U21)", "U3"),
+            precedence: !0,
+            n_args: 2,
+            op_type: Function,
+        },
     ];
 
     use std::io::Write;

--- a/build/tests.rs
+++ b/build/tests.rs
@@ -1,6 +1,17 @@
-use std::{env, fmt, fs, io, path};
+use std::{env, fmt, fs, io, mem, path};
 
 use super::{gen_int, gen_uint};
+
+/// Computes the greatest common divisor of two integers.
+fn gcd(mut a: i64, mut b: i64) -> i64 {
+    while (a != 0) {
+        let tmp = b % a;
+        b = a;
+        a = tmp;
+    }
+
+    b
+}
 
 fn sign(i: i64) -> char {
     if i > 0 {
@@ -244,6 +255,7 @@ use typenum::*;
         write!(writer, "{}", uint_binary_test(a, "Add", b, a + b))?;
         write!(writer, "{}", uint_binary_test(a, "Min", b, cmp::min(a, b)))?;
         write!(writer, "{}", uint_binary_test(a, "Max", b, cmp::max(a, b)))?;
+        write!(writer, "{}", uint_binary_test(a, "Gcd", b, gcd(a, b)))?;
         if a >= b {
             write!(writer, "{}", uint_binary_test(a, "Sub", b, a - b))?;
         }
@@ -265,6 +277,7 @@ use typenum::*;
         write!(writer, "{}", int_binary_test(a, "Mul", b, a * b))?;
         write!(writer, "{}", int_binary_test(a, "Min", b, cmp::min(a, b)))?;
         write!(writer, "{}", int_binary_test(a, "Max", b, cmp::max(a, b)))?;
+        write!(writer, "{}", int_binary_test(a, "Gcd", b, gcd(a, b)))?;
         if b != 0 {
             write!(writer, "{}", int_binary_test(a, "Div", b, a / b))?;
             write!(writer, "{}", int_binary_test(a, "Rem", b, a % b))?;

--- a/src/int.rs
+++ b/src/int.rs
@@ -887,6 +887,78 @@ where
 }
 
 // ---------------------------------------------------------------------------------------
+// Gcd
+use {Gcd, Gcf};
+
+impl Gcd<Z0> for Z0 {
+    type Output = Z0;
+}
+
+impl<U> Gcd<PInt<U>> for Z0
+where
+    U: Unsigned + NonZero,
+{
+    type Output = PInt<U>;
+}
+
+impl<U> Gcd<Z0> for PInt<U>
+where
+    U: Unsigned + NonZero,
+{
+    type Output = PInt<U>;
+}
+
+impl<U> Gcd<NInt<U>> for Z0
+where
+    U: Unsigned + NonZero,
+{
+    type Output = PInt<U>;
+}
+
+impl<U> Gcd<Z0> for NInt<U>
+where
+    U: Unsigned + NonZero,
+{
+    type Output = PInt<U>;
+}
+
+impl<U1, U2> Gcd<PInt<U2>> for PInt<U1>
+where
+    U1: Unsigned + NonZero + Gcd<U2>,
+    U2: Unsigned + NonZero,
+    Gcf<U1, U2>: Unsigned + NonZero,
+{
+    type Output = PInt<Gcf<U1, U2>>;
+}
+
+impl<U1, U2> Gcd<PInt<U2>> for NInt<U1>
+where
+    U1: Unsigned + NonZero + Gcd<U2>,
+    U2: Unsigned + NonZero,
+    Gcf<U1, U2>: Unsigned + NonZero,
+{
+    type Output = PInt<Gcf<U1, U2>>;
+}
+
+impl<U1, U2> Gcd<NInt<U2>> for PInt<U1>
+where
+    U1: Unsigned + NonZero + Gcd<U2>,
+    U2: Unsigned + NonZero,
+    Gcf<U1, U2>: Unsigned + NonZero,
+{
+    type Output = PInt<Gcf<U1, U2>>;
+}
+
+impl<U1, U2> Gcd<NInt<U2>> for NInt<U1>
+where
+    U1: Unsigned + NonZero + Gcd<U2>,
+    U2: Unsigned + NonZero,
+    Gcf<U1, U2>: Unsigned + NonZero,
+{
+    type Output = PInt<Gcf<U1, U2>>;
+}
+
+// ---------------------------------------------------------------------------------------
 // Min
 use {Max, Maximum, Min, Minimum};
 

--- a/src/operator_aliases.rs
+++ b/src/operator_aliases.rs
@@ -22,7 +22,7 @@
 
 // Aliases!!!
 use core::ops::{Add, BitAnd, BitOr, BitXor, Div, Mul, Neg, Rem, Shl, Shr, Sub};
-use type_operators::{Abs, Cmp, Len, Logarithm2, Max, Min, PartialDiv, Pow, SquareRoot};
+use type_operators::{Abs, Cmp, Gcd, Len, Logarithm2, Max, Min, PartialDiv, Pow, SquareRoot};
 
 /// Alias for the associated type of `BitAnd`: `And<A, B> = <A as BitAnd<B>>::Output`
 pub type And<A, B> = <A as BitAnd<B>>::Output;
@@ -59,6 +59,9 @@ pub type AbsVal<A> = <A as Abs>::Output;
 
 /// Alias for the associated type of `Pow`: `Exp<A, B> = <A as Pow<B>>::Output`
 pub type Exp<A, B> = <A as Pow<B>>::Output;
+
+/// Alias for the associated type of `Gcd`: `Gcf<A, B> = <A as Gcd<B>>::Output>`
+pub type Gcf<A, B> = <A as Gcd<B>>::Output;
 
 /// Alias to make it easy to add 1: `Add1<A> = <A as Add<B1>>::Output`
 pub type Add1<A> = <A as Add<::bit::B1>>::Output;

--- a/src/type_operators.rs
+++ b/src/type_operators.rs
@@ -542,3 +542,19 @@ pub trait Logarithm2 {
     /// The result of the integer binary logarithm.
     type Output;
 }
+
+/// A **type operator** that computes the [greatest common divisor][gcd] of `Self` and `Rhs`.
+///
+/// [gcd]: https://en.wikipedia.org/wiki/Greatest_common_divisor
+///
+/// # Example
+///
+/// ```rust
+/// use typenum::{Gcd, U12, U8, Unsigned};
+///
+/// assert_eq!(<U12 as Gcd<U8>>::Output::to_i32(), 4);
+/// ```
+pub trait Gcd<Rhs> {
+    /// The greatest common divisor.
+    type Output;
+}

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -29,7 +29,10 @@
 //!
 
 use core::ops::{Add, BitAnd, BitOr, BitXor, Mul, Shl, Shr, Sub};
-use {Cmp, Equal, Greater, IsGreaterOrEqual, Len, Less, Logarithm2, NonZero, Ord, Pow, SquareRoot};
+use {
+    Cmp, Equal, Gcd, Greater, IsGreaterOrEqual, Len, Less, Logarithm2, Maximum, Minimum, NonZero,
+    Ord, Pow, SquareRoot,
+};
 
 use bit::{Bit, B0, B1};
 
@@ -45,7 +48,7 @@ use private::{
 use private::{Internal, InternalMarker};
 
 use consts::{U0, U1};
-use {Add1, Double, GrEq, Length, Log2, Or, Prod, Shleft, Shright, Sqrt, Square, Sub1, Sum};
+use {Add1, Double, Gcf, GrEq, Length, Log2, Or, Prod, Shleft, Shright, Sqrt, Square, Sub1, Sum};
 
 pub use marker_traits::{PowerOfTwo, Unsigned};
 
@@ -1356,6 +1359,113 @@ where
     #[inline]
     fn private_pow(self, y: Y, n: UInt<UInt<U, B>, B1>) -> Self::Output {
         (self * self).private_pow(self * y, n.msb)
+    }
+}
+
+//------------------------------------------
+// Greatest Common Divisor
+
+/// The even number 2*N
+type Even<N> = UInt<N, B0>;
+
+/// The odd number 2*N + 1
+type Odd<N> = UInt<N, B1>;
+
+// gcd(0, 0) = 0
+impl Gcd<U0> for U0 {
+    type Output = U0;
+}
+
+// gcd(x, 0) = x
+impl<X> Gcd<U0> for X
+where
+    X: Unsigned + NonZero,
+{
+    type Output = X;
+}
+
+// gcd(0, y) = y
+impl<Y> Gcd<Y> for U0
+where
+    Y: Unsigned + NonZero,
+{
+    type Output = Y;
+}
+
+// gcd(x, y) = 2*gcd(x/2, y/2) if both x and y even
+impl<Xp, Yp> Gcd<Even<Yp>> for Even<Xp>
+where
+    Xp: Gcd<Yp>,
+    Even<Xp>: NonZero,
+    Even<Yp>: NonZero,
+{
+    type Output = UInt<Gcf<Xp, Yp>, B0>;
+}
+
+// gcd(x, y) = gcd(x, y/2) if x odd and y even
+impl<Xp, Yp> Gcd<Even<Yp>> for Odd<Xp>
+where
+    Odd<Xp>: Gcd<Yp>,
+    Even<Yp>: NonZero,
+{
+    type Output = Gcf<Odd<Xp>, Yp>;
+}
+
+// gcd(x, y) = gcd(x/2, y) if x even and y odd
+impl<Xp, Yp> Gcd<Odd<Yp>> for Even<Xp>
+where
+    Xp: Gcd<Odd<Yp>>,
+    Even<Xp>: NonZero,
+{
+    type Output = Gcf<Xp, Odd<Yp>>;
+}
+
+// gcd(x, y) = gcd([max(x, y) - min(x, y)], min(x, y)) if both x and y odd
+//
+// This will immediately invoke the case for x even and y odd because the difference of two odd
+// numbers is an even number.
+impl<Xp, Yp> Gcd<Odd<Yp>> for Odd<Xp>
+where
+    Odd<Xp>: Max<Odd<Yp>> + Min<Odd<Yp>>,
+    Odd<Yp>: Max<Odd<Xp>> + Min<Odd<Xp>>,
+    Maximum<Odd<Xp>, Odd<Yp>>: Sub<Minimum<Odd<Xp>, Odd<Yp>>>,
+    Diff<Maximum<Odd<Xp>, Odd<Yp>>, Minimum<Odd<Xp>, Odd<Yp>>>: Gcd<Minimum<Odd<Xp>, Odd<Yp>>>,
+{
+    type Output = Gcf<
+        Diff<
+            Maximum<Odd<Xp>, Odd<Yp>>,
+            Minimum<Odd<Xp>, Odd<Yp>>
+        >,
+        Minimum<Odd<Xp>, Odd<Yp>>
+    >;
+}
+
+#[cfg(test)]
+mod gcd_tests {
+    use super::*;
+    use consts::*;
+
+    macro_rules! gcd_test {
+        (
+            $( $a:ident, $b:ident => $c:ident ),* $(,)*
+        ) => {
+            $(
+                assert_eq!(<Gcf<$a, $b> as Unsigned>::to_usize(), $c::to_usize());
+                assert_eq!(<Gcf<$b, $a> as Unsigned>::to_usize(), $c::to_usize());
+             )*
+        }
+    }
+
+    #[test]
+    fn gcd() {
+        gcd_test! {
+            U0,   U42   => U42,
+            U12,  U8    => U4,
+            U13,  U1013 => U1,  // Two primes
+            U9,   U26   => U1,  // Not prime but coprime
+            U143, U273  => U13,
+            U117, U273  => U39,
+        }
     }
 }
 

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -1366,6 +1366,7 @@ where
 // Greatest Common Divisor
 
 /// The even number 2*N
+#[allow(unused)] // Silence spurious warning on older versions of rust
 type Even<N> = UInt<N, B0>;
 
 /// The odd number 2*N + 1

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -1371,12 +1371,12 @@ type Even<N> = UInt<N, B0>;
 /// The odd number 2*N + 1
 type Odd<N> = UInt<N, B1>;
 
-// gcd(0, 0) = 0
+/// gcd(0, 0) = 0
 impl Gcd<U0> for U0 {
     type Output = U0;
 }
 
-// gcd(x, 0) = x
+/// gcd(x, 0) = x
 impl<X> Gcd<U0> for X
 where
     X: Unsigned + NonZero,
@@ -1384,7 +1384,7 @@ where
     type Output = X;
 }
 
-// gcd(0, y) = y
+/// gcd(0, y) = y
 impl<Y> Gcd<Y> for U0
 where
     Y: Unsigned + NonZero,
@@ -1392,7 +1392,7 @@ where
     type Output = Y;
 }
 
-// gcd(x, y) = 2*gcd(x/2, y/2) if both x and y even
+/// gcd(x, y) = 2*gcd(x/2, y/2) if both x and y even
 impl<Xp, Yp> Gcd<Even<Yp>> for Even<Xp>
 where
     Xp: Gcd<Yp>,
@@ -1402,7 +1402,7 @@ where
     type Output = UInt<Gcf<Xp, Yp>, B0>;
 }
 
-// gcd(x, y) = gcd(x, y/2) if x odd and y even
+/// gcd(x, y) = gcd(x, y/2) if x odd and y even
 impl<Xp, Yp> Gcd<Even<Yp>> for Odd<Xp>
 where
     Odd<Xp>: Gcd<Yp>,
@@ -1411,7 +1411,7 @@ where
     type Output = Gcf<Odd<Xp>, Yp>;
 }
 
-// gcd(x, y) = gcd(x/2, y) if x even and y odd
+/// gcd(x, y) = gcd(x/2, y) if x even and y odd
 impl<Xp, Yp> Gcd<Odd<Yp>> for Even<Xp>
 where
     Xp: Gcd<Odd<Yp>>,
@@ -1420,10 +1420,10 @@ where
     type Output = Gcf<Xp, Odd<Yp>>;
 }
 
-// gcd(x, y) = gcd([max(x, y) - min(x, y)], min(x, y)) if both x and y odd
-//
-// This will immediately invoke the case for x even and y odd because the difference of two odd
-// numbers is an even number.
+/// gcd(x, y) = gcd([max(x, y) - min(x, y)], min(x, y)) if both x and y odd
+///
+/// This will immediately invoke the case for x even and y odd because the difference of two odd
+/// numbers is an even number.
 impl<Xp, Yp> Gcd<Odd<Yp>> for Odd<Xp>
 where
     Odd<Xp>: Max<Odd<Yp>> + Min<Odd<Yp>>,
@@ -1431,13 +1431,8 @@ where
     Maximum<Odd<Xp>, Odd<Yp>>: Sub<Minimum<Odd<Xp>, Odd<Yp>>>,
     Diff<Maximum<Odd<Xp>, Odd<Yp>>, Minimum<Odd<Xp>, Odd<Yp>>>: Gcd<Minimum<Odd<Xp>, Odd<Yp>>>,
 {
-    type Output = Gcf<
-        Diff<
-            Maximum<Odd<Xp>, Odd<Yp>>,
-            Minimum<Odd<Xp>, Odd<Yp>>
-        >,
-        Minimum<Odd<Xp>, Odd<Yp>>
-    >;
+    type Output =
+        Gcf<Diff<Maximum<Odd<Xp>, Odd<Yp>>, Minimum<Odd<Xp>, Odd<Yp>>>, Minimum<Odd<Xp>, Odd<Yp>>>;
 }
 
 #[cfg(test)]
@@ -1459,6 +1454,7 @@ mod gcd_tests {
     #[test]
     fn gcd() {
         gcd_test! {
+            U0,   U0    => U0,
             U0,   U42   => U42,
             U12,  U8    => U4,
             U13,  U1013 => U1,  // Two primes


### PR DESCRIPTION
Implements the [binary GCD](https://en.wikipedia.org/wiki/Binary_GCD_algorithm) algorithm for type-level integers.

Same as #101 
cc #97