### PR TITLE
allow calling `assert_type{,_eq}!` at top-level

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rust:
   - stable
   - beta
   - nightly
-  - 1.22.0
+  - 1.37.0
 cache: cargo
 os:
   - linux

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 This project follows semantic versioning.
 
-The MSRV (Minimum Supported Rust Version) is 1.22.0, and typenum is tested against this Rust
+The MSRV (Minimum Supported Rust Version) is 1.37.0, and typenum is tested against this Rust
 version. Much of typenum should work on as low a version as 1.20.0, but that is not guaranteed.
 
 ### Unreleased
+
+- [changed] Allowed calling `assert_type_eq` and `assert_type` at top level
 
 ### 1.12.0 (2020-04-13)
 - [added] Feature `force_unix_path_separator` to support building without Cargo.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,7 +140,7 @@ impl Ord for Equal {
 #[macro_export]
 macro_rules! assert_type_eq {
     ($a:ty, $b:ty) => {
-        let _: <$a as $crate::Same<$b>>::Output;
+        const _: core::marker::PhantomData<<$a as $crate::Same<$b>>::Output> = core::marker::PhantomData;
     };
 }
 
@@ -148,6 +148,6 @@ macro_rules! assert_type_eq {
 #[macro_export]
 macro_rules! assert_type {
     ($a:ty) => {
-        let _: <$a as $crate::Same<True>>::Output;
+        const _: core::marker::PhantomData<<$a as $crate::Same<True>>::Output> = core::marker::PhantomData;
     };
 }


### PR DESCRIPTION
This PR allows using `assert_type_eq!` and `assert_type!` macros
at top-level.

This is done by using `const _` instead of `let _`. `const`s could not be
uninitialized, so PhantomData is also used.

Note: 
This requires `rustc` version `1.37.0` or higher (the version in which [`underscore_const_names` was stabilized](https://github.com/rust-lang/rust/pull/61347)).
If such a bump of MSRV is not acceptable either of 2 things can be done:
- simply close this pr*
- update this pr, so in the macros, there will be 2 branches - one with const, and one without**

Personally, I would prefer the second one, but both are fine.

*anyway on `1.37`+ you can do `const _: () = { assert_type_eq!(A, B) };`
**: 
  ```rust
  ($a:ty, $b:ty) => {
      let _: <$a as $crate::Same<$b>>::Output;
  };
  (const $a:ty, $b:ty) => {
      const _: core::marker::PhantomData<<$a as $crate::Same<$b>>::Output> = 
  core::marker::PhantomData;
  };
  ```