### PR TITLE
Add feature `force_unix_path_separator`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ rust:
 cache: cargo
 os:
   - linux
-  - osx
   - windows
 matrix:
   allow_failures:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The MSRV (Minimum Supported Rust Version) is 1.22.0, and typenum is tested again
 version. Much of typenum should work on as low a version as 1.20.0, but that is not guaranteed.
 
 ### Unreleased
+- [added] Feature `force_unix_path_separator` to support building without Cargo.
 - [added] Greatest common divisor operator `Gcd` with alias `Gcf`.
 - [added] `gcd` to the `op!` macro.
 - [changed] Added `Copy` bound to `Rhs` of `Mul<Rhs>` impl for `<TArr<V, A>`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@
   no_std = []
   i128 = []
   strict = []
+  force_unix_path_separator = []

--- a/build/main.rs
+++ b/build/main.rs
@@ -88,7 +88,7 @@ fn main() {
 
     let out_dir = env::var("OUT_DIR").unwrap();
     let dest = Path::new(&out_dir).join("consts.rs");
-    println!("cargo:rustc-env=TYPENUM_BUILD_OP={}", dest.display());
+    println!("cargo:rustc-env=TYPENUM_BUILD_CONSTS={}", dest.display());
 
     let mut f = File::create(&dest).unwrap();
 

--- a/build/op.rs
+++ b/build/op.rs
@@ -18,7 +18,7 @@ struct Op {
 pub fn write_op_macro() -> ::std::io::Result<()> {
     let out_dir = ::std::env::var("OUT_DIR").unwrap();
     let dest = ::std::path::Path::new(&out_dir).join("op.rs");
-    println!("cargo:rustc-env=TYPENUM_BUILD_CONSTS={}", dest.display());
+    println!("cargo:rustc-env=TYPENUM_BUILD_OP={}", dest.display());
     let mut f = ::std::fs::File::create(&dest).unwrap();
 
     // Operator precedence is taken from

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,8 +65,17 @@
 
 use core::cmp::Ordering;
 
-include!(env!("TYPENUM_BUILD_OP"));
-include!(env!("TYPENUM_BUILD_CONSTS"));
+#[cfg(feature = "force_unix_path_separator")]
+mod generated {
+    include!(concat!(env!("OUT_DIR"), "/op.rs"));
+    include!(concat!(env!("OUT_DIR"), "/consts.rs"));
+}
+
+#[cfg(not(feature = "force_unix_path_separator"))]
+mod generated {
+    include!(env!("TYPENUM_BUILD_OP"));
+    include!(env!("TYPENUM_BUILD_CONSTS"));
+}
 
 pub mod bit;
 pub mod int;
@@ -79,6 +88,7 @@ pub mod uint;
 pub mod array;
 
 pub use consts::*;
+pub use generated::consts;
 pub use marker_traits::*;
 pub use operator_aliases::*;
 pub use type_operators::*;


### PR DESCRIPTION
This allows for building without using Cargo, such as with Bazel.

Fixes #127.