### PR TITLE
Add CI for 32-bit and big-endian platforms

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,12 +10,10 @@ name: CI
 
 jobs:
   test-linux:
-    name: Test
-    runs-on: ${{ matrix.os }}
+    name: Test Linux
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        os:
-          - ubuntu-latest
         rust:
           - 1.37.0
           - stable
@@ -27,11 +25,27 @@ jobs:
         exclude:
           - mb_const_generics: "--features const-generics"
             rust: 1.37.0
-        include:
-          - os: macos-latest
-            rust: stable
-          - os: windows-latest
-            rust: stable
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+      - run: cargo test --verbose --features "strict" ${{ matrix.mb_const_generics }}
+      - run: cargo doc --features "strict" ${{ matrix.mb_const_generics }}
+
+  test-non-linux:
+    name: Test non-Linux
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - macos-latest
+          - windows-latest
+        rust:
+          - stable
+        mb_const_generics:
+          - ""
+          - "--features const-generics"
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,6 +13,7 @@ jobs:
     name: Test Linux
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         rust:
           - stable

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -21,16 +21,29 @@ jobs:
         mb_const_generics:
           - ""
           - "--features const-generics"
+        target:
+          - x86_64
+          - i686
+          - sparc64
         include:
           - mb_const_generics: ""
             rust: 1.37.0
+            target: x86_64
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-      - run: cargo test --verbose --features "strict" ${{ matrix.mb_const_generics }}
-      - run: cargo doc --features "strict" ${{ matrix.mb_const_generics }}
+      - uses: actions-rs/cargo@v1
+        with:
+          use-cross: ${{ matrix.target != 'x86_64' }}
+          command: test
+          args: --verbose --features "strict" ${{ matrix.mb_const_generics }} --target ${{ matrix.target }}-unknown-linux-gnu
+      - uses: actions-rs/cargo@v1
+        with:
+          use-cross: ${{ matrix.target != 'x86_64' }}
+          command: doc
+          args: --features "strict" ${{ matrix.mb_const_generics }} --target ${{ matrix.target }}-unknown-linux-gnu
 
   test-non-linux:
     name: Test non-Linux

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,15 +15,14 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.37.0
           - stable
           - beta
           - nightly
         mb_const_generics:
           - ""
           - "--features const-generics"
-        exclude:
-          - mb_const_generics: "--features const-generics"
+        include:
+          - mb_const_generics: ""
             rust: 1.37.0
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This will fail until 32-bit testing is fixed (via #197 or something
else), but will help prevent platform-specific regressions in the
future.