### PR TITLE
Remove wrong documentation about type operators

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,13 +14,10 @@
 //! ```
 //!
 //! **Type operators** are traits that behave as functions at the type level. These are the meat of
-//! this library. Where possible, traits defined in libcore have been used, but their attached
-//! functions have not been implemented.
+//! this library. Where possible, traits defined in libcore have been used.
 //!
-//! For example, the `Add` trait is implemented for both unsigned and signed integers, but the
-//! `add` function is not. As there are never any objects of the types defined here, it wouldn't
-//! make sense to implement it. What is important is its associated type `Output`, which is where
-//! the addition happens.
+//! For example, the `Add` trait is implemented for both unsigned and signed integers, where its
+//! associated type `Output` represents the sum of the two integers.
 //!
 //! ```rust
 //! use std::ops::Add;


### PR DESCRIPTION
The `add` function is actually implemented.