### PR TITLE
chore: exclude some files from published crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,14 @@ description = """Typenum is a Rust library for type-level numbers evaluated at
 categories = ["no-std"]
 edition = "2018"
 rust-version = "1.37.0"
+exclude = [
+    "/.github/",
+    "/clippy.toml",
+    "/flake.lock",
+    "/flake.nix",
+    "/justfile",
+    "/.envrc",
+]
 
 [dependencies]
 scale-info = { version = "1.0", default-features = false, optional = true }


### PR DESCRIPTION
These all seem to be only useful during development. Dropping them should reduce download sizes for this crate from crates.io a tiny bit (though to be fair, the size difference is not significant since there's a large amount of generated code).