### PR TITLE
Fix const-generics feature on 16-bit targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The MSRV (Minimum Supported Rust Version) is 1.37.0, and typenum is tested
 against this Rust version.
 
 ### Unreleased
+- [fixed] Conflicting trait implementations with the `const-generics` feature
+  on 16-bit targets
 
 ### 1.18.0 (2025-02-17)
 - [changed] Remove build scripts; instead check-in the built code (PR #219)

--- a/generate/src/generic_const_mappings.rs
+++ b/generate/src/generic_const_mappings.rs
@@ -70,16 +70,18 @@ pub trait ToUInt {
 \
             ",
             uint = uint,
-            cfg = feature_gate_to_64_bit(uint),
+            cfg = feature_gate_to_pointer_width(uint),
         ));
     }
 
     result
 }
 
-const fn feature_gate_to_64_bit(uint: u64) -> &'static str {
+const fn feature_gate_to_pointer_width(uint: u64) -> &'static str {
     if uint > u32::MAX as u64 {
         r#"#[cfg(target_pointer_width = "64")]"#
+    } else if uint > u16::MAX as u64 {
+        r#"#[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]"#
     } else {
         ""
     }

--- a/src/gen/generic_const_mappings.rs
+++ b/src/gen/generic_const_mappings.rs
@@ -4179,66 +4179,82 @@ impl ToUInt for Const<32768> {
     type Output = U32768;
 }
 
+#[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
 impl ToUInt for Const<65536> {
     type Output = U65536;
 }
 
+#[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
 impl ToUInt for Const<131072> {
     type Output = U131072;
 }
 
+#[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
 impl ToUInt for Const<262144> {
     type Output = U262144;
 }
 
+#[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
 impl ToUInt for Const<524288> {
     type Output = U524288;
 }
 
+#[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
 impl ToUInt for Const<1048576> {
     type Output = U1048576;
 }
 
+#[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
 impl ToUInt for Const<2097152> {
     type Output = U2097152;
 }
 
+#[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
 impl ToUInt for Const<4194304> {
     type Output = U4194304;
 }
 
+#[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
 impl ToUInt for Const<8388608> {
     type Output = U8388608;
 }
 
+#[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
 impl ToUInt for Const<16777216> {
     type Output = U16777216;
 }
 
+#[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
 impl ToUInt for Const<33554432> {
     type Output = U33554432;
 }
 
+#[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
 impl ToUInt for Const<67108864> {
     type Output = U67108864;
 }
 
+#[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
 impl ToUInt for Const<134217728> {
     type Output = U134217728;
 }
 
+#[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
 impl ToUInt for Const<268435456> {
     type Output = U268435456;
 }
 
+#[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
 impl ToUInt for Const<536870912> {
     type Output = U536870912;
 }
 
+#[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
 impl ToUInt for Const<1073741824> {
     type Output = U1073741824;
 }
 
+#[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
 impl ToUInt for Const<2147483648> {
     type Output = U2147483648;
 }
@@ -4407,22 +4423,27 @@ impl ToUInt for Const<10000> {
     type Output = U10000;
 }
 
+#[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
 impl ToUInt for Const<100000> {
     type Output = U100000;
 }
 
+#[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
 impl ToUInt for Const<1000000> {
     type Output = U1000000;
 }
 
+#[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
 impl ToUInt for Const<10000000> {
     type Output = U10000000;
 }
 
+#[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
 impl ToUInt for Const<100000000> {
     type Output = U100000000;
 }
 
+#[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
 impl ToUInt for Const<1000000000> {
     type Output = U1000000000;
 }


### PR DESCRIPTION
Currently, compiling typenum with the const-generics feature on 16-bit targets causes an error due to conflicting implementations of the ToUInt trait for Const<0> as the generated code assumes that the pointer width is at least 32.  This patch adds support for 16-bit targets to the generated code.

The problem can be reproduced with:
```
RUSTFLAGS="-C target-cpu=atmega328p" cargo +nightly build -Z build-std=core --target=avr-none
```