### PR TITLE
Set html_root_url attribute

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
   name = "typenum"
   build = "build/main.rs"
-  version = "1.13.0"
+  version = "1.13.0" # remember to update html_root_url
   authors = [
     "Paho Lurie-Gregg <paho@paholg.com>",
     "Andre Bogus <bogusandre@gmail.com>"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@
     )
 )]
 #![cfg_attr(feature = "cargo-clippy", deny(clippy::missing_inline_in_public_items))]
+#![doc(html_root_url = "https://docs.rs/typenum/1.13.0")]
 
 // For debugging macros:
 // #![feature(trace_macros)]


### PR DESCRIPTION
https://rust-lang.github.io/api-guidelines/documentation.html#crate-sets-html_root_url-attribute-c-html-root