### PR TITLE
add elixir-style tarr![A, B, C | Rest] (where Rest: TypeArray) capturing of the rest of the array

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -47,6 +47,8 @@ macro_rules! tarr {
     ($n:ty,) => ( $crate::TArr<$n, $crate::ATerm> );
     ($n:ty, $($tail:ty),+) => ( $crate::TArr<$n, tarr![$($tail),+]> );
     ($n:ty, $($tail:ty),+,) => ( $crate::TArr<$n, tarr![$($tail),+]> );
+    ($n:ty | $rest:ty) => ( $crate::TArr<$n, $rest> );
+    ($n:ty, $($tail:ty),+ | $rest:ty) => ( $crate::TArr<$n, ta![$($tail),+ | $rest]> );
 }
 
 // ---------------------------------------------------------------------------------------


### PR DESCRIPTION
Adds new patterns to the tarr! macro to support elixir-style matching

Handy for "recursively" iterating on a TypeArray.

eg
```rust
pub trait IndexOf<V> {
    type Idx: Unsigned;
    type Found: Bit;
}
impl<V> IndexOf<V> for tarr![] {
    type Idx = U0; // Always zero if not found
    type Found = B0;
}
impl<V, HD, TL: IndexOf<V>> IndexOf<V> for tarr![HD | TL]
where
    V: IsEqual<HD, Output: BitOr<TL::Found, Output: Bit>>,
    TL::Idx: Add<TL::Found, Output: Unsigned>,
{
    type Idx = Sum<TL::Idx, TL::Found>; // Add one if V in TL
    type Found = Or<Eq<V, HD>, TL::Found>;
}
```

btw, I've been using this lib (mostly TArr and Unsigned) pretty heavily. might put together a PR for some more of my utils in the future but [link](https://github.com/kgullion/reefer/tree/main/src/utils) for the curious.