### PR TITLE
add scale_info feauture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ against this Rust version.
 
 ### Unreleased
 
+### 1.15.0 (2021-12-06)
+- [added] New feauture `scale_info` for using inside [Substrate](https://github.com/paritytech/substrate.git)-based runtimes
+  (PR #175)
+
 ### 1.14.0 (2021-09-01)
 - [changed] Sealed all marker traits. Documentation already stated that these
   should not be implemented outside the crate, so this is not considered a

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@
   edition = "2018"
 
 [dependencies]
-scale-info = { version = "1.0", default-features = false }
+scale-info = { version = "1.0", default-features = false, optional=true }
 
 [lib]
   name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
   name = "typenum"
   build = "build/main.rs"
-  version = "1.14.1" # remember to update html_root_url
+  version = "1.15.0" # remember to update html_root_url
   authors = [
     "Paho Lurie-Gregg <paho@paholg.com>",
     "Andre Bogus <bogusandre@gmail.com>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
   name = "typenum"
   build = "build/main.rs"
-  version = "1.14.0" # remember to update html_root_url
+  version = "1.14.1" # remember to update html_root_url
   authors = [
     "Paho Lurie-Gregg <paho@paholg.com>",
     "Andre Bogus <bogusandre@gmail.com>"
@@ -17,6 +17,9 @@
   categories = ["no-std"]
   edition = "2018"
 
+[dependencies]
+scale-info = { version = "1.0", default-features = false }
+
 [lib]
   name = "typenum"
 
@@ -25,3 +28,4 @@
   i128 = []
   strict = []
   force_unix_path_separator = []
+  scale_info = ["scale-info/derive"]

--- a/src/array.rs
+++ b/src/array.rs
@@ -8,6 +8,7 @@ use super::*;
 
 /// The terminating type for type arrays.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug)]
+#[cfg_attr(feature = "scale_info", derive(scale_info::TypeInfo))]
 pub struct ATerm;
 
 impl TypeArray for ATerm {}
@@ -19,6 +20,7 @@ impl TypeArray for ATerm {}
 /// This array is only really designed to contain `Integer` types. If you use it with others, you
 /// may find it lacking functionality.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug)]
+#[cfg_attr(feature = "scale_info", derive(scale_info::TypeInfo))]
 pub struct TArr<V, A> {
     first: V,
     rest: A,

--- a/src/bit.rs
+++ b/src/bit.rs
@@ -16,6 +16,7 @@ pub use crate::marker_traits::Bit;
 
 /// The type-level bit 0.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug, Default)]
+#[cfg_attr(feature = "scale_info", derive(scale_info::TypeInfo))]
 pub struct B0;
 
 impl B0 {
@@ -28,6 +29,7 @@ impl B0 {
 
 /// The type-level bit 1.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug, Default)]
+#[cfg_attr(feature = "scale_info", derive(scale_info::TypeInfo))]
 pub struct B1;
 
 impl B1 {

--- a/src/int.rs
+++ b/src/int.rs
@@ -38,12 +38,14 @@ use core::ops::{Add, Div, Mul, Neg, Rem, Sub};
 
 /// Type-level signed integers with positive sign.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug, Default)]
+#[cfg_attr(feature = "scale_info", derive(scale_info::TypeInfo))]
 pub struct PInt<U: Unsigned + NonZero> {
     pub(crate) n: U,
 }
 
 /// Type-level signed integers with negative sign.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug, Default)]
+#[cfg_attr(feature = "scale_info", derive(scale_info::TypeInfo))]
 pub struct NInt<U: Unsigned + NonZero> {
     pub(crate) n: U,
 }
@@ -66,6 +68,7 @@ impl<U: Unsigned + NonZero> NInt<U> {
 
 /// The type-level signed integer 0.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug, Default)]
+#[cfg_attr(feature = "scale_info", derive(scale_info::TypeInfo))]
 pub struct Z0;
 
 impl Z0 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,16 +103,19 @@ pub use crate::{
 /// A potential output from `Cmp`, this is the type equivalent to the enum variant
 /// `core::cmp::Ordering::Greater`.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug, Default)]
+#[cfg_attr(feature = "scale_info", derive(scale_info::TypeInfo))]
 pub struct Greater;
 
 /// A potential output from `Cmp`, this is the type equivalent to the enum variant
 /// `core::cmp::Ordering::Less`.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug, Default)]
+#[cfg_attr(feature = "scale_info", derive(scale_info::TypeInfo))]
 pub struct Less;
 
 /// A potential output from `Cmp`, this is the type equivalent to the enum variant
 /// `core::cmp::Ordering::Equal`.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug, Default)]
+#[cfg_attr(feature = "scale_info", derive(scale_info::TypeInfo))]
 pub struct Equal;
 
 /// Returns `core::cmp::Ordering::Greater`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@
     )
 )]
 #![cfg_attr(feature = "cargo-clippy", deny(clippy::missing_inline_in_public_items))]
-#![doc(html_root_url = "https://docs.rs/typenum/1.14.0")]
+#![doc(html_root_url = "https://docs.rs/typenum/1.15.0")]
 
 // For debugging macros:
 // #![feature(trace_macros)]

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -46,6 +46,7 @@ pub use crate::marker_traits::{PowerOfTwo, Unsigned};
 /// The terminating type for `UInt`; it always comes after the most significant
 /// bit. `UTerm` by itself represents zero, which is aliased to `U0`.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug, Default)]
+#[cfg_attr(feature = "scale_info", derive(scale_info::TypeInfo))]
 pub struct UTerm;
 
 impl UTerm {

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -143,6 +143,7 @@ impl Unsigned for UTerm {
 /// type U6 = UInt<UInt<UInt<UTerm, B1>, B1>, B0>;
 /// ```
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug, Default)]
+#[cfg_attr(feature = "scale_info", derive(scale_info::TypeInfo))]
 pub struct UInt<U, B> {
     /// The more significant bits of `Self`.
     pub(crate) msb: U,


### PR DESCRIPTION
## Description
This pr adds new feature `scale_info` that adds `scale_info::TypeInfo` derive for all structs

## Justification
[Substrate](https://github.com/paritytech/substrate)'s new [Metadata](https://github.com/paritytech/substrate/pull/8615) introduces new restriction for runtime types: all encoded with SCALE codec types needs to be annotated with with scale_info::TypeInfo derive.
[substrate-fixed](https://github.com/encointer/substrate-fixed) trait depends on `typenum` and wildly used for building Substrate's runtimes so pr is usefull for all Substrate devs