### PR TITLE
Migrate to 2018 edition (continuing #138)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rust:
   - stable
   - beta
   - nightly
-  - 1.22.0
+  - 1.31.0
 cache: cargo
 os:
   - linux

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@
   license = "MIT/Apache-2.0"
   description = "Typenum is a Rust library for type-level numbers evaluated at compile time. It currently supports bits, unsigned integers, and signed integers. It also provides a type-level array of type-level numbers, but its implementation is incomplete."
   categories = ["no-std"]
+  edition = "2018"
 
 [lib]
   name = "typenum"

--- a/build/main.rs
+++ b/build/main.rs
@@ -151,11 +151,11 @@ We also define the aliases `False` and `True` for `B0` and `B1`, respectively.
 */
 #[allow(missing_docs)]
 pub mod consts {{
-    use uint::{{UInt, UTerm}};
-    use int::{{PInt, NInt}};
+    use crate::uint::{{UInt, UTerm}};
+    use crate::int::{{PInt, NInt}};
 
-    pub use bit::{{B0, B1}};
-    pub use int::Z0;
+    pub use crate::bit::{{B0, B1}};
+    pub use crate::int::Z0;
 
     pub type True = B1;
     pub type False = B0;

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+format_code_in_doc_comments = true

--- a/src/bit.rs
+++ b/src/bit.rs
@@ -10,11 +10,10 @@
 //! - From `typenum`: `Same` and `Cmp`.
 //!
 
+use crate::{private::InternalMarker, Cmp, Equal, Greater, Less, NonZero, PowerOfTwo};
 use core::ops::{BitAnd, BitOr, BitXor, Not};
-use private::InternalMarker;
-use {Cmp, Equal, Greater, Less, NonZero, PowerOfTwo};
 
-pub use marker_traits::Bit;
+pub use crate::marker_traits::Bit;
 
 /// The type-level bit 0.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug, Default)]
@@ -248,7 +247,7 @@ impl Cmp<B1> for B1 {
     }
 }
 
-use Min;
+use crate::Min;
 impl Min<B0> for B0 {
     type Output = B0;
     #[inline]
@@ -278,7 +277,7 @@ impl Min<B1> for B1 {
     }
 }
 
-use Max;
+use crate::Max;
 impl Max<B0> for B0 {
     type Output = B0;
     #[inline]

--- a/src/int.rs
+++ b/src/int.rs
@@ -25,18 +25,16 @@
 //! assert_eq!(<N3 as Div<P2>>::Output::to_i32(), -1);
 //! assert_eq!(<N3 as Rem<P2>>::Output::to_i32(), -1);
 //! ```
-//!
 
+pub use crate::marker_traits::Integer;
+use crate::{
+    bit::{Bit, B0, B1},
+    consts::{N1, P1, U0, U1},
+    private::{Internal, InternalMarker, PrivateDivInt, PrivateIntegerAdd, PrivateRem},
+    uint::{UInt, Unsigned},
+    Cmp, Equal, Greater, Less, NonZero, Pow, PowerOfTwo,
+};
 use core::ops::{Add, Div, Mul, Neg, Rem, Sub};
-
-use bit::{Bit, B0, B1};
-use consts::{N1, P1, U0, U1};
-use private::{Internal, InternalMarker};
-use private::{PrivateDivInt, PrivateIntegerAdd, PrivateRem};
-use uint::{UInt, Unsigned};
-use {Cmp, Equal, Greater, Less, NonZero, Pow, PowerOfTwo};
-
-pub use marker_traits::Integer;
 
 /// Type-level signed integers with positive sign.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug, Default)]
@@ -610,7 +608,7 @@ impl_int_div!(NInt, NInt, PInt);
 // ---------------------------------------------------------------------------------------
 // PartialDiv
 
-use {PartialDiv, Quot};
+use crate::{PartialDiv, Quot};
 
 impl<M, N> PartialDiv<N> for M
 where
@@ -888,7 +886,7 @@ where
 
 // ---------------------------------------------------------------------------------------
 // Gcd
-use {Gcd, Gcf};
+use crate::{Gcd, Gcf};
 
 impl Gcd<Z0> for Z0 {
     type Output = Z0;
@@ -960,7 +958,7 @@ where
 
 // ---------------------------------------------------------------------------------------
 // Min
-use {Max, Maximum, Min, Minimum};
+use crate::{Max, Maximum, Min, Minimum};
 
 impl Min<Z0> for Z0 {
     type Output = Z0;
@@ -1179,8 +1177,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use consts::*;
-    use Integer;
+    use crate::{consts::*, Integer};
 
     #[test]
     fn to_ix_min() {

--- a/src/int.rs
+++ b/src/int.rs
@@ -16,7 +16,7 @@
 //!
 //! # Example
 //! ```rust
-//! use std::ops::{Add, Sub, Mul, Div, Rem};
+//! use std::ops::{Add, Div, Mul, Rem, Sub};
 //! use typenum::{Integer, N3, P2};
 //!
 //! assert_eq!(<N3 as Add<P2>>::Output::to_i32(), -1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 //! example,
 //!
 //! ```rust
-//! use typenum::{N4, Integer};
+//! use typenum::{Integer, N4};
 //!
 //! assert_eq!(N4::to_i32(), -4);
 //! ```
@@ -34,14 +34,13 @@
 //! could be replaced with
 //!
 //! ```rust
-//! use typenum::{Sum, Integer, P3, P4};
+//! use typenum::{Integer, Sum, P3, P4};
 //!
 //! type X = Sum<P3, P4>;
 //! assert_eq!(<X as Integer>::to_i32(), 7);
 //! ```
 //!
 //! Documented in each module is the full list of type operators implemented.
-//!
 
 #![no_std]
 #![forbid(unsafe_code)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,15 +86,16 @@ pub mod uint;
 
 pub mod array;
 
-pub use consts::*;
-pub use generated::consts;
-pub use marker_traits::*;
-pub use operator_aliases::*;
-pub use type_operators::*;
-
-pub use array::{ATerm, TArr};
-pub use int::{NInt, PInt};
-pub use uint::{UInt, UTerm};
+pub use crate::{
+    array::{ATerm, TArr},
+    consts::*,
+    generated::consts,
+    int::{NInt, PInt},
+    marker_traits::*,
+    operator_aliases::*,
+    type_operators::*,
+    uint::{UInt, UTerm},
+};
 
 /// A potential output from `Cmp`, this is the type equivalent to the enum variant
 /// `core::cmp::Ordering::Greater`.

--- a/src/marker_traits.rs
+++ b/src/marker_traits.rs
@@ -9,7 +9,7 @@
 //! to_i32() -> i32` and the associated constant `I32` so that one can do this:
 //!
 //! ```
-//! use typenum::{N42, Integer};
+//! use typenum::{Integer, N42};
 //!
 //! assert_eq!(-42, N42::to_i32());
 //! assert_eq!(-42, N42::I32);
@@ -49,7 +49,7 @@ pub trait Bit: Copy + Default {
 ///
 /// # Example
 /// ```rust
-/// use typenum::{U3, Unsigned};
+/// use typenum::{Unsigned, U3};
 ///
 /// assert_eq!(U3::to_u32(), 3);
 /// assert_eq!(U3::I32, 3);
@@ -118,7 +118,7 @@ pub trait Unsigned: Copy + Default {
 ///
 /// # Example
 /// ```rust
-/// use typenum::{P3, Integer};
+/// use typenum::{Integer, P3};
 ///
 /// assert_eq!(P3::to_i32(), 3);
 /// assert_eq!(P3::I32, 3);
@@ -171,9 +171,9 @@ pub trait TypeArray {}
 /// Here's a working example:
 ///
 /// ```rust
-/// use typenum::{P4, P8, PowerOfTwo};
+/// use typenum::{PowerOfTwo, P4, P8};
 ///
-/// fn only_p2<P: PowerOfTwo>() { }
+/// fn only_p2<P: PowerOfTwo>() {}
 ///
 /// only_p2::<P4>();
 /// only_p2::<P8>();

--- a/src/operator_aliases.rs
+++ b/src/operator_aliases.rs
@@ -7,7 +7,6 @@
 //!
 //! ```rust
 //! # #[macro_use] extern crate typenum;
-//! # fn main() {
 //! use std::ops::Mul;
 //! use typenum::{Prod, P5, P7};
 //!
@@ -15,14 +14,15 @@
 //! type Y = Prod<P7, P5>;
 //!
 //! assert_type_eq!(X, Y);
-//! # }
 //! ```
 //!
 //!
 
 // Aliases!!!
+use crate::type_operators::{
+    Abs, Cmp, Gcd, Len, Logarithm2, Max, Min, PartialDiv, Pow, SquareRoot,
+};
 use core::ops::{Add, BitAnd, BitOr, BitXor, Div, Mul, Neg, Rem, Shl, Shr, Sub};
-use type_operators::{Abs, Cmp, Gcd, Len, Logarithm2, Max, Min, PartialDiv, Pow, SquareRoot};
 
 /// Alias for the associated type of `BitAnd`: `And<A, B> = <A as BitAnd<B>>::Output`
 pub type And<A, B> = <A as BitAnd<B>>::Output;
@@ -64,12 +64,12 @@ pub type Exp<A, B> = <A as Pow<B>>::Output;
 pub type Gcf<A, B> = <A as Gcd<B>>::Output;
 
 /// Alias to make it easy to add 1: `Add1<A> = <A as Add<B1>>::Output`
-pub type Add1<A> = <A as Add<::bit::B1>>::Output;
+pub type Add1<A> = <A as Add<crate::bit::B1>>::Output;
 /// Alias to make it easy to subtract 1: `Sub1<A> = <A as Sub<B1>>::Output`
-pub type Sub1<A> = <A as Sub<::bit::B1>>::Output;
+pub type Sub1<A> = <A as Sub<crate::bit::B1>>::Output;
 
 /// Alias to make it easy to multiply by 2. `Double<A> = Shleft<A, B1>`
-pub type Double<A> = Shleft<A, ::bit::B1>;
+pub type Double<A> = Shleft<A, crate::bit::B1>;
 
 /// Alias to make it easy to square. `Square<A> = <A as Mul<A>>::Output`
 pub type Square<A> = <A as Mul>::Output;
@@ -91,7 +91,9 @@ pub type Minimum<A, B> = <A as Min<B>>::Output;
 /// Alias for the associated type of `Max`: `Maximum<A, B> = <A as Max<B>>::Output`
 pub type Maximum<A, B> = <A as Max<B>>::Output;
 
-use type_operators::{IsEqual, IsGreater, IsGreaterOrEqual, IsLess, IsLessOrEqual, IsNotEqual};
+use crate::type_operators::{
+    IsEqual, IsGreater, IsGreaterOrEqual, IsLess, IsLessOrEqual, IsNotEqual,
+};
 /// Alias for the associated type of `IsLess`: `Le<A, B> = <A as IsLess<B>>::Output`
 pub type Le<A, B> = <A as IsLess<B>>::Output;
 /// Alias for the associated type of `IsEqual`: `Eq<A, B> = <A as IsEqual<B>>::Output`

--- a/src/private.rs
+++ b/src/private.rs
@@ -17,12 +17,13 @@
 //!
 //! Note: Aliases for private type operators will all be named simply that operator followed
 //! by an abbreviated name of its associated type.
-//!
 
 #![doc(hidden)]
 
-use bit::{Bit, B0, B1};
-use uint::{UInt, UTerm, Unsigned};
+use crate::{
+    bit::{Bit, B0, B1},
+    uint::{UInt, UTerm, Unsigned},
+};
 
 /// A marker for restricting a method on a public trait to internal use only.
 pub(crate) enum Internal {}
@@ -63,7 +64,7 @@ pub type InvertOut<A> = <A as Invert>::Output;
 pub trait PrivateInvert<Rhs> {
     type Output;
 
-    fn private_invert(self, Rhs) -> Self::Output;
+    fn private_invert(self, rhs: Rhs) -> Self::Output;
 }
 pub type PrivateInvertOut<A, Rhs> = <A as PrivateInvert<Rhs>>::Output;
 
@@ -80,7 +81,7 @@ pub struct InvertedUInt<IU: InvertedUnsigned, B: Bit> {
 pub trait PrivateAnd<Rhs = Self> {
     type Output;
 
-    fn private_and(self, Rhs) -> Self::Output;
+    fn private_and(self, rhs: Rhs) -> Self::Output;
 }
 pub type PrivateAndOut<A, Rhs> = <A as PrivateAnd<Rhs>>::Output;
 
@@ -88,7 +89,7 @@ pub type PrivateAndOut<A, Rhs> = <A as PrivateAnd<Rhs>>::Output;
 pub trait PrivateXor<Rhs = Self> {
     type Output;
 
-    fn private_xor(self, Rhs) -> Self::Output;
+    fn private_xor(self, rhs: Rhs) -> Self::Output;
 }
 pub type PrivateXorOut<A, Rhs> = <A as PrivateXor<Rhs>>::Output;
 
@@ -96,7 +97,7 @@ pub type PrivateXorOut<A, Rhs> = <A as PrivateXor<Rhs>>::Output;
 pub trait PrivateSub<Rhs = Self> {
     type Output;
 
-    fn private_sub(self, Rhs) -> Self::Output;
+    fn private_sub(self, rhs: Rhs) -> Self::Output;
 }
 pub type PrivateSubOut<A, Rhs> = <A as PrivateSub<Rhs>>::Output;
 
@@ -106,14 +107,14 @@ pub type PrivateSubOut<A, Rhs> = <A as PrivateSub<Rhs>>::Output;
 pub trait PrivateIntegerAdd<C, N> {
     type Output;
 
-    fn private_integer_add(self, C, N) -> Self::Output;
+    fn private_integer_add(self, _: C, _: N) -> Self::Output;
 }
 pub type PrivateIntegerAddOut<P, C, N> = <P as PrivateIntegerAdd<C, N>>::Output;
 
 pub trait PrivatePow<Y, N> {
     type Output;
 
-    fn private_pow(self, Y, N) -> Self::Output;
+    fn private_pow(self, _: Y, _: N) -> Self::Output;
 }
 pub type PrivatePowOut<A, Y, N> = <A as PrivatePow<Y, N>>::Output;
 
@@ -199,10 +200,10 @@ where
 
 #[test]
 fn test_inversion() {
-    type Test4 = <::consts::U4 as Invert>::Output;
-    type Test5 = <::consts::U5 as Invert>::Output;
-    type Test12 = <::consts::U12 as Invert>::Output;
-    type Test16 = <::consts::U16 as Invert>::Output;
+    type Test4 = <crate::consts::U4 as Invert>::Output;
+    type Test5 = <crate::consts::U5 as Invert>::Output;
+    type Test12 = <crate::consts::U12 as Invert>::Output;
+    type Test16 = <crate::consts::U16 as Invert>::Output;
 
     assert_eq!(1, <Test4 as InvertedUnsigned>::to_u64());
     assert_eq!(5, <Test5 as InvertedUnsigned>::to_u64());
@@ -260,10 +261,10 @@ where
 
 #[test]
 fn test_double_inversion() {
-    type Test4 = <<::consts::U4 as Invert>::Output as Invert>::Output;
-    type Test5 = <<::consts::U5 as Invert>::Output as Invert>::Output;
-    type Test12 = <<::consts::U12 as Invert>::Output as Invert>::Output;
-    type Test16 = <<::consts::U16 as Invert>::Output as Invert>::Output;
+    type Test4 = <<crate::consts::U4 as Invert>::Output as Invert>::Output;
+    type Test5 = <<crate::consts::U5 as Invert>::Output as Invert>::Output;
+    type Test12 = <<crate::consts::U12 as Invert>::Output as Invert>::Output;
+    type Test16 = <<crate::consts::U16 as Invert>::Output as Invert>::Output;
 
     assert_eq!(4, <Test4 as Unsigned>::to_u64());
     assert_eq!(5, <Test5 as Unsigned>::to_u64());
@@ -320,7 +321,7 @@ where
 pub trait PrivateCmp<Rhs, SoFar> {
     type Output;
 
-    fn private_cmp(&self, &Rhs, SoFar) -> Self::Output;
+    fn private_cmp(&self, _: &Rhs, _: SoFar) -> Self::Output;
 }
 pub type PrivateCmpOut<A, Rhs, SoFar> = <A as PrivateCmp<Rhs, SoFar>>::Output;
 
@@ -328,7 +329,7 @@ pub type PrivateCmpOut<A, Rhs, SoFar> = <A as PrivateCmp<Rhs, SoFar>>::Output;
 pub trait PrivateSetBit<I, B> {
     type Output;
 
-    fn private_set_bit(self, I, B) -> Self::Output;
+    fn private_set_bit(self, _: I, _: B) -> Self::Output;
 }
 pub type PrivateSetBitOut<N, I, B> = <N as PrivateSetBit<I, B>>::Output;
 
@@ -337,9 +338,9 @@ pub trait PrivateDiv<N, D, Q, R, I> {
     type Quotient;
     type Remainder;
 
-    fn private_div_quotient(self, N, D, Q, R, I) -> Self::Quotient;
+    fn private_div_quotient(self, _: N, _: D, _: Q, _: R, _: I) -> Self::Quotient;
 
-    fn private_div_remainder(self, N, D, Q, R, I) -> Self::Remainder;
+    fn private_div_remainder(self, _: N, _: D, _: Q, _: R, _: I) -> Self::Remainder;
 }
 
 pub type PrivateDivQuot<N, D, Q, R, I> = <() as PrivateDiv<N, D, Q, R, I>>::Quotient;
@@ -349,9 +350,9 @@ pub trait PrivateDivIf<N, D, Q, R, I, RcmpD> {
     type Quotient;
     type Remainder;
 
-    fn private_div_if_quotient(self, N, D, Q, R, I, RcmpD) -> Self::Quotient;
+    fn private_div_if_quotient(self, _: N, _: D, _: Q, _: R, _: I, _: RcmpD) -> Self::Quotient;
 
-    fn private_div_if_remainder(self, N, D, Q, R, I, RcmpD) -> Self::Remainder;
+    fn private_div_if_remainder(self, _: N, _: D, _: Q, _: R, _: I, _: RcmpD) -> Self::Remainder;
 }
 
 pub type PrivateDivIfQuot<N, D, Q, R, I, RcmpD> =
@@ -363,38 +364,38 @@ pub type PrivateDivIfRem<N, D, Q, R, I, RcmpD> =
 pub trait PrivateDivInt<C, Divisor> {
     type Output;
 
-    fn private_div_int(self, C, Divisor) -> Self::Output;
+    fn private_div_int(self, _: C, _: Divisor) -> Self::Output;
 }
 pub type PrivateDivIntOut<A, C, Divisor> = <A as PrivateDivInt<C, Divisor>>::Output;
 
 pub trait PrivateRem<URem, Divisor> {
     type Output;
 
-    fn private_rem(self, URem, Divisor) -> Self::Output;
+    fn private_rem(self, _: URem, _: Divisor) -> Self::Output;
 }
 pub type PrivateRemOut<A, URem, Divisor> = <A as PrivateRem<URem, Divisor>>::Output;
 
 // min max
 pub trait PrivateMin<Rhs, CmpResult> {
     type Output;
-    fn private_min(self, Rhs) -> Self::Output;
+    fn private_min(self, rhs: Rhs) -> Self::Output;
 }
 pub type PrivateMinOut<A, B, CmpResult> = <A as PrivateMin<B, CmpResult>>::Output;
 
 pub trait PrivateMax<Rhs, CmpResult> {
     type Output;
-    fn private_max(self, Rhs) -> Self::Output;
+    fn private_max(self, rhs: Rhs) -> Self::Output;
 }
 pub type PrivateMaxOut<A, B, CmpResult> = <A as PrivateMax<B, CmpResult>>::Output;
 
 // Comparisons
 
-use {Equal, False, Greater, Less, True};
+use crate::{Equal, False, Greater, Less, True};
 
 pub trait IsLessPrivate<Rhs, Cmp> {
     type Output: Bit;
 
-    fn is_less_private(self, Rhs, Cmp) -> Self::Output;
+    fn is_less_private(self, _: Rhs, _: Cmp) -> Self::Output;
 }
 
 impl<A, B> IsLessPrivate<B, Less> for A {
@@ -425,7 +426,7 @@ impl<A, B> IsLessPrivate<B, Greater> for A {
 pub trait IsEqualPrivate<Rhs, Cmp> {
     type Output: Bit;
 
-    fn is_equal_private(self, Rhs, Cmp) -> Self::Output;
+    fn is_equal_private(self, _: Rhs, _: Cmp) -> Self::Output;
 }
 
 impl<A, B> IsEqualPrivate<B, Less> for A {
@@ -456,7 +457,7 @@ impl<A, B> IsEqualPrivate<B, Greater> for A {
 pub trait IsGreaterPrivate<Rhs, Cmp> {
     type Output: Bit;
 
-    fn is_greater_private(self, Rhs, Cmp) -> Self::Output;
+    fn is_greater_private(self, _: Rhs, _: Cmp) -> Self::Output;
 }
 
 impl<A, B> IsGreaterPrivate<B, Less> for A {
@@ -487,7 +488,7 @@ impl<A, B> IsGreaterPrivate<B, Greater> for A {
 pub trait IsLessOrEqualPrivate<Rhs, Cmp> {
     type Output: Bit;
 
-    fn is_less_or_equal_private(self, Rhs, Cmp) -> Self::Output;
+    fn is_less_or_equal_private(self, _: Rhs, _: Cmp) -> Self::Output;
 }
 
 impl<A, B> IsLessOrEqualPrivate<B, Less> for A {
@@ -518,7 +519,7 @@ impl<A, B> IsLessOrEqualPrivate<B, Greater> for A {
 pub trait IsNotEqualPrivate<Rhs, Cmp> {
     type Output: Bit;
 
-    fn is_not_equal_private(self, Rhs, Cmp) -> Self::Output;
+    fn is_not_equal_private(self, _: Rhs, _: Cmp) -> Self::Output;
 }
 
 impl<A, B> IsNotEqualPrivate<B, Less> for A {
@@ -549,7 +550,7 @@ impl<A, B> IsNotEqualPrivate<B, Greater> for A {
 pub trait IsGreaterOrEqualPrivate<Rhs, Cmp> {
     type Output: Bit;
 
-    fn is_greater_or_equal_private(self, Rhs, Cmp) -> Self::Output;
+    fn is_greater_or_equal_private(self, _: Rhs, _: Cmp) -> Self::Output;
 }
 
 impl<A, B> IsGreaterOrEqualPrivate<B, Less> for A {

--- a/src/type_operators.rs
+++ b/src/type_operators.rs
@@ -15,7 +15,7 @@ use {Bit, NInt, NonZero, PInt, UInt, UTerm, Unsigned, Z0};
 ///
 /// # Example
 /// ```rust
-/// use typenum::{Same, U4, U5, Unsigned};
+/// use typenum::{Same, Unsigned, U4, U5};
 ///
 /// assert_eq!(<U5 as Same<U5>>::Output::to_u32(), 5);
 ///
@@ -38,7 +38,7 @@ impl<T> Same<T> for T {
 ///
 /// # Example
 /// ```rust
-/// use typenum::{Abs, N5, Integer};
+/// use typenum::{Abs, Integer, N5};
 ///
 /// assert_eq!(<N5 as Abs>::Output::to_i32(), 5);
 /// ```
@@ -63,7 +63,7 @@ impl<U: Unsigned + NonZero> Abs for NInt<U> {
 ///
 /// # Example
 /// ```rust
-/// use typenum::{Pow, N3, P3, Integer};
+/// use typenum::{Integer, Pow, N3, P3};
 ///
 /// assert_eq!(<N3 as Pow<P3>>::Output::to_i32(), -27);
 /// ```
@@ -550,7 +550,7 @@ pub trait Logarithm2 {
 /// # Example
 ///
 /// ```rust
-/// use typenum::{Gcd, U12, U8, Unsigned};
+/// use typenum::{Gcd, Unsigned, U12, U8};
 ///
 /// assert_eq!(<U12 as Gcd<U8>>::Output::to_i32(), 4);
 /// ```

--- a/src/type_operators.rs
+++ b/src/type_operators.rs
@@ -1,8 +1,9 @@
 //! Useful **type operators** that are not defined in `core::ops`.
-//!
 
-use private::{Internal, InternalMarker};
-use {Bit, NInt, NonZero, PInt, UInt, UTerm, Unsigned, Z0};
+use crate::{
+    private::{Internal, InternalMarker},
+    Bit, NInt, NonZero, PInt, UInt, UTerm, Unsigned, Z0,
+};
 
 /// A **type operator** that ensures that `Rhs` is the same as `Self`, it is mainly useful
 /// for writing macros that can take arbitrary binary or unary operators.
@@ -222,7 +223,7 @@ impl_pow_i!(u128, i128);
 
 #[test]
 fn pow_test() {
-    use consts::*;
+    use crate::consts::*;
     let z0 = Z0::new();
     let p3 = P3::new();
 
@@ -284,13 +285,13 @@ pub trait Cmp<Rhs = Self> {
     type Output;
 
     #[doc(hidden)]
-    fn compare<IM: InternalMarker>(&self, &Rhs) -> Self::Output;
+    fn compare<IM: InternalMarker>(&self, _: &Rhs) -> Self::Output;
 }
 
 /// A **type operator** that gives the length of an `Array` or the number of bits in a `UInt`.
 pub trait Len {
     /// The length as a type-level unsigned integer.
-    type Output: ::Unsigned;
+    type Output: crate::Unsigned;
     /// This function isn't used in this crate, but may be useful for others.
     fn len(&self) -> Self::Output;
 }
@@ -320,7 +321,7 @@ pub trait Max<Rhs = Self> {
     fn max(self, rhs: Rhs) -> Self::Output;
 }
 
-use Compare;
+use crate::Compare;
 
 /// A **type operator** that returns `True` if `Self < Rhs`, otherwise returns `False`.
 pub trait IsLess<Rhs = Self> {
@@ -330,7 +331,7 @@ pub trait IsLess<Rhs = Self> {
     fn is_less(self, rhs: Rhs) -> Self::Output;
 }
 
-use private::IsLessPrivate;
+use crate::private::IsLessPrivate;
 impl<A, B> IsLess<B> for A
 where
     A: Cmp<B> + IsLessPrivate<B, Compare<A, B>>,
@@ -352,7 +353,7 @@ pub trait IsEqual<Rhs = Self> {
     fn is_equal(self, rhs: Rhs) -> Self::Output;
 }
 
-use private::IsEqualPrivate;
+use crate::private::IsEqualPrivate;
 impl<A, B> IsEqual<B> for A
 where
     A: Cmp<B> + IsEqualPrivate<B, Compare<A, B>>,
@@ -374,7 +375,7 @@ pub trait IsGreater<Rhs = Self> {
     fn is_greater(self, rhs: Rhs) -> Self::Output;
 }
 
-use private::IsGreaterPrivate;
+use crate::private::IsGreaterPrivate;
 impl<A, B> IsGreater<B> for A
 where
     A: Cmp<B> + IsGreaterPrivate<B, Compare<A, B>>,
@@ -396,7 +397,7 @@ pub trait IsLessOrEqual<Rhs = Self> {
     fn is_less_or_equal(self, rhs: Rhs) -> Self::Output;
 }
 
-use private::IsLessOrEqualPrivate;
+use crate::private::IsLessOrEqualPrivate;
 impl<A, B> IsLessOrEqual<B> for A
 where
     A: Cmp<B> + IsLessOrEqualPrivate<B, Compare<A, B>>,
@@ -418,7 +419,7 @@ pub trait IsNotEqual<Rhs = Self> {
     fn is_not_equal(self, rhs: Rhs) -> Self::Output;
 }
 
-use private::IsNotEqualPrivate;
+use crate::private::IsNotEqualPrivate;
 impl<A, B> IsNotEqual<B> for A
 where
     A: Cmp<B> + IsNotEqualPrivate<B, Compare<A, B>>,
@@ -440,7 +441,7 @@ pub trait IsGreaterOrEqual<Rhs = Self> {
     fn is_greater_or_equal(self, rhs: Rhs) -> Self::Output;
 }
 
-use private::IsGreaterOrEqualPrivate;
+use crate::private::IsGreaterOrEqualPrivate;
 impl<A, B> IsGreaterOrEqual<B> for A
 where
     A: Cmp<B> + IsGreaterOrEqualPrivate<B, Compare<A, B>>,

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -12,7 +12,7 @@
 //!
 //! # Example
 //! ```rust
-//! use std::ops::{BitAnd, BitOr, BitXor, Shl, Shr, Add, Sub, Mul, Div, Rem};
+//! use std::ops::{Add, BitAnd, BitOr, BitXor, Div, Mul, Rem, Shl, Shr, Sub};
 //! use typenum::{Unsigned, U1, U2, U3, U4};
 //!
 //! assert_eq!(<U3 as BitAnd<U2>>::Output::to_u32(), 2);
@@ -146,7 +146,7 @@ impl Unsigned for UTerm {
 ///
 /// # Example
 /// ```rust
-/// use typenum::{B0, B1, UInt, UTerm};
+/// use typenum::{UInt, UTerm, B0, B1};
 ///
 /// # #[allow(dead_code)]
 /// type U6 = UInt<UInt<UInt<UTerm, B1>, B1>, B0>;

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -3,7 +3,7 @@
 //!
 //! **Type operators** implemented:
 //!
-//! From `core::ops`: `BitAnd`, `BitOr`, `BitXor`, `Shl`, `Shr`, `Add`, `Sub`,
+//! From `::core::ops`: `BitAnd`, `BitOr`, `BitXor`, `Shl`, `Shr`, `Add`, `Sub`,
 //!                 `Mul`, `Div`, and `Rem`.
 //! From `typenum`: `Same`, `Cmp`, and `Pow`.
 //!
@@ -26,31 +26,22 @@
 //! assert_eq!(<U3 as Div<U2>>::Output::to_u32(), 1);
 //! assert_eq!(<U3 as Rem<U2>>::Output::to_u32(), 1);
 //! ```
-//!
 
+use crate::{
+    bit::{Bit, B0, B1},
+    consts::{U0, U1},
+    private::{
+        BitDiff, BitDiffOut, Internal, InternalMarker, PrivateAnd, PrivateAndOut, PrivateCmp,
+        PrivateCmpOut, PrivateLogarithm2, PrivatePow, PrivatePowOut, PrivateSquareRoot, PrivateSub,
+        PrivateSubOut, PrivateXor, PrivateXorOut, Trim, TrimOut,
+    },
+    Add1, Cmp, Double, Equal, Gcd, Gcf, GrEq, Greater, IsGreaterOrEqual, Len, Length, Less, Log2,
+    Logarithm2, Maximum, Minimum, NonZero, Or, Ord, Pow, Prod, Shleft, Shright, Sqrt, Square,
+    SquareRoot, Sub1, Sum,
+};
 use core::ops::{Add, BitAnd, BitOr, BitXor, Mul, Shl, Shr, Sub};
-use {
-    Cmp, Equal, Gcd, Greater, IsGreaterOrEqual, Len, Less, Logarithm2, Maximum, Minimum, NonZero,
-    Ord, Pow, SquareRoot,
-};
 
-use bit::{Bit, B0, B1};
-
-use private::{
-    BitDiff, PrivateAnd, PrivateCmp, PrivateLogarithm2, PrivatePow, PrivateSquareRoot, PrivateSub,
-    PrivateXor, Trim,
-};
-
-use private::{
-    BitDiffOut, PrivateAndOut, PrivateCmpOut, PrivatePowOut, PrivateSubOut, PrivateXorOut, TrimOut,
-};
-
-use private::{Internal, InternalMarker};
-
-use consts::{U0, U1};
-use {Add1, Double, Gcf, GrEq, Length, Log2, Or, Prod, Shleft, Shright, Sqrt, Square, Sub1, Sum};
-
-pub use marker_traits::{PowerOfTwo, Unsigned};
+pub use crate::marker_traits::{PowerOfTwo, Unsigned};
 
 /// The terminating type for `UInt`; it always comes after the most significant
 /// bit. `UTerm` by itself represents zero, which is aliased to `U0`.
@@ -1289,7 +1280,7 @@ where
 
 // ---------------------------------------------------------------------------------------
 // Shifting one number until it's the size of another
-use private::ShiftDiff;
+use crate::private::ShiftDiff;
 impl<Ul: Unsigned, Ur: Unsigned> ShiftDiff<Ur> for Ul
 where
     Ur: BitDiff<Ul>,
@@ -1439,7 +1430,7 @@ where
 #[cfg(test)]
 mod gcd_tests {
     use super::*;
-    use consts::*;
+    use crate::consts::*;
 
     macro_rules! gcd_test {
         (
@@ -1475,7 +1466,7 @@ pub trait GetBit<I> {
     type Output;
 
     #[doc(hidden)]
-    fn get_bit<IM: InternalMarker>(&self, &I) -> Self::Output;
+    fn get_bit<IM: InternalMarker>(&self, _: &I) -> Self::Output;
 }
 
 #[allow(missing_docs)]
@@ -1520,8 +1511,8 @@ impl<I> GetBit<I> for UTerm {
 
 #[test]
 fn test_get_bit() {
-    use consts::*;
-    use Same;
+    use crate::consts::*;
+    use crate::Same;
     type T1 = <GetBitOut<U2, U0> as Same<B0>>::Output;
     type T2 = <GetBitOut<U2, U1> as Same<B1>>::Output;
     type T3 = <GetBitOut<U2, U2> as Same<B0>>::Output;
@@ -1541,12 +1532,12 @@ pub trait SetBit<I, B> {
     type Output;
 
     #[doc(hidden)]
-    fn set_bit<IM: InternalMarker>(self, I, B) -> Self::Output;
+    fn set_bit<IM: InternalMarker>(self, _: I, _: B) -> Self::Output;
 }
 /// Alias for the result of calling `SetBit`: `SetBitOut<N, I, B> = <N as SetBit<I, B>>::Output`.
 pub type SetBitOut<N, I, B> = <N as SetBit<I, B>>::Output;
 
-use private::{PrivateSetBit, PrivateSetBitOut};
+use crate::private::{PrivateSetBit, PrivateSetBitOut};
 
 // Call private one then trim it
 impl<N, I, B> SetBit<I, B> for N
@@ -1617,8 +1608,8 @@ where
 
 #[test]
 fn test_set_bit() {
-    use consts::*;
-    use Same;
+    use crate::consts::*;
+    use crate::Same;
     type T1 = <SetBitOut<U2, U0, B0> as Same<U2>>::Output;
     type T2 = <SetBitOut<U2, U0, B1> as Same<U3>>::Output;
     type T3 = <SetBitOut<U2, U1, B0> as Same<U0>>::Output;
@@ -1669,8 +1660,8 @@ mod tests {
     }
     #[test]
     fn test_div() {
-        use consts::*;
-        use {Quot, Same};
+        use crate::consts::*;
+        use crate::{Quot, Same};
 
         test_div!(U0 / U1 = U0);
         test_div!(U1 / U1 = U1);
@@ -1747,9 +1738,9 @@ where
 
 // -----------------------------------------
 // PrivateDiv
-use private::{PrivateDiv, PrivateDivQuot, PrivateDivRem};
+use crate::private::{PrivateDiv, PrivateDivQuot, PrivateDivRem};
 
-use Compare;
+use crate::Compare;
 // R == 0: We set R = UInt<UTerm, N[i]>, then call out to PrivateDivIf for the if statement
 impl<N, D, Q, I> PrivateDiv<N, D, Q, U0, I> for ()
 where
@@ -1861,7 +1852,7 @@ where
 // -----------------------------------------
 // PrivateDivIf
 
-use private::{PrivateDivIf, PrivateDivIfQuot, PrivateDivIfRem};
+use crate::private::{PrivateDivIf, PrivateDivIfQuot, PrivateDivIfRem};
 
 // R < D, I > 0, we do nothing and recurse
 impl<N, D, Q, R, Ui, Bi> PrivateDivIf<N, D, Q, R, UInt<Ui, Bi>, Less> for ()
@@ -1940,7 +1931,7 @@ where {
     }
 }
 
-use Diff;
+use crate::Diff;
 // R > D, I > 0, we set R -= D, Q[I] = 1 and recurse
 impl<N, D, Q, R, Ui, Bi> PrivateDivIf<N, D, Q, R, UInt<Ui, Bi>, Greater> for ()
 where
@@ -2049,7 +2040,7 @@ where
 
 // -----------------------------------------
 // PartialDiv
-use {PartialDiv, Quot};
+use crate::{PartialDiv, Quot};
 impl<Ur: Unsigned, Br: Bit> PartialDiv<UInt<Ur, Br>> for UTerm {
     type Output = UTerm;
     #[inline]
@@ -2072,7 +2063,7 @@ where
 
 // -----------------------------------------
 // PrivateMin
-use private::{PrivateMin, PrivateMinOut};
+use crate::private::{PrivateMin, PrivateMinOut};
 
 impl<U, B, Ur> PrivateMin<Ur, Equal> for UInt<U, B>
 where
@@ -2115,7 +2106,7 @@ where
 
 // -----------------------------------------
 // Min
-use Min;
+use crate::Min;
 
 impl<U> Min<U> for UTerm
 where
@@ -2144,7 +2135,7 @@ where
 
 // -----------------------------------------
 // PrivateMax
-use private::{PrivateMax, PrivateMaxOut};
+use crate::private::{PrivateMax, PrivateMaxOut};
 
 impl<U, B, Ur> PrivateMax<Ur, Equal> for UInt<U, B>
 where
@@ -2187,7 +2178,7 @@ where
 
 // -----------------------------------------
 // Max
-use Max;
+use crate::Max;
 
 impl<U> Max<U> for UTerm
 where
@@ -2262,7 +2253,7 @@ where
 
 #[test]
 fn sqrt_test() {
-    use consts::*;
+    use crate::consts::*;
 
     assert_eq!(0, <Sqrt<U0>>::to_u32());
 
@@ -2326,7 +2317,7 @@ where
 
 #[test]
 fn log2_test() {
-    use consts::*;
+    use crate::consts::*;
 
     assert_eq!(0, <Log2<U1>>::to_u32());
 


### PR DESCRIPTION
Migrate to Rust 2018 edition and bump minimum rustc version to 1.31. It is rework of #138.