### PR TITLE
Add impl Pow<NInt<...>> for f{32,64}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ version. Much of typenum should work on as low a version as 1.20.0, but that is 
 
 ### Unreleased
 
+- [added] Implementation of `Pow` trait for f32 and f64 with negative exponent
+
 ### 1.12.0 (2020-04-13)
 - [added] Feature `force_unix_path_separator` to support building without Cargo.
 - [added] Greatest common divisor operator `Gcd` with alias `Gcf`.

--- a/src/type_operators.rs
+++ b/src/type_operators.rs
@@ -171,6 +171,14 @@ macro_rules! impl_pow_f {
                 acc
             }
         }
+
+        impl<U: Unsigned + NonZero> Pow<NInt<U>> for $t {
+            type Output = $t;
+
+            fn powi(self, _: NInt<U>) -> Self::Output {
+                <$t as Pow<PInt<U>>>::powi(self, PInt::new()).recip()
+            }
+        }
     };
 }
 
@@ -228,6 +236,7 @@ fn pow_test() {
 
     let u0 = U0::new();
     let u3 = U3::new();
+    let n3 = N3::new();
 
     macro_rules! check {
         ($x:ident) => {
@@ -243,6 +252,12 @@ fn pow_test() {
 
             assert!((<$f as Pow<P3>>::powi(*$x, p3) - $x * $x * $x).abs() < ::core::$f::EPSILON);
             assert!((<$f as Pow<U3>>::powi(*$x, u3) - $x * $x * $x).abs() < ::core::$f::EPSILON);
+
+            if *$x == 0.0 {
+                assert!(<$f as Pow<N3>>::powi(*$x, n3).is_infinite());
+            } else {
+                assert!((<$f as Pow<N3>>::powi(*$x, n3) - 1. / $x / $x / $x).abs() < ::core::$f::EPSILON);
+            }
         };
     }
 


### PR DESCRIPTION
Add implementation of `Pow` trait for f32 and f64 with negative exponent.

Resolves #113 (impls for `i*` and `u*` weren't added since those types can't be rational)