### PR TITLE
Add time constants

### DIFF
--- a/build/main.rs
+++ b/build/main.rs
@@ -192,6 +192,18 @@ pub mod consts {{
             .unwrap();
         }
     }
+    if HIGHEST < 60 {
+        writeln!(f, "    /// Seconds in a Minute, or Minutes in an Hour").unwrap();
+        writeln!(f, "    pub type U60 = {};", gen_uint(60)).unwrap();
+    }
+    if HIGHEST < 3600 {
+        writeln!(f, "    /// Seconds in an hour").unwrap();
+        writeln!(f, "    pub type U3600 = {};", gen_uint(3600)).unwrap();
+    }
+    if HIGHEST < 86400 {
+        writeln!(f, "    /// Seconds in a day").unwrap();
+        writeln!(f, "    pub type U86400 = {};", gen_uint(86400)).unwrap();
+    }
     write!(f, "}}").unwrap();
 
     tests::build_tests().unwrap();


### PR DESCRIPTION
I have Use cases where having direct access to U3600 is needed. I tried making a `type U3600 = op!(U36 * 100);`, but when I try implementing for something that looks like this, I get an error:

```rust
trait SpecializedPeriod {}
impl SpecializedPeriod for Period<op!(U36 * U100), U1> {}
impl SpecializedPeriod for Period<U60, U1> {}
impl SpecializedPeriod for Period<U1, U1> {}
```

```
error[E0119]: conflicting implementations of trait `SpecializedPeriod` for type `period::Period<UInt<UInt<UInt<UInt<UInt<UInt<UTerm, B1>, B1>, B1>, B1>, B0>, B0>, UInt<UTerm, B1>>`
  --> src/duration/period.rs:15:1
   |
14 | impl SpecializedPeriod for Period<op!(U36 * U100), U1> {}
   | ------------------------------------------------------ first implementation here
15 | impl SpecializedPeriod for Period<U60, U1> {}
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `period::Period<UInt<UInt<UInt<UInt<UInt<UInt<UTerm, B1>, B1>, B1>, B1>, B0>, B0>, UInt<UTerm, B1>>`

error[E0119]: conflicting implementations of trait `SpecializedPeriod` for type `period::Period<UInt<UTerm, B1>, UInt<UTerm, B1>>`
  --> src/duration/period.rs:16:1
   |
14 | impl SpecializedPeriod for Period<op!(U36 * U100), U1> {}
   | ------------------------------------------------------ first implementation here
15 | impl SpecializedPeriod for Period<U60, U1> {}
16 | impl SpecializedPeriod for Period<U1, U1> {}
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `period::Period<UInt<UTerm, B1>, UInt<UTerm, B1>>`
   ```
   
   This allows for such numbers to be used directly.
   
   A follow-up issue might be to setup some way to provide specific numbers in a config file if needed, and provide these vals to the build script somehow, but that's well out of scope for this PR.