### PR TITLE
Support compiling in Windows `\\?\` verbatim location

### DIFF
--- a/build/main.rs
+++ b/build/main.rs
@@ -102,6 +102,11 @@ fn uints() -> impl Iterator<Item = u64> {
 fn main() {
     println!("cargo:rerun-if-changed=build/main.rs"); // Allow caching the generation if `src/*` files change.
 
+    let host = env::var_os("HOST").unwrap();
+    if let Some("windows") = host.to_str().unwrap().split('-').nth(2) {
+        println!("cargo:rustc-cfg=host_os=\"windows\"");
+    }
+
     let out_dir = env::var("OUT_DIR").unwrap();
     let dest = Path::new(&out_dir).join("consts.rs");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,11 +69,20 @@
 use core::cmp::Ordering;
 
 mod generated {
+    #[cfg(not(host_os = "windows"))]
     include!(concat!(env!("OUT_DIR"), "/op.rs"));
-    include!(concat!(env!("OUT_DIR"), "/consts.rs"));
+    #[cfg(host_os = "windows")]
+    include!(concat!(env!("OUT_DIR"), "\\op.rs"));
 
-    #[cfg(feature = "const-generics")]
+    #[cfg(not(host_os = "windows"))]
+    include!(concat!(env!("OUT_DIR"), "/consts.rs"));
+    #[cfg(host_os = "windows")]
+    include!(concat!(env!("OUT_DIR"), "\\consts.rs"));
+
+    #[cfg(all(feature = "const-generics", not(host_os = "windows")))]
     include!(concat!(env!("OUT_DIR"), "/generic_const_mappings.rs"));
+    #[cfg(all(feature = "const-generics", host_os = "windows"))]
+    include!(concat!(env!("OUT_DIR"), "\\generic_const_mappings.rs"));
 }
 
 pub mod bit;


### PR DESCRIPTION
This PR implements a workaround for https://github.com/rust-lang/cargo/issues/13919.

See https://github.com/rust-lang/cargo/issues/13919#issuecomment-2462174627 and https://github.com/rust-lang/cargo/issues/13919#issuecomment-2661757619 of 2 different users reporting experiencing build errors in `typenum`.

```console
error: couldn't read \\?\C:\myproj\rust\gui\gpuimg\target\debug\build\typenum-8c302cc9c705de15\out/op.rs: 文件名、目录名或卷标语法不正确。 (os error 123)
  --> C:\rust\cargo\registry\src\rsproxy.cn-0dccff568467c15b\typenum-1.17.0\src\lib.rs:72:5
   |
72 |     include!(concat!(env!("OUT_DIR"), "/op.rs"));
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

```console
build\typenum-255e67d6ee89f566\out/op.rs: The filename, directory name, or volume label syntax is incorrect. (os error 123)
  --> src\lib.rs:72:5
   |
72 |     include!(concat!(env!("OUT_DIR"), "/op.rs"));
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: this error originates in the macro `include` (in Nightly builds, run with -Z macro-backtrace for more info)
```

Rustc 1.84 contains a mitigation for this (https://github.com/rust-lang/rust/pull/125205) but is very recent (5 weeks old) compared to typenum's oldest supported compiler which is 1.37.