### PR TITLE
Add `local_inner_macros` for 2018 edition support.

### DIFF
--- a/build/op.rs
+++ b/build/op.rs
@@ -307,13 +307,13 @@ assert_type_eq!(op!({ex0}), {ex1});
     write!(
         f,
         "*/
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! op {{
     ($($tail:tt)*) => ( __op_internal__!($($tail)*) );
 }}
 
     #[doc(hidden)]
-    #[macro_export]
+    #[macro_export(local_inner_macros)]
     macro_rules! __op_internal__ {{
 "
     )?;


### PR DESCRIPTION
Closes #159 .