### PR TITLE
fix tarr! pattern match corner case

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -48,7 +48,7 @@ macro_rules! tarr {
     ($n:ty, $($tail:ty),+) => ( $crate::TArr<$n, tarr![$($tail),+]> );
     ($n:ty, $($tail:ty),+,) => ( $crate::TArr<$n, tarr![$($tail),+]> );
     ($n:ty | $rest:ty) => ( $crate::TArr<$n, $rest> );
-    ($n:ty, $($tail:ty),+ | $rest:ty) => ( $crate::TArr<$n, ta![$($tail),+ | $rest]> );
+    ($n:ty, $($tail:ty),+ | $rest:ty) => ( $crate::TArr<$n, tarr![$($tail),+ | $rest]> );
 }
 
 // ---------------------------------------------------------------------------------------


### PR DESCRIPTION
this fix is needed for `tarr![A, B, C, D | Rest]` style matching due to a typo in my previous PR #214

`tarr![A | Rest]` works as is but the case that includes a comma and a pipe like `tarr![A, B | Rest]` looks for a non-existent macro named `ta!` instead of the correct macro `tarr!`. I'm still using `ta!` in my own code so only just caught this :facepalm: