### PR TITLE
Mark generated files with git attribute

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+src/gen/consts.rs linguist-generated
+src/gen/generic_const_mappings.rs linguist-generated
+src/gen/op.rs linguist-generated


### PR DESCRIPTION
This will make GitHub and other tools collapse the diff by default.

![Screenshot from 2025-02-18 02-47-56](https://github.com/user-attachments/assets/3e8de9a7-f29e-4b50-93df-49fee56a10f0)
