### PR TITLE
Do not emit unnecessary "cargo:rustc-env=" instructions with the force_unix_path_separator feature

### DIFF
--- a/build/main.rs
+++ b/build/main.rs
@@ -90,6 +90,7 @@ fn main() {
 
     let out_dir = env::var("OUT_DIR").unwrap();
     let dest = Path::new(&out_dir).join("consts.rs");
+    #[cfg(not(feature = "force_unix_path_separator"))]
     println!("cargo:rustc-env=TYPENUM_BUILD_CONSTS={}", dest.display());
 
     let mut f = File::create(&dest).unwrap();

--- a/build/op.rs
+++ b/build/op.rs
@@ -18,6 +18,7 @@ struct Op {
 pub fn write_op_macro() -> ::std::io::Result<()> {
     let out_dir = ::std::env::var("OUT_DIR").unwrap();
     let dest = ::std::path::Path::new(&out_dir).join("op.rs");
+    #[cfg(not(feature = "force_unix_path_separator"))]
     println!("cargo:rustc-env=TYPENUM_BUILD_OP={}", dest.display());
     let mut f = ::std::fs::File::create(&dest).unwrap();
 


### PR DESCRIPTION
 "cargo:rustc-env=TYPENUM_BUILD_OP=..." and "cargo:rustc-env=TYPENUM_BUILD_CONSTS=..." trigger unnecessary rebuilds when using the "force_unix_path_separator" feature.