### PR TITLE
Add a `const` field to the `ToInt` trait to allow its use in `const` contexts

### DIFF
--- a/src/int.rs
+++ b/src/int.rs
@@ -1187,6 +1187,7 @@ impl ToInt<i8> for Z0 {
     fn to_int() -> i8 {
         Self::I8
     }
+    const INT: i8 = Self::I8;
 }
 
 impl ToInt<i16> for Z0 {
@@ -1194,6 +1195,7 @@ impl ToInt<i16> for Z0 {
     fn to_int() -> i16 {
         Self::I16
     }
+    const INT: i16 = Self::I16;
 }
 
 impl ToInt<i32> for Z0 {
@@ -1201,6 +1203,7 @@ impl ToInt<i32> for Z0 {
     fn to_int() -> i32 {
         Self::I32
     }
+    const INT: i32 = Self::I32;
 }
 
 impl ToInt<i64> for Z0 {
@@ -1208,6 +1211,7 @@ impl ToInt<i64> for Z0 {
     fn to_int() -> i64 {
         Self::I64
     }
+    const INT: i64 = Self::I64;
 }
 
 // negative numbers
@@ -1220,6 +1224,7 @@ where
     fn to_int() -> i8 {
         Self::I8
     }
+    const INT: i8 = Self::I8;
 }
 
 impl<U> ToInt<i16> for NInt<U>
@@ -1230,6 +1235,7 @@ where
     fn to_int() -> i16 {
         Self::I16
     }
+    const INT: i16 = Self::I16;
 }
 
 impl<U> ToInt<i32> for NInt<U>
@@ -1240,6 +1246,7 @@ where
     fn to_int() -> i32 {
         Self::I32
     }
+    const INT: i32 = Self::I32;
 }
 
 impl<U> ToInt<i64> for NInt<U>
@@ -1250,6 +1257,7 @@ where
     fn to_int() -> i64 {
         Self::I64
     }
+    const INT: i64 = Self::I64;
 }
 
 // positive numbers
@@ -1262,6 +1270,7 @@ where
     fn to_int() -> i8 {
         Self::I8
     }
+    const INT: i8 = Self::I8;
 }
 
 impl<U> ToInt<i16> for PInt<U>
@@ -1272,6 +1281,7 @@ where
     fn to_int() -> i16 {
         Self::I16
     }
+    const INT: i16 = Self::I16;
 }
 
 impl<U> ToInt<i32> for PInt<U>
@@ -1282,6 +1292,7 @@ where
     fn to_int() -> i32 {
         Self::I32
     }
+    const INT: i32 = Self::I32;
 }
 
 impl<U> ToInt<i64> for PInt<U>
@@ -1292,6 +1303,7 @@ where
     fn to_int() -> i64 {
         Self::I64
     }
+    const INT: i64 = Self::I64;
 }
 
 #[cfg(test)]
@@ -1316,6 +1328,15 @@ mod tests {
         assert_eq!(-2_i8, N2::to_int());
         assert_eq!(-3_i8, N3::to_int());
         assert_eq!(-4_i8, N4::to_int());
+        assert_eq!(0_i8, Z0::INT);
+        assert_eq!(1_i8, P1::INT);
+        assert_eq!(2_i8, P2::INT);
+        assert_eq!(3_i8, P3::INT);
+        assert_eq!(4_i8, P4::INT);
+        assert_eq!(-1_i8, N1::INT);
+        assert_eq!(-2_i8, N2::INT);
+        assert_eq!(-3_i8, N3::INT);
+        assert_eq!(-4_i8, N4::INT);
 
         // i16
         assert_eq!(0_i16, Z0::to_int());
@@ -1327,6 +1348,15 @@ mod tests {
         assert_eq!(-2_i16, N2::to_int());
         assert_eq!(-3_i16, N3::to_int());
         assert_eq!(-4_i16, N4::to_int());
+        assert_eq!(0_i16, Z0::INT);
+        assert_eq!(1_i16, P1::INT);
+        assert_eq!(2_i16, P2::INT);
+        assert_eq!(3_i16, P3::INT);
+        assert_eq!(4_i16, P4::INT);
+        assert_eq!(-1_i16, N1::INT);
+        assert_eq!(-2_i16, N2::INT);
+        assert_eq!(-3_i16, N3::INT);
+        assert_eq!(-4_i16, N4::INT);
 
         // i32
         assert_eq!(0_i32, Z0::to_int());
@@ -1338,6 +1368,15 @@ mod tests {
         assert_eq!(-2_i32, N2::to_int());
         assert_eq!(-3_i32, N3::to_int());
         assert_eq!(-4_i32, N4::to_int());
+        assert_eq!(0_i32, Z0::INT);
+        assert_eq!(1_i32, P1::INT);
+        assert_eq!(2_i32, P2::INT);
+        assert_eq!(3_i32, P3::INT);
+        assert_eq!(4_i32, P4::INT);
+        assert_eq!(-1_i32, N1::INT);
+        assert_eq!(-2_i32, N2::INT);
+        assert_eq!(-3_i32, N3::INT);
+        assert_eq!(-4_i32, N4::INT);
 
         // i64
         assert_eq!(0_i64, Z0::to_int());
@@ -1349,5 +1388,14 @@ mod tests {
         assert_eq!(-2_i64, N2::to_int());
         assert_eq!(-3_i64, N3::to_int());
         assert_eq!(-4_i64, N4::to_int());
+        assert_eq!(0_i64, Z0::INT);
+        assert_eq!(1_i64, P1::INT);
+        assert_eq!(2_i64, P2::INT);
+        assert_eq!(3_i64, P3::INT);
+        assert_eq!(4_i64, P4::INT);
+        assert_eq!(-1_i64, N1::INT);
+        assert_eq!(-2_i64, N2::INT);
+        assert_eq!(-3_i64, N3::INT);
+        assert_eq!(-4_i64, N4::INT);
     }
 }

--- a/src/type_operators.rs
+++ b/src/type_operators.rs
@@ -587,4 +587,6 @@ pub trait Gcd<Rhs> {
 pub trait ToInt<T> {
     /// Method returning the concrete value for the type.
     fn to_int() -> T;
+    /// The concrete value for the type. Can be used in `const` contexts.
+    const INT: T;
 }

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -2326,6 +2326,7 @@ impl ToInt<i8> for UTerm {
     fn to_int() -> i8 {
         Self::I8
     }
+    const INT: i8 = Self::I8;
 }
 
 impl ToInt<i16> for UTerm {
@@ -2333,6 +2334,7 @@ impl ToInt<i16> for UTerm {
     fn to_int() -> i16 {
         Self::I16
     }
+    const INT: i16 = Self::I16;
 }
 
 impl ToInt<i32> for UTerm {
@@ -2340,6 +2342,7 @@ impl ToInt<i32> for UTerm {
     fn to_int() -> i32 {
         Self::I32
     }
+    const INT: i32 = Self::I32;
 }
 
 impl ToInt<i64> for UTerm {
@@ -2347,6 +2350,7 @@ impl ToInt<i64> for UTerm {
     fn to_int() -> i64 {
         Self::I64
     }
+    const INT: i64 = Self::I64;
 }
 
 impl ToInt<u8> for UTerm {
@@ -2354,6 +2358,7 @@ impl ToInt<u8> for UTerm {
     fn to_int() -> u8 {
         Self::U8
     }
+    const INT: u8 = Self::U8;
 }
 
 impl ToInt<u16> for UTerm {
@@ -2361,6 +2366,7 @@ impl ToInt<u16> for UTerm {
     fn to_int() -> u16 {
         Self::U16
     }
+    const INT: u16 = Self::U16;
 }
 
 impl ToInt<u32> for UTerm {
@@ -2368,6 +2374,7 @@ impl ToInt<u32> for UTerm {
     fn to_int() -> u32 {
         Self::U32
     }
+    const INT: u32 = Self::U32;
 }
 
 impl ToInt<u64> for UTerm {
@@ -2375,6 +2382,7 @@ impl ToInt<u64> for UTerm {
     fn to_int() -> u64 {
         Self::U64
     }
+    const INT: u64 = Self::U64;
 }
 
 impl ToInt<usize> for UTerm {
@@ -2382,6 +2390,7 @@ impl ToInt<usize> for UTerm {
     fn to_int() -> usize {
         Self::USIZE
     }
+    const INT: usize = Self::USIZE;
 }
 
 impl<U, B> ToInt<i8> for UInt<U, B>
@@ -2393,6 +2402,7 @@ where
     fn to_int() -> i8 {
         Self::I8
     }
+    const INT: i8 = Self::I8;
 }
 
 impl<U, B> ToInt<i16> for UInt<U, B>
@@ -2404,6 +2414,7 @@ where
     fn to_int() -> i16 {
         Self::I16
     }
+    const INT: i16 = Self::I16;
 }
 
 impl<U, B> ToInt<i32> for UInt<U, B>
@@ -2415,6 +2426,7 @@ where
     fn to_int() -> i32 {
         Self::I32
     }
+    const INT: i32 = Self::I32;
 }
 
 impl<U, B> ToInt<i64> for UInt<U, B>
@@ -2426,6 +2438,7 @@ where
     fn to_int() -> i64 {
         Self::I64
     }
+    const INT: i64 = Self::I64;
 }
 
 impl<U, B> ToInt<u8> for UInt<U, B>
@@ -2437,6 +2450,7 @@ where
     fn to_int() -> u8 {
         Self::U8
     }
+    const INT: u8 = Self::U8;
 }
 
 impl<U, B> ToInt<u16> for UInt<U, B>
@@ -2448,6 +2462,7 @@ where
     fn to_int() -> u16 {
         Self::U16
     }
+    const INT: u16 = Self::U16;
 }
 
 impl<U, B> ToInt<u32> for UInt<U, B>
@@ -2459,6 +2474,7 @@ where
     fn to_int() -> u32 {
         Self::U32
     }
+    const INT: u32 = Self::U32;
 }
 
 impl<U, B> ToInt<u64> for UInt<U, B>
@@ -2470,6 +2486,7 @@ where
     fn to_int() -> u64 {
         Self::U64
     }
+    const INT: u64 = Self::U64;
 }
 
 impl<U, B> ToInt<usize> for UInt<U, B>
@@ -2481,6 +2498,7 @@ where
     fn to_int() -> usize {
         Self::USIZE
     }
+    const INT: usize = Self::USIZE;
 }
 
 #[cfg(test)]
@@ -2540,6 +2558,11 @@ mod tests {
         assert_eq!(2_i8, U2::to_int());
         assert_eq!(3_i8, U3::to_int());
         assert_eq!(4_i8, U4::to_int());
+        assert_eq!(0_i8, U0::INT);
+        assert_eq!(1_i8, U1::INT);
+        assert_eq!(2_i8, U2::INT);
+        assert_eq!(3_i8, U3::INT);
+        assert_eq!(4_i8, U4::INT);
 
         // i16
         assert_eq!(0_i16, U0::to_int());
@@ -2547,6 +2570,11 @@ mod tests {
         assert_eq!(2_i16, U2::to_int());
         assert_eq!(3_i16, U3::to_int());
         assert_eq!(4_i16, U4::to_int());
+        assert_eq!(0_i16, U0::INT);
+        assert_eq!(1_i16, U1::INT);
+        assert_eq!(2_i16, U2::INT);
+        assert_eq!(3_i16, U3::INT);
+        assert_eq!(4_i16, U4::INT);
 
         // i32
         assert_eq!(0_i32, U0::to_int());
@@ -2554,6 +2582,11 @@ mod tests {
         assert_eq!(2_i32, U2::to_int());
         assert_eq!(3_i32, U3::to_int());
         assert_eq!(4_i32, U4::to_int());
+        assert_eq!(0_i32, U0::INT);
+        assert_eq!(1_i32, U1::INT);
+        assert_eq!(2_i32, U2::INT);
+        assert_eq!(3_i32, U3::INT);
+        assert_eq!(4_i32, U4::INT);
 
         // i64
         assert_eq!(0_i64, U0::to_int());
@@ -2561,6 +2594,11 @@ mod tests {
         assert_eq!(2_i64, U2::to_int());
         assert_eq!(3_i64, U3::to_int());
         assert_eq!(4_i64, U4::to_int());
+        assert_eq!(0_i64, U0::INT);
+        assert_eq!(1_i64, U1::INT);
+        assert_eq!(2_i64, U2::INT);
+        assert_eq!(3_i64, U3::INT);
+        assert_eq!(4_i64, U4::INT);
 
         // u8
         assert_eq!(0_u8, U0::to_int());
@@ -2568,6 +2606,11 @@ mod tests {
         assert_eq!(2_u8, U2::to_int());
         assert_eq!(3_u8, U3::to_int());
         assert_eq!(4_u8, U4::to_int());
+        assert_eq!(0_u8, U0::INT);
+        assert_eq!(1_u8, U1::INT);
+        assert_eq!(2_u8, U2::INT);
+        assert_eq!(3_u8, U3::INT);
+        assert_eq!(4_u8, U4::INT);
 
         // u16
         assert_eq!(0_u16, U0::to_int());
@@ -2575,6 +2618,11 @@ mod tests {
         assert_eq!(2_u16, U2::to_int());
         assert_eq!(3_u16, U3::to_int());
         assert_eq!(4_u16, U4::to_int());
+        assert_eq!(0_u16, U0::INT);
+        assert_eq!(1_u16, U1::INT);
+        assert_eq!(2_u16, U2::INT);
+        assert_eq!(3_u16, U3::INT);
+        assert_eq!(4_u16, U4::INT);
 
         // u32
         assert_eq!(0_u32, U0::to_int());
@@ -2582,6 +2630,11 @@ mod tests {
         assert_eq!(2_u32, U2::to_int());
         assert_eq!(3_u32, U3::to_int());
         assert_eq!(4_u32, U4::to_int());
+        assert_eq!(0_u32, U0::INT);
+        assert_eq!(1_u32, U1::INT);
+        assert_eq!(2_u32, U2::INT);
+        assert_eq!(3_u32, U3::INT);
+        assert_eq!(4_u32, U4::INT);
 
         // u64
         assert_eq!(0_u64, U0::to_int());
@@ -2589,6 +2642,11 @@ mod tests {
         assert_eq!(2_u64, U2::to_int());
         assert_eq!(3_u64, U3::to_int());
         assert_eq!(4_u64, U4::to_int());
+        assert_eq!(0_u64, U0::INT);
+        assert_eq!(1_u64, U1::INT);
+        assert_eq!(2_u64, U2::INT);
+        assert_eq!(3_u64, U3::INT);
+        assert_eq!(4_u64, U4::INT);
 
         // usize
         assert_eq!(0_usize, U0::to_int());
@@ -2596,5 +2654,10 @@ mod tests {
         assert_eq!(2_usize, U2::to_int());
         assert_eq!(3_usize, U3::to_int());
         assert_eq!(4_usize, U4::to_int());
+        assert_eq!(0_usize, U0::INT);
+        assert_eq!(1_usize, U1::INT);
+        assert_eq!(2_usize, U2::INT);
+        assert_eq!(3_usize, U3::INT);
+        assert_eq!(4_usize, U4::INT);
     }
 }


### PR DESCRIPTION
Closes #178

Happy to adjust the name of the field or anything else if wanted.