### PR TITLE
Add implementations for ToInt for isize, i128, and u128

### DIFF
--- a/src/int.rs
+++ b/src/int.rs
@@ -1214,6 +1214,23 @@ impl ToInt<i64> for Z0 {
     const INT: i64 = Self::I64;
 }
 
+impl ToInt<isize> for Z0 {
+    #[inline]
+    fn to_int() -> isize {
+        Self::ISIZE
+    }
+    const INT: isize = Self::ISIZE;
+}
+
+#[cfg(feature = "i128")]
+impl ToInt<i128> for Z0 {
+    #[inline]
+    fn to_int() -> i128 {
+        Self::I128
+    }
+    const INT: i128 = Self::I128;
+}
+
 // negative numbers
 
 impl<U> ToInt<i8> for NInt<U>
@@ -1260,6 +1277,29 @@ where
     const INT: i64 = Self::I64;
 }
 
+impl<U> ToInt<isize> for NInt<U>
+where
+    U: Unsigned + NonZero,
+{
+    #[inline]
+    fn to_int() -> isize {
+        Self::ISIZE
+    }
+    const INT: isize = Self::ISIZE;
+}
+
+#[cfg(feature = "i128")]
+impl<U> ToInt<i128> for NInt<U>
+where
+    U: Unsigned + NonZero,
+{
+    #[inline]
+    fn to_int() -> i128 {
+        Self::I128
+    }
+    const INT: i128 = Self::I128;
+}
+
 // positive numbers
 
 impl<U> ToInt<i8> for PInt<U>
@@ -1304,6 +1344,29 @@ where
         Self::I64
     }
     const INT: i64 = Self::I64;
+}
+
+impl<U> ToInt<isize> for PInt<U>
+where
+    U: Unsigned + NonZero,
+{
+    #[inline]
+    fn to_int() -> isize {
+        Self::ISIZE
+    }
+    const INT: isize = Self::ISIZE;
+}
+
+#[cfg(feature = "i128")]
+impl<U> ToInt<i128> for PInt<U>
+where
+    U: Unsigned + NonZero,
+{
+    #[inline]
+    fn to_int() -> i128 {
+        Self::I128
+    }
+    const INT: i128 = Self::I128;
 }
 
 #[cfg(test)]
@@ -1397,5 +1460,48 @@ mod tests {
         assert_eq!(-2_i64, N2::INT);
         assert_eq!(-3_i64, N3::INT);
         assert_eq!(-4_i64, N4::INT);
+
+        // isize
+        assert_eq!(0_isize, Z0::to_int());
+        assert_eq!(1_isize, P1::to_int());
+        assert_eq!(2_isize, P2::to_int());
+        assert_eq!(3_isize, P3::to_int());
+        assert_eq!(4_isize, P4::to_int());
+        assert_eq!(-1_isize, N1::to_int());
+        assert_eq!(-2_isize, N2::to_int());
+        assert_eq!(-3_isize, N3::to_int());
+        assert_eq!(-4_isize, N4::to_int());
+        assert_eq!(0_isize, Z0::INT);
+        assert_eq!(1_isize, P1::INT);
+        assert_eq!(2_isize, P2::INT);
+        assert_eq!(3_isize, P3::INT);
+        assert_eq!(4_isize, P4::INT);
+        assert_eq!(-1_isize, N1::INT);
+        assert_eq!(-2_isize, N2::INT);
+        assert_eq!(-3_isize, N3::INT);
+        assert_eq!(-4_isize, N4::INT);
+
+        // i128
+        #[cfg(feature = "i128")]
+        {
+            assert_eq!(0_i128, Z0::to_int());
+            assert_eq!(1_i128, P1::to_int());
+            assert_eq!(2_i128, P2::to_int());
+            assert_eq!(3_i128, P3::to_int());
+            assert_eq!(4_i128, P4::to_int());
+            assert_eq!(-1_i128, N1::to_int());
+            assert_eq!(-2_i128, N2::to_int());
+            assert_eq!(-3_i128, N3::to_int());
+            assert_eq!(-4_i128, N4::to_int());
+            assert_eq!(0_i128, Z0::INT);
+            assert_eq!(1_i128, P1::INT);
+            assert_eq!(2_i128, P2::INT);
+            assert_eq!(3_i128, P3::INT);
+            assert_eq!(4_i128, P4::INT);
+            assert_eq!(-1_i128, N1::INT);
+            assert_eq!(-2_i128, N2::INT);
+            assert_eq!(-3_i128, N3::INT);
+            assert_eq!(-4_i128, N4::INT);
+        }
     }
 }

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -2360,6 +2360,23 @@ impl ToInt<i64> for UTerm {
     const INT: i64 = Self::I64;
 }
 
+impl ToInt<isize> for UTerm {
+    #[inline]
+    fn to_int() -> isize {
+        Self::ISIZE
+    }
+    const INT: isize = Self::ISIZE;
+}
+
+#[cfg(feature = "i128")]
+impl ToInt<i128> for UTerm {
+    #[inline]
+    fn to_int() -> i128 {
+        Self::I128
+    }
+    const INT: i128 = Self::I128;
+}
+
 impl ToInt<u8> for UTerm {
     #[inline]
     fn to_int() -> u8 {
@@ -2398,6 +2415,15 @@ impl ToInt<usize> for UTerm {
         Self::USIZE
     }
     const INT: usize = Self::USIZE;
+}
+
+#[cfg(feature = "i128")]
+impl ToInt<u128> for UTerm {
+    #[inline]
+    fn to_int() -> u128 {
+        Self::U128
+    }
+    const INT: u128 = Self::U128;
 }
 
 impl<U, B> ToInt<i8> for UInt<U, B>
@@ -2446,6 +2472,31 @@ where
         Self::I64
     }
     const INT: i64 = Self::I64;
+}
+
+impl<U, B> ToInt<isize> for UInt<U, B>
+where
+    U: Unsigned,
+    B: Bit,
+{
+    #[inline]
+    fn to_int() -> isize {
+        Self::ISIZE
+    }
+    const INT: isize = Self::ISIZE;
+}
+
+#[cfg(feature = "i128")]
+impl<U, B> ToInt<i128> for UInt<U, B>
+where
+    U: Unsigned,
+    B: Bit,
+{
+    #[inline]
+    fn to_int() -> i128 {
+        Self::I128
+    }
+    const INT: i128 = Self::I128;
 }
 
 impl<U, B> ToInt<u8> for UInt<U, B>
@@ -2506,6 +2557,19 @@ where
         Self::USIZE
     }
     const INT: usize = Self::USIZE;
+}
+
+#[cfg(feature = "i128")]
+impl<U, B> ToInt<u128> for UInt<U, B>
+where
+    U: Unsigned,
+    B: Bit,
+{
+    #[inline]
+    fn to_int() -> u128 {
+        Self::U128
+    }
+    const INT: u128 = Self::U128;
 }
 
 #[cfg(test)]
@@ -2607,6 +2671,33 @@ mod tests {
         assert_eq!(3_i64, U3::INT);
         assert_eq!(4_i64, U4::INT);
 
+        // isize
+        assert_eq!(0_isize, U0::to_int());
+        assert_eq!(1_isize, U1::to_int());
+        assert_eq!(2_isize, U2::to_int());
+        assert_eq!(3_isize, U3::to_int());
+        assert_eq!(4_isize, U4::to_int());
+        assert_eq!(0_isize, U0::INT);
+        assert_eq!(1_isize, U1::INT);
+        assert_eq!(2_isize, U2::INT);
+        assert_eq!(3_isize, U3::INT);
+        assert_eq!(4_isize, U4::INT);
+
+        // i128
+        #[cfg(feature = "i128")]
+        {
+            assert_eq!(0_i128, U0::to_int());
+            assert_eq!(1_i128, U1::to_int());
+            assert_eq!(2_i128, U2::to_int());
+            assert_eq!(3_i128, U3::to_int());
+            assert_eq!(4_i128, U4::to_int());
+            assert_eq!(0_i128, U0::INT);
+            assert_eq!(1_i128, U1::INT);
+            assert_eq!(2_i128, U2::INT);
+            assert_eq!(3_i128, U3::INT);
+            assert_eq!(4_i128, U4::INT);
+        }
+
         // u8
         assert_eq!(0_u8, U0::to_int());
         assert_eq!(1_u8, U1::to_int());
@@ -2666,5 +2757,20 @@ mod tests {
         assert_eq!(2_usize, U2::INT);
         assert_eq!(3_usize, U3::INT);
         assert_eq!(4_usize, U4::INT);
+
+        // u128
+        #[cfg(feature = "i128")]
+        {
+            assert_eq!(0_u128, U0::to_int());
+            assert_eq!(1_u128, U1::to_int());
+            assert_eq!(2_u128, U2::to_int());
+            assert_eq!(3_u128, U3::to_int());
+            assert_eq!(4_u128, U4::to_int());
+            assert_eq!(0_u128, U0::INT);
+            assert_eq!(1_u128, U1::INT);
+            assert_eq!(2_u128, U2::INT);
+            assert_eq!(3_u128, U3::INT);
+            assert_eq!(4_u128, U4::INT);
+        }
     }
 }


### PR DESCRIPTION
`ToInt` was missing some implementations for `isize` as well as `i128` and `u128` (with feature = "i128").

This PR adds those implementations.