### PR TITLE
Remove `doc_auto_cfg`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@
 #![cfg_attr(feature = "strict", deny(missing_docs))]
 #![cfg_attr(feature = "strict", deny(warnings))]
 #![doc(html_root_url = "https://docs.rs/typenum/1.18.0")]
-#![cfg_attr(docsrs, feature(doc_auto_cfg, doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 // For debugging macros:
 // #![feature(trace_macros)]


### PR DESCRIPTION
`doc_auto_cfg` was merged into `doc_cfg` in rust-lang/rust#138907

When `docsrs` is enabled, the old `doc_auto_cfg` results in the following error on the latest nightlies:

```
error[E0557]: feature has been removed
  --> ~/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/typenum-1.18.0/src/lib.rs:51:29
   |
51 | #![cfg_attr(docsrs, feature(doc_auto_cfg, doc_cfg))]
   |                             ^^^^^^^^^^^^ feature has been removed
```

The new `doc_cfg` retains the automatic `cfg` generation that `doc_auto_cfg` used to provide.