### PR TITLE
Offer (opt-in) `const-generic` mappings. Mainly, a `U<N>` type alias.

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -21,6 +21,12 @@ jobs:
           - stable
           - beta
           - nightly
+        mb_const_generics:
+          - ""
+          - "--features const-generics"
+        exclude:
+          - mb_const_generics: "--features const-generics"
+            rust: 1.37.0
         include:
           - os: macos-latest
             rust: stable
@@ -36,11 +42,11 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --verbose --features "strict"
+          args: --verbose --features "strict" ${{ matrix.mb_const_generics }}
       - uses: actions-rs/cargo@v1
         with:
           command: doc
-          args: --features "strict"
+          args: --features "strict" ${{ matrix.mb_const_generics }}
 
   clippy:
     name: clippy + fmt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
   name = "typenum"
   build = "build/main.rs"
-  version = "1.14.0" # remember to update html_root_url
+  version = "1.15.0" # remember to update html_root_url
   authors = [
     "Paho Lurie-Gregg <paho@paholg.com>",
     "Andre Bogus <bogusandre@gmail.com>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,4 @@
   i128 = []
   strict = []
   force_unix_path_separator = []
+  const-generics = []

--- a/build/generic_const_mappings.rs
+++ b/build/generic_const_mappings.rs
@@ -1,0 +1,91 @@
+use super::*;
+
+pub fn emit_impls() -> ::std::io::Result<()> {
+    let out_dir = ::std::env::var("OUT_DIR").unwrap();
+    let dest = ::std::path::Path::new(&out_dir).join("generic_const_mappings.rs");
+    println!(
+        "cargo:rustc-env=TYPENUM_BUILD_GENERIC_CONSTS={}",
+        dest.display()
+    );
+    let mut f = ::std::fs::File::create(&dest).unwrap();
+
+    #[allow(clippy::write_literal)]
+    write!(f, "{}", "\
+#[cfg(doc)]
+use generic_const_mappings::*;
+
+/// Module with some `const`-generics-friendly definitions, to help bridge the gap
+/// between those and `typenum` types.
+///
+///   - It requires the `const-generics` crate feature to be enabled.
+///
+/// The main type to use here is [`U`], although [`Const`] and [`ToUInt`] may be needed
+/// in a generic context.
+#[allow(warnings)] // script-generated code
+pub mod generic_const_mappings {
+    use crate::*;
+
+    /// The main mapping from a generic `const: usize` to a [`UInt`]: [`U<N>`] is expected to work like [`UN`].
+    ///
+    ///   - It requires the `const-generics` crate feature to be enabled.
+    ///
+    /// [`U<N>`]: `U`
+    /// [`UN`]: `U42`
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use typenum::*;
+    ///
+    /// assert_type_eq!(U<42>, U42);
+    /// ```
+    ///
+    /// This can even be used in a generic `const N: usize` context, provided the
+    /// genericity is guarded by a `where` clause:
+    ///
+    /// ```rust
+    /// use typenum::*;
+    ///
+    /// struct MyStruct<const N: usize>;
+    ///
+    /// trait MyTrait { type AssocType; }
+    ///
+    /// impl<const N: usize> MyTrait
+    ///     for MyStruct<N>
+    /// where
+    ///     Const<N> : ToUInt,
+    /// {
+    ///     type AssocType = U<N>;
+    /// }
+    ///
+    /// assert_type_eq!(<MyStruct<42> as MyTrait>::AssocType, U42);
+    /// ```
+    pub type U<const N: usize> = <Const<N> as ToUInt>::Output;
+
+    /// Used to allow the usage of [`U`] in a generic context.
+    pub struct Const<const N: usize>;
+
+    /// Used to allow the usage of [`U`] in a generic context.
+    pub trait ToUInt {
+        /// The [`UN`][`crate::U42`] type corresponding to `Self = Const<N>`.
+        type Output;
+    }
+\
+    ")?;
+
+    for uint in uints() {
+        write!(
+            f,
+            "
+    impl ToUInt for Const<{uint}> {{
+        type Output = U{uint};
+    }}
+\
+            ",
+            uint = uint,
+        )?;
+    }
+    write!(f, "}}")?;
+    f.flush()?;
+    Ok(())
+}

--- a/build/main.rs
+++ b/build/main.rs
@@ -89,6 +89,7 @@ fn uints() -> impl Iterator<Item = u64> {
 // fixme: get a warning when testing without this
 #[allow(dead_code)]
 fn main() {
+    println!("cargo:rerun-if-changed=build/main.rs"); // Allow caching the generation if `src/*` files change.
     let out_dir = env::var("OUT_DIR").unwrap();
     let dest = Path::new(&out_dir).join("consts.rs");
     println!("cargo:rustc-env=TYPENUM_BUILD_CONSTS={}", dest.display());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,12 +71,16 @@ use core::cmp::Ordering;
 mod generated {
     include!(concat!(env!("OUT_DIR"), "/op.rs"));
     include!(concat!(env!("OUT_DIR"), "/consts.rs"));
+    #[cfg(feature = "const-generics")]
+    include!(concat!(env!("OUT_DIR"), "/generic_const_mappings.rs"));
 }
 
 #[cfg(not(feature = "force_unix_path_separator"))]
 mod generated {
     include!(env!("TYPENUM_BUILD_OP"));
     include!(env!("TYPENUM_BUILD_CONSTS"));
+    #[cfg(feature = "const-generics")]
+    include!(env!("TYPENUM_BUILD_GENERIC_CONSTS"));
 }
 
 pub mod bit;
@@ -99,6 +103,13 @@ pub use crate::{
     type_operators::*,
     uint::{UInt, UTerm},
 };
+
+#[cfg(feature = "const-generics")]
+pub use crate::generated::generic_const_mappings;
+
+#[cfg(feature = "const-generics")]
+#[doc(no_inline)]
+pub use generic_const_mappings::{Const, ToUInt, U};
 
 /// A potential output from `Cmp`, this is the type equivalent to the enum variant
 /// `core::cmp::Ordering::Greater`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@
     )
 )]
 #![cfg_attr(feature = "cargo-clippy", deny(clippy::missing_inline_in_public_items))]
-#![doc(html_root_url = "https://docs.rs/typenum/1.14.0")]
+#![doc(html_root_url = "https://docs.rs/typenum/1.15.0")]
 
 // For debugging macros:
 // #![feature(trace_macros)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,13 +95,20 @@ pub mod array;
 
 pub use crate::{
     array::{ATerm, TArr},
-    consts::*,
     generated::consts,
     int::{NInt, PInt},
     marker_traits::*,
     operator_aliases::*,
     type_operators::*,
     uint::{UInt, UTerm},
+};
+
+#[doc(no_inline)]
+#[rustfmt::skip]
+pub use consts::{
+    False, True, B0, B1,
+    U0, U1, U2, *,
+    N1, N2, Z0, P1, P2, *,
 };
 
 #[cfg(feature = "const-generics")]


### PR DESCRIPTION
Through a `cfg`-gated `const-generics` Cargo feature (disabled by default, obviously), a `const_generic_mappings` module is added, featuring `U<N>`, a nifty type alias so that `U<42> = U42;`, and so on.

It can even be used in a generic context, thanks to the following clause:

```rust
...<const N: usize> ...
where
    Const<N> : ToUInt,
...
```

which allows `U<N>` to Just Work™, where `Const<N>` and `ToUInt` are the two other items featured within that module. All three are re-exported at the root of the crate for convenience.

  - ![image](https://user-images.githubusercontent.com/9920355/142773085-6277169c-7259-4b7e-89ed-cb1a17a65cdb.png)

  - ![image](https://user-images.githubusercontent.com/9920355/142773148-a62e59a9-d240-46a4-8289-ca80f1cff893.png)

Note that until `generic_const_exprs` are powerful enough to allow bit operations on a generic `const` to be used as another generic const parameter, the mapping from a `Const<N>` to a `UInt` cannot be expressed in a fully generic fashion.

Instead, similarly to the list of hard-coded `U...` aliases, there is an equally long list of hard-coded `impl ToUInt for Const<...> { type Output = U...; }` impls. This means that not all `const N: usize` are valid choices for `U<>` (hence the needed extra `where` clause to restrict it to the list of valid hard-coded impls).


### Commits

 1. The addition of the `build.rs` script code to generate such impls, as well as the Cargo feature, importing the items, their documentation, and tweaking the workflow file to enable that feature on non-MSRV have all been implemented in the first commit.

 1. The second commit is an unrelated minor quality-of-life improvement for devs, whereby the `build.rs` script is not re-executed should code under `src/` change. This commit can be removed if it is not deemed relevant.

 1. The third commit is another unrelated improvement: when one goes over https://docs.rs/typenum/1.14.0/typenum/, they find this huge list of type aliases taking up all the screen. This is because the `pub use` was `#[doc(inline)]` by default. I've made that blob re-export become `#[doc(no_inline)]`, but added some re-exports explicitly for the sake of readability:

    ![image](https://user-images.githubusercontent.com/9920355/142773459-be6ecd96-e279-4c06-8122-2604062215fe.png)

    For those curious about the exact values of `U...`, that huge list is still available within the `consts` module.

 1. And then a version bump commit (I don't think this warrants a minor bump since the new logic is feature-gated: a patch commit makes sense).

### How to test this feature until this PR is merged and released upstream

Use a `[patch]` section in your workspace's `Cargo.toml` targetting the third commit (https://github.com/danielhenrymantilla/typenum/commit/077aa8386e0f22c0ce90f66bebe9e3f3e0fd3123) of this PR:

```toml
[patch.crates-io.typenum]
git = "https://github.com/danielhenrymantilla/typenum"
version = "1.0.14"
rev = "077aa8386e0f22c0ce90f66bebe9e3f3e0fd3123"
```