### PR TITLE
Improve docs.rs builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The MSRV (Minimum Supported Rust Version) is 1.37.0, and typenum is tested
 against this Rust version.
 
 ### Unreleased
+- [removed] Remove `force_unix_path_separator` feature, make it the default
+- [added] docs.rs metadata and cfg options
+- [added] Playground metadata
 
 ### 1.16.0 (2022-12-05)
 - [added] `const INT` field to the `ToInt` trait.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,16 @@ scale-info = { version = "1.0", default-features = false, optional = true }
   name = "typenum"
 
 [features]
-  no_std = []
+  no_std = [] # Deprecated
   i128 = []
   strict = []
-  force_unix_path_separator = []
+  force_unix_path_separator = [] # Deprecated
   const-generics = []
   scale_info = ["scale-info/derive"]
+
+[package.metadata.docs.rs]
+  features = ["i128", "const-generics"]
+  rustdoc-args = ["--cfg", "docsrs"]
+
+[package.metadata.playground]
+  features = ["i128", "const-generics"]

--- a/build/generic_const_mappings.rs
+++ b/build/generic_const_mappings.rs
@@ -3,10 +3,6 @@ use super::*;
 pub fn emit_impls() -> ::std::io::Result<()> {
     let out_dir = ::std::env::var("OUT_DIR").unwrap();
     let dest = ::std::path::Path::new(&out_dir).join("generic_const_mappings.rs");
-    println!(
-        "cargo:rustc-env=TYPENUM_BUILD_GENERIC_CONSTS={}",
-        dest.display()
-    );
     let mut f = ::std::fs::File::create(&dest).unwrap();
 
     #[allow(clippy::write_literal)]
@@ -22,6 +18,7 @@ use generic_const_mappings::*;
 /// The main type to use here is [`U`], although [`Const`] and [`ToUInt`] may be needed
 /// in a generic context.
 #[allow(warnings)] // script-generated code
+#[cfg(feature = \"const-generics\")] // hints at doc_auto_cfg
 pub mod generic_const_mappings {
     use crate::*;
 

--- a/build/main.rs
+++ b/build/main.rs
@@ -77,6 +77,15 @@ pub fn gen_int(i: i64) -> IntCode {
 )]
 pub fn no_std() {}
 
+#[cfg_attr(
+    feature = "force_unix_path_separator",
+    deprecated(
+        since = "1.17.0",
+        note = "the `force_unix_path_separator` flag is no longer necessary and will be removed in the future"
+    )
+)]
+pub fn force_unix_path_separator() {}
+
 const HIGHEST: u64 = 1024;
 fn uints() -> impl Iterator<Item = u64> {
     // Use hardcoded values to avoid issues with cross-compilation.
@@ -95,12 +104,11 @@ fn main() {
 
     let out_dir = env::var("OUT_DIR").unwrap();
     let dest = Path::new(&out_dir).join("consts.rs");
-    #[cfg(not(feature = "force_unix_path_separator"))]
-    println!("cargo:rustc-env=TYPENUM_BUILD_CONSTS={}", dest.display());
 
     let mut f = File::create(&dest).unwrap();
 
     no_std();
+    force_unix_path_separator();
 
     // Header stuff here!
     write!(

--- a/build/op.rs
+++ b/build/op.rs
@@ -18,8 +18,6 @@ struct Op {
 pub fn write_op_macro() -> ::std::io::Result<()> {
     let out_dir = ::std::env::var("OUT_DIR").unwrap();
     let dest = ::std::path::Path::new(&out_dir).join("op.rs");
-    #[cfg(not(feature = "force_unix_path_separator"))]
-    println!("cargo:rustc-env=TYPENUM_BUILD_OP={}", dest.display());
     let mut f = ::std::fs::File::create(&dest).unwrap();
 
     // Operator precedence is taken from

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,7 @@
 )]
 #![cfg_attr(feature = "cargo-clippy", deny(clippy::missing_inline_in_public_items))]
 #![doc(html_root_url = "https://docs.rs/typenum/1.16.0")]
+#![cfg_attr(docsrs, feature(doc_auto_cfg, doc_cfg))]
 
 // For debugging macros:
 // #![feature(trace_macros)]
@@ -67,20 +68,12 @@
 
 use core::cmp::Ordering;
 
-#[cfg(feature = "force_unix_path_separator")]
 mod generated {
     include!(concat!(env!("OUT_DIR"), "/op.rs"));
     include!(concat!(env!("OUT_DIR"), "/consts.rs"));
+
     #[cfg(feature = "const-generics")]
     include!(concat!(env!("OUT_DIR"), "/generic_const_mappings.rs"));
-}
-
-#[cfg(not(feature = "force_unix_path_separator"))]
-mod generated {
-    include!(env!("TYPENUM_BUILD_OP"));
-    include!(env!("TYPENUM_BUILD_CONSTS"));
-    #[cfg(feature = "const-generics")]
-    include!(env!("TYPENUM_BUILD_GENERIC_CONSTS"));
 }
 
 pub mod bit;

--- a/src/type_operators.rs
+++ b/src/type_operators.rs
@@ -189,7 +189,8 @@ impl_pow_f!(f64);
 
 macro_rules! impl_pow_i {
     () => ();
-    ($t: ty $(, $tail:tt)*) => (
+    ($(#[$meta:meta])*  $t: ty $(, $tail:tt)*) => (
+        $(#[$meta])*
         impl Pow<UTerm> for $t {
             type Output = $t;
             #[inline]
@@ -198,6 +199,7 @@ macro_rules! impl_pow_i {
             }
         }
 
+        $(#[$meta])*
         impl<U: Unsigned, B: Bit> Pow<UInt<U, B>> for $t {
             type Output = $t;
             #[inline]
@@ -206,6 +208,7 @@ macro_rules! impl_pow_i {
             }
         }
 
+        $(#[$meta])*
         impl Pow<Z0> for $t {
             type Output = $t;
             #[inline]
@@ -214,6 +217,7 @@ macro_rules! impl_pow_i {
             }
         }
 
+        $(#[$meta])*
         impl<U: Unsigned + NonZero> Pow<PInt<U>> for $t {
             type Output = $t;
             #[inline]
@@ -228,7 +232,7 @@ macro_rules! impl_pow_i {
 
 impl_pow_i!(u8, u16, u32, u64, usize, i8, i16, i32, i64, isize);
 #[cfg(feature = "i128")]
-impl_pow_i!(u128, i128);
+impl_pow_i!(#[cfg_attr(docsrs, doc(cfg(feature = "i128")))] u128, i128);
 
 #[test]
 fn pow_test() {


### PR DESCRIPTION
While working on [`generic-array 1.0`](https://docs.rs/generic-array/1.0.0-alpha.1/), I noticed docs.rs does not contain the `const-generics` portions of `typenum`, so the links were broken. Enabling support for that with automatic "Available on crate feature `const-generics` only." text would have been easy, except for the `force_unix_path_separator` feature interfering with it. 

After looking through the commit history, your original commit and message 694130d80cee6316879b1eb4889a7db1de3755b3 implied _enabling_ the feature made it more compatible. If I'm wrong, please correct me, but I don't see any reason why this should not be the default behavior. Making `force_unix_path_separator` the default behavior has no visible downsides and allows `doc_auto_cfg` to function correctly, more or less. 

I added a couple extra hints to rustdoc for i128 implementations as well. Unfortunately, these rustdoc hints don't work for the `scale-info` derives, so they are still excluded from docs.rs.

As a bonus, I added a Rust Playground metadata section to enable i128 and const-generics support there.