### PR TITLE
Use GAT to eliminate the need for traits in operations

### DIFF
--- a/generate/src/main.rs
+++ b/generate/src/main.rs
@@ -125,7 +125,7 @@ pub type False = B0;
 
     for u in uints() {
         result.push_str(&format!("pub type U{} = {};\n", u, gen_uint(u)));
-        if u <= ::std::i64::MAX as u64 && u != 0 {
+        if u <= i64::MAX as u64 && u != 0 {
             let i = u as i64;
             result.push_str(&format!(
                 "pub type P{i} = PInt<U{i}>;\npub type N{i} = NInt<U{i}>;\n",

--- a/generate/src/op.rs
+++ b/generate/src/op.rs
@@ -297,18 +297,18 @@ assert_type_eq!(op!({ex0}), {ex1});
         ));
     }
 
-    result.push_str(&format!(
+    result.push_str(
         "*/
 #[macro_export(local_inner_macros)]
-macro_rules! op {{
+macro_rules! op {
     ($($tail:tt)*) => ( __op_internal__!($($tail)*) );
-}}
+}
 
     #[doc(hidden)]
     #[macro_export(local_inner_macros)]
-    macro_rules! __op_internal__ {{
-"
-    ));
+    macro_rules! __op_internal__ {
+",
+    );
 
     // We first us the shunting-yard algorithm to produce our tokens in Polish notation.
     // See: https://en.wikipedia.org/wiki/Shunting-yard_algorithm

--- a/generate/src/tests.rs
+++ b/generate/src/tests.rs
@@ -23,7 +23,7 @@ fn gen_int(i: i64) -> IntCode {
 
     match i.cmp(&0) {
         Greater => IntCode::Pos(Box::new(gen_uint(i as u64))),
-        Less => IntCode::Neg(Box::new(gen_uint(i.abs() as u64))),
+        Less => IntCode::Neg(Box::new(gen_uint(i.unsigned_abs()))),
         Equal => IntCode::Zero,
     }
 }

--- a/src/bit.rs
+++ b/src/bit.rs
@@ -9,7 +9,7 @@
 //! - From `core::ops`: `BitAnd`, `BitOr`, `BitXor`, and `Not`.
 //! - From `typenum`: `Same` and `Cmp`.
 
-use crate::{private::InternalMarker, Cmp, Equal, Greater, Less, NonZero, PowerOfTwo, Zero};
+use crate::{private::InternalMarker, Cmp, Equal, Greater, Less, NonZero, Ord, PowerOfTwo, Zero};
 use core::ops::{BitAnd, BitOr, BitXor, Not};
 
 pub use crate::marker_traits::Bit;
@@ -44,6 +44,30 @@ impl Bit for B0 {
     const U8: u8 = 0;
     const BOOL: bool = false;
 
+    /// Not of 0 (!0 = 1)
+    type Not = B1;
+
+    /// And with 0 (0 & B = 0)
+    type BitAnd<Rhs: Bit> = B0;
+
+    /// Or with 0 (0 | B = B)
+    type BitOr<Rhs: Bit> = Rhs;
+
+    /// Xor with 0 (0 ^ B = B)
+    type BitXor<Rhs: Bit> = Rhs;
+
+    /// Min with 0 (min(0, B) = 0)
+    type Min<Rhs: Bit> = B0;
+
+    /// Max with 0 (max(0, B) = B)
+    type Max<Rhs: Bit> = Rhs;
+
+    /// Comparison with 0 is Less if Rhs is 1, Equal otherwise
+    type Cmp<Rhs: Bit> = Rhs::IfOrd<Less, Equal>;
+
+    /// If false then B
+    type IfOrd<A: Ord, B: Ord> = B;
+
     #[inline]
     fn new() -> Self {
         Self
@@ -61,6 +85,30 @@ impl Bit for B0 {
 impl Bit for B1 {
     const U8: u8 = 1;
     const BOOL: bool = true;
+
+    /// Not of 1 (!1 = 0)
+    type Not = B0;
+
+    /// And with 1 (1 & B = B)
+    type BitAnd<Rhs: Bit> = Rhs;
+
+    /// Or with 1 (1 | B = 1)
+    type BitOr<Rhs: Bit> = B1;
+
+    /// Xor with 1 (1 ^ B = !B)
+    type BitXor<Rhs: Bit> = Rhs::Not;
+
+    /// Min with 1 (min(1, B) = B)
+    type Min<Rhs: Bit> = Rhs;
+
+    /// Max with 1 (max(1, B) = 1)
+    type Max<Rhs: Bit> = B1;
+
+    /// Comparison with 1 is Equal if Rhs is 1, Greater otherwise
+    type Cmp<Rhs: Bit> = Rhs::IfOrd<Greater, Equal>;
+
+    /// If true then A
+    type IfOrd<A: Ord, B: Ord> = A;
 
     #[inline]
     fn new() -> Self {
@@ -80,107 +128,48 @@ impl Zero for B0 {}
 impl NonZero for B1 {}
 impl PowerOfTwo for B1 {}
 
+macro_rules! delegate_bit_binary_impls {
+    (@inner $type:ident, $fn_name:ident, $target:ty) => {
+        impl<Rhs: Bit> $type<Rhs> for $target {
+            // Delegate the implementation
+            type Output = <Self as Bit>::$type<Rhs>;
+            #[inline]
+            fn $fn_name(self, _: Rhs) -> Self::Output {
+                Self::Output::new()
+            }
+        }
+    };
+    // `type` is the rust operation trait name, and fn_name the name of the function in this trait
+    ($($type:ident, $fn_name:ident,)*) => {
+        $(
+            // Implementation for B0
+            delegate_bit_binary_impls!{@inner $type, $fn_name, B0}
+            // Implementation for B1
+            delegate_bit_binary_impls!{@inner $type, $fn_name, B1}
+        )*
+    };
+}
+
+delegate_bit_binary_impls! {
+    BitAnd, bitand,
+    BitOr, bitor,
+    BitXor, bitxor,
+}
+
 /// Not of 0 (!0 = 1)
 impl Not for B0 {
-    type Output = B1;
+    type Output = <Self as Bit>::Not;
     #[inline]
     fn not(self) -> Self::Output {
-        B1
+        Self::Output::new()
     }
 }
 /// Not of 1 (!1 = 0)
 impl Not for B1 {
-    type Output = B0;
+    type Output = <Self as Bit>::Not;
     #[inline]
     fn not(self) -> Self::Output {
-        B0
-    }
-}
-
-/// And with 0 ( 0 & B = 0)
-impl<Rhs: Bit> BitAnd<Rhs> for B0 {
-    type Output = B0;
-    #[inline]
-    fn bitand(self, _: Rhs) -> Self::Output {
-        B0
-    }
-}
-
-/// And with 1 ( 1 & 0 = 0)
-impl BitAnd<B0> for B1 {
-    type Output = B0;
-    #[inline]
-    fn bitand(self, _: B0) -> Self::Output {
-        B0
-    }
-}
-
-/// And with 1 ( 1 & 1 = 1)
-impl BitAnd<B1> for B1 {
-    type Output = B1;
-    #[inline]
-    fn bitand(self, _: B1) -> Self::Output {
-        B1
-    }
-}
-
-/// Or with 0 ( 0 | 0 = 0)
-impl BitOr<B0> for B0 {
-    type Output = B0;
-    #[inline]
-    fn bitor(self, _: B0) -> Self::Output {
-        B0
-    }
-}
-
-/// Or with 0 ( 0 | 1 = 1)
-impl BitOr<B1> for B0 {
-    type Output = B1;
-    #[inline]
-    fn bitor(self, _: B1) -> Self::Output {
-        B1
-    }
-}
-
-/// Or with 1 ( 1 | B = 1)
-impl<Rhs: Bit> BitOr<Rhs> for B1 {
-    type Output = B1;
-    #[inline]
-    fn bitor(self, _: Rhs) -> Self::Output {
-        B1
-    }
-}
-
-/// Xor between 0 and 0 ( 0 ^ 0 = 0)
-impl BitXor<B0> for B0 {
-    type Output = B0;
-    #[inline]
-    fn bitxor(self, _: B0) -> Self::Output {
-        B0
-    }
-}
-/// Xor between 1 and 0 ( 1 ^ 0 = 1)
-impl BitXor<B0> for B1 {
-    type Output = B1;
-    #[inline]
-    fn bitxor(self, _: B0) -> Self::Output {
-        B1
-    }
-}
-/// Xor between 0 and 1 ( 0 ^ 1 = 1)
-impl BitXor<B1> for B0 {
-    type Output = B1;
-    #[inline]
-    fn bitxor(self, _: B1) -> Self::Output {
-        B1
-    }
-}
-/// Xor between 1 and 1 ( 1 ^ 1 = 0)
-impl BitXor<B1> for B1 {
-    type Output = B0;
-    #[inline]
-    fn bitxor(self, _: B1) -> Self::Output {
-        B0
+        Self::Output::new()
     }
 }
 
@@ -231,100 +220,27 @@ mod bit_op_tests {
     }
 }
 
-impl Cmp<B0> for B0 {
-    type Output = Equal;
-
+impl<Rhs: Bit> Cmp<Rhs> for B0 {
+    type Output = <Self as Bit>::Cmp<Rhs>;
     #[inline]
-    fn compare<P: InternalMarker>(&self, _: &B0) -> Self::Output {
-        Equal
+    fn compare<P: InternalMarker>(&self, _: &Rhs) -> Self::Output {
+        Self::Output::new()
     }
 }
 
-impl Cmp<B1> for B0 {
-    type Output = Less;
-
+impl<Rhs: Bit> Cmp<Rhs> for B1 {
+    type Output = <Self as Bit>::Cmp<Rhs>;
     #[inline]
-    fn compare<P: InternalMarker>(&self, _: &B1) -> Self::Output {
-        Less
-    }
-}
-
-impl Cmp<B0> for B1 {
-    type Output = Greater;
-
-    #[inline]
-    fn compare<P: InternalMarker>(&self, _: &B0) -> Self::Output {
-        Greater
-    }
-}
-
-impl Cmp<B1> for B1 {
-    type Output = Equal;
-
-    #[inline]
-    fn compare<P: InternalMarker>(&self, _: &B1) -> Self::Output {
-        Equal
-    }
-}
-
-use crate::Min;
-impl Min<B0> for B0 {
-    type Output = B0;
-    #[inline]
-    fn min(self, _: B0) -> B0 {
-        self
-    }
-}
-impl Min<B1> for B0 {
-    type Output = B0;
-    #[inline]
-    fn min(self, _: B1) -> B0 {
-        self
-    }
-}
-impl Min<B0> for B1 {
-    type Output = B0;
-    #[inline]
-    fn min(self, rhs: B0) -> B0 {
-        rhs
-    }
-}
-impl Min<B1> for B1 {
-    type Output = B1;
-    #[inline]
-    fn min(self, _: B1) -> B1 {
-        self
+    fn compare<P: InternalMarker>(&self, _: &Rhs) -> Self::Output {
+        Self::Output::new()
     }
 }
 
 use crate::Max;
-impl Max<B0> for B0 {
-    type Output = B0;
-    #[inline]
-    fn max(self, _: B0) -> B0 {
-        self
-    }
-}
-impl Max<B1> for B0 {
-    type Output = B1;
-    #[inline]
-    fn max(self, rhs: B1) -> B1 {
-        rhs
-    }
-}
-impl Max<B0> for B1 {
-    type Output = B1;
-    #[inline]
-    fn max(self, _: B0) -> B1 {
-        self
-    }
-}
-impl Max<B1> for B1 {
-    type Output = B1;
-    #[inline]
-    fn max(self, _: B1) -> B1 {
-        self
-    }
+use crate::Min;
+delegate_bit_binary_impls! {
+    Min, min,
+    Max, max,
 }
 
 #[cfg(test)]

--- a/src/bit.rs
+++ b/src/bit.rs
@@ -12,6 +12,7 @@
 use crate::{
     private::InternalMarker, Cmp, Equal, Greater, Less, NonZero, Ord, PowerOfTwo, Unsigned, Zero,
 };
+use crate::{IntoUnsigned, U0, U1};
 use core::ops::{BitAnd, BitOr, BitXor, Not};
 
 pub use crate::marker_traits::Bit;
@@ -66,15 +67,29 @@ impl Bit for B0 {
 
     /// Comparison with 0 is Less if Rhs is 1, Equal otherwise
     type Cmp<Rhs: Bit> = Rhs::IfOrd<Less, Equal>;
+    #[inline]
+    fn compare<Rhs: Bit>(_: Rhs) -> Self::Cmp<Rhs> {
+        Rhs::if_ord(Less, Equal)
+    }
 
     /// If false then B
     type IfOrd<A: Ord, B: Ord> = B;
+    #[inline]
+    fn if_ord<A: Ord, B: Ord>(_: A, b: B) -> Self::IfOrd<A, B> {
+        b
+    }
 
     /// If false then B
     type IfUnsigned<A: Unsigned, B: Unsigned> = B;
     #[inline]
     fn if_unsigned<A: Unsigned, B: Unsigned>(_: A, b: B) -> Self::IfUnsigned<A, B> {
         b
+    }
+
+    type SelectShlUnsigned<S: Unsigned, N: Unsigned> = <S::Double as Unsigned>::Shl<N::Predecessor>;
+    #[allow(missing_docs)]
+    fn select_shl_unsigned<S: Unsigned, N: Unsigned>(s: S, n: N) -> Self::SelectShlUnsigned<S, N> {
+        s.double().shl(n.predecessor())
     }
 
     #[inline]
@@ -114,16 +129,30 @@ impl Bit for B1 {
     type Max<Rhs: Bit> = B1;
 
     /// Comparison with 1 is Equal if Rhs is 1, Greater otherwise
-    type Cmp<Rhs: Bit> = Rhs::IfOrd<Greater, Equal>;
+    type Cmp<Rhs: Bit> = Rhs::IfOrd<Equal, Greater>;
+    #[inline]
+    fn compare<Rhs: Bit>(_: Rhs) -> Self::Cmp<Rhs> {
+        Rhs::if_ord(Equal, Greater)
+    }
 
     /// If true then A
     type IfOrd<A: Ord, B: Ord> = A;
+    #[inline]
+    fn if_ord<A: Ord, B: Ord>(a: A, _: B) -> Self::IfOrd<A, B> {
+        a
+    }
 
     /// If true then A
     type IfUnsigned<A: Unsigned, B: Unsigned> = A;
     #[inline]
     fn if_unsigned<A: Unsigned, B: Unsigned>(a: A, _: B) -> Self::IfUnsigned<A, B> {
         a
+    }
+
+    type SelectShlUnsigned<S: Unsigned, N: Unsigned> = S;
+    #[inline]
+    fn select_shl_unsigned<S: Unsigned, N: Unsigned>(s: S, _: N) -> Self::SelectShlUnsigned<S, N> {
+        s
     }
 
     #[inline]
@@ -257,6 +286,24 @@ use crate::Min;
 delegate_bit_binary_impls! {
     Min, min,
     Max, max,
+}
+
+impl IntoUnsigned for B0 {
+    type IntoUnsigned = U0;
+
+    #[inline]
+    fn into_unsigned(self) -> Self::IntoUnsigned {
+        U0::new()
+    }
+}
+
+impl IntoUnsigned for B1 {
+    type IntoUnsigned = U1;
+
+    #[inline]
+    fn into_unsigned(self) -> Self::IntoUnsigned {
+        U1::new()
+    }
 }
 
 #[cfg(test)]

--- a/src/bit.rs
+++ b/src/bit.rs
@@ -9,7 +9,9 @@
 //! - From `core::ops`: `BitAnd`, `BitOr`, `BitXor`, and `Not`.
 //! - From `typenum`: `Same` and `Cmp`.
 
-use crate::{private::InternalMarker, Cmp, Equal, Greater, Less, NonZero, Ord, PowerOfTwo, Zero};
+use crate::{
+    private::InternalMarker, Cmp, Equal, Greater, Less, NonZero, Ord, PowerOfTwo, Unsigned, Zero,
+};
 use core::ops::{BitAnd, BitOr, BitXor, Not};
 
 pub use crate::marker_traits::Bit;
@@ -68,6 +70,12 @@ impl Bit for B0 {
     /// If false then B
     type IfOrd<A: Ord, B: Ord> = B;
 
+    /// If false then B
+    type IfUnsigned<A: Unsigned, B: Unsigned> = B;
+    fn if_unsigned<A: Unsigned, B: Unsigned>(_: A, b: B) -> Self::IfUnsigned<A, B> {
+        b
+    }
+
     #[inline]
     fn new() -> Self {
         Self
@@ -109,6 +117,12 @@ impl Bit for B1 {
 
     /// If true then A
     type IfOrd<A: Ord, B: Ord> = A;
+
+    /// If true then A
+    type IfUnsigned<A: Unsigned, B: Unsigned> = A;
+    fn if_unsigned<A: Unsigned, B: Unsigned>(a: A, _: B) -> Self::IfUnsigned<A, B> {
+        a
+    }
 
     #[inline]
     fn new() -> Self {

--- a/src/bit.rs
+++ b/src/bit.rs
@@ -72,6 +72,7 @@ impl Bit for B0 {
 
     /// If false then B
     type IfUnsigned<A: Unsigned, B: Unsigned> = B;
+    #[inline]
     fn if_unsigned<A: Unsigned, B: Unsigned>(_: A, b: B) -> Self::IfUnsigned<A, B> {
         b
     }
@@ -120,6 +121,7 @@ impl Bit for B1 {
 
     /// If true then A
     type IfUnsigned<A: Unsigned, B: Unsigned> = A;
+    #[inline]
     fn if_unsigned<A: Unsigned, B: Unsigned>(a: A, _: B) -> Self::IfUnsigned<A, B> {
         a
     }

--- a/src/int.rs
+++ b/src/int.rs
@@ -30,7 +30,7 @@ pub use crate::marker_traits::Integer;
 use crate::{
     bit::{Bit, B0, B1},
     consts::{N1, P1, U0, U1},
-    private::{Internal, InternalMarker, PrivateDivInt, PrivateIntegerAdd, PrivateRem},
+    private::{InternalMarker, PrivateDivInt, PrivateIntegerAdd, PrivateRem},
     uint::{UInt, Unsigned},
     Cmp, Equal, Greater, Less, NonZero, Pow, PowerOfTwo, ToInt, Zero,
 };
@@ -305,14 +305,14 @@ where
 /// `P(Ul) + N(Ur)`: We resolve this with our `PrivateAdd`
 impl<Ul: Unsigned + NonZero, Ur: Unsigned + NonZero> Add<NInt<Ur>> for PInt<Ul>
 where
-    Ul: Cmp<Ur> + PrivateIntegerAdd<<Ul as Cmp<Ur>>::Output, Ur>,
+    Ul: PrivateIntegerAdd<Ul::Cmp<Ur>, Ur>,
 {
-    type Output = <Ul as PrivateIntegerAdd<<Ul as Cmp<Ur>>::Output, Ur>>::Output;
+    type Output = <Ul as PrivateIntegerAdd<Ul::Cmp<Ur>, Ur>>::Output;
     #[inline]
     fn add(self, rhs: NInt<Ur>) -> Self::Output {
         let lhs = self.n;
         let rhs = rhs.n;
-        let lhs_cmp_rhs = lhs.compare::<Internal>(&rhs);
+        let lhs_cmp_rhs = lhs.compare(rhs);
         lhs.private_integer_add(lhs_cmp_rhs, rhs)
     }
 }
@@ -321,14 +321,14 @@ where
 // We just do the same thing as above, swapping Lhs and Rhs
 impl<Ul: Unsigned + NonZero, Ur: Unsigned + NonZero> Add<PInt<Ur>> for NInt<Ul>
 where
-    Ur: Cmp<Ul> + PrivateIntegerAdd<<Ur as Cmp<Ul>>::Output, Ul>,
+    Ur: Cmp<Ul> + PrivateIntegerAdd<Ur::Cmp<Ul>, Ul>,
 {
-    type Output = <Ur as PrivateIntegerAdd<<Ur as Cmp<Ul>>::Output, Ul>>::Output;
+    type Output = <Ur as PrivateIntegerAdd<Ur::Cmp<Ul>, Ul>>::Output;
     #[inline]
     fn add(self, rhs: PInt<Ur>) -> Self::Output {
         let lhs = self.n;
         let rhs = rhs.n;
-        let rhs_cmp_lhs = rhs.compare::<Internal>(&lhs);
+        let rhs_cmp_lhs = rhs.compare(lhs);
         rhs.private_integer_add(rhs_cmp_lhs, lhs)
     }
 }
@@ -448,14 +448,14 @@ where
 /// `P(Ul) - P(Ur)`: We resolve this with our `PrivateAdd`
 impl<Ul: Unsigned + NonZero, Ur: Unsigned + NonZero> Sub<PInt<Ur>> for PInt<Ul>
 where
-    Ul: Cmp<Ur> + PrivateIntegerAdd<<Ul as Cmp<Ur>>::Output, Ur>,
+    Ul: Cmp<Ur> + PrivateIntegerAdd<Ul::Cmp<Ur>, Ur>,
 {
-    type Output = <Ul as PrivateIntegerAdd<<Ul as Cmp<Ur>>::Output, Ur>>::Output;
+    type Output = <Ul as PrivateIntegerAdd<Ul::Cmp<Ur>, Ur>>::Output;
     #[inline]
     fn sub(self, rhs: PInt<Ur>) -> Self::Output {
         let lhs = self.n;
         let rhs = rhs.n;
-        let lhs_cmp_rhs = lhs.compare::<Internal>(&rhs);
+        let lhs_cmp_rhs = lhs.compare(rhs);
         lhs.private_integer_add(lhs_cmp_rhs, rhs)
     }
 }
@@ -464,14 +464,14 @@ where
 // We just do the same thing as above, swapping Lhs and Rhs
 impl<Ul: Unsigned + NonZero, Ur: Unsigned + NonZero> Sub<NInt<Ur>> for NInt<Ul>
 where
-    Ur: Cmp<Ul> + PrivateIntegerAdd<<Ur as Cmp<Ul>>::Output, Ul>,
+    Ur: Cmp<Ul> + PrivateIntegerAdd<Ur::Cmp<Ul>, Ul>,
 {
-    type Output = <Ur as PrivateIntegerAdd<<Ur as Cmp<Ul>>::Output, Ul>>::Output;
+    type Output = <Ur as PrivateIntegerAdd<Ur::Cmp<Ul>, Ul>>::Output;
     #[inline]
     fn sub(self, rhs: NInt<Ur>) -> Self::Output {
         let lhs = self.n;
         let rhs = rhs.n;
-        let rhs_cmp_lhs = rhs.compare::<Internal>(&lhs);
+        let rhs_cmp_lhs = rhs.compare(lhs);
         rhs.private_integer_add(rhs_cmp_lhs, lhs)
     }
 }
@@ -576,12 +576,12 @@ macro_rules! impl_int_div {
         impl<Ul: Unsigned + NonZero, Ur: Unsigned + NonZero> Div<$B<Ur>> for $A<Ul>
         where
             Ul: Cmp<Ur>,
-            $A<Ul>: PrivateDivInt<<Ul as Cmp<Ur>>::Output, $B<Ur>>,
+            $A<Ul>: PrivateDivInt<Ul::Cmp<Ur>, $B<Ur>>,
         {
-            type Output = <$A<Ul> as PrivateDivInt<<Ul as Cmp<Ur>>::Output, $B<Ur>>>::Output;
+            type Output = <$A<Ul> as PrivateDivInt<Ul::Cmp<Ur>, $B<Ur>>>::Output;
             #[inline]
             fn div(self, rhs: $B<Ur>) -> Self::Output {
-                let lhs_cmp_rhs = self.n.compare::<Internal>(&rhs.n);
+                let lhs_cmp_rhs = self.n.compare(rhs.n);
                 self.private_div_int(lhs_cmp_rhs, rhs)
             }
         }
@@ -720,22 +720,22 @@ impl<P: Unsigned + NonZero, N: Unsigned + NonZero> Cmp<NInt<N>> for PInt<P> {
 }
 
 /// X <==> Y
-impl<Pl: Cmp<Pr> + Unsigned + NonZero, Pr: Unsigned + NonZero> Cmp<PInt<Pr>> for PInt<Pl> {
-    type Output = <Pl as Cmp<Pr>>::Output;
+impl<Pl: Unsigned + NonZero, Pr: Unsigned + NonZero> Cmp<PInt<Pr>> for PInt<Pl> {
+    type Output = Pl::Cmp<Pr>;
 
     #[inline]
     fn compare<IM: InternalMarker>(&self, rhs: &PInt<Pr>) -> Self::Output {
-        self.n.compare::<Internal>(&rhs.n)
+        self.n.compare(rhs.n)
     }
 }
 
 /// -X <==> -Y
-impl<Nl: Unsigned + NonZero, Nr: Cmp<Nl> + Unsigned + NonZero> Cmp<NInt<Nr>> for NInt<Nl> {
-    type Output = <Nr as Cmp<Nl>>::Output;
+impl<Nl: Unsigned + NonZero, Nr: Unsigned + NonZero> Cmp<NInt<Nr>> for NInt<Nl> {
+    type Output = Nr::Cmp<Nl>;
 
     #[inline]
     fn compare<IM: InternalMarker>(&self, rhs: &NInt<Nr>) -> Self::Output {
-        rhs.n.compare::<Internal>(&self.n)
+        rhs.n.compare(self.n)
     }
 }
 
@@ -1047,7 +1047,7 @@ where
     #[inline]
     fn min(self, rhs: PInt<Ur>) -> Self::Output {
         PInt {
-            n: self.n.min(rhs.n),
+            n: Min::min(self.n, rhs.n),
         }
     }
 }
@@ -1086,7 +1086,7 @@ where
     #[inline]
     fn min(self, rhs: NInt<Ur>) -> Self::Output {
         NInt {
-            n: self.n.max(rhs.n),
+            n: Max::max(self.n, rhs.n),
         }
     }
 }
@@ -1156,7 +1156,7 @@ where
     #[inline]
     fn max(self, rhs: PInt<Ur>) -> Self::Output {
         PInt {
-            n: self.n.max(rhs.n),
+            n: Max::max(self.n, rhs.n),
         }
     }
 }
@@ -1195,7 +1195,7 @@ where
     #[inline]
     fn max(self, rhs: NInt<Ur>) -> Self::Output {
         NInt {
-            n: self.n.min(rhs.n),
+            n: Min::min(self.n, rhs.n),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,10 @@ pub struct Equal;
 /// Returns `core::cmp::Ordering::Greater`
 impl Ord for Greater {
     #[inline]
+    fn new() -> Self {
+        Self
+    }
+    #[inline]
     fn to_ordering() -> Ordering {
         Ordering::Greater
     }
@@ -114,6 +118,10 @@ impl Ord for Greater {
 /// Returns `core::cmp::Ordering::Less`
 impl Ord for Less {
     #[inline]
+    fn new() -> Self {
+        Self
+    }
+    #[inline]
     fn to_ordering() -> Ordering {
         Ordering::Less
     }
@@ -121,6 +129,10 @@ impl Ord for Less {
 
 /// Returns `core::cmp::Ordering::Equal`
 impl Ord for Equal {
+    #[inline]
+    fn new() -> Self {
+        Self
+    }
     #[inline]
     fn to_ordering() -> Ordering {
         Ordering::Equal

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,9 +109,15 @@ impl Ord for Greater {
     fn new() -> Self {
         Self
     }
+    type IsLess = B0;
     #[inline]
     fn to_ordering() -> Ordering {
         Ordering::Greater
+    }
+    type Then<Rhs: Ord> = Greater;
+    #[inline]
+    fn then<Rhs: Ord>() -> Self::Then<Rhs> {
+        Greater
     }
 }
 
@@ -121,9 +127,15 @@ impl Ord for Less {
     fn new() -> Self {
         Self
     }
+    type IsLess = B1;
     #[inline]
     fn to_ordering() -> Ordering {
         Ordering::Less
+    }
+    type Then<Rhs: Ord> = Less;
+    #[inline]
+    fn then<Rhs: Ord>() -> Self::Then<Rhs> {
+        Less
     }
 }
 
@@ -133,9 +145,15 @@ impl Ord for Equal {
     fn new() -> Self {
         Self
     }
+    type IsLess = B0;
     #[inline]
     fn to_ordering() -> Ordering {
         Ordering::Equal
+    }
+    type Then<Rhs: Ord> = Rhs;
+    #[inline]
+    fn then<Rhs: Ord>() -> Self::Then<Rhs> {
+        Rhs::new()
     }
 }
 

--- a/src/marker_traits.rs
+++ b/src/marker_traits.rs
@@ -65,6 +65,11 @@ pub trait Bit: Sealed + Copy + Default + 'static {
     /// Returns `A` if `Self` is `B1`, `B` otherwise. `A`, `B` and the output must implement `Cmp`.
     type IfOrd<A: Ord, B: Ord>: Ord;
 
+    /// Returns `A` if `Self` is `B1`, `B` otherwise. `A`, `B` and the output must implement `Unsigned`.
+    type IfUnsigned<A: Unsigned, B: Unsigned>: Unsigned;
+    #[allow(missing_docs)]
+    fn if_unsigned<A: Unsigned, B: Unsigned>(a: A, b: B) -> Self::IfUnsigned<A, B>;
+
     /// Instantiates a singleton representing this bit.
     fn new() -> Self;
 
@@ -139,6 +144,35 @@ pub trait Unsigned: Sealed + Copy + Default + 'static {
     fn to_i128() -> i128;
     #[allow(missing_docs)]
     fn to_isize() -> isize;
+
+    /// Get the Most Significant bits as a type.
+    type GetMSB: Unsigned;
+    #[allow(missing_docs)]
+    fn get_msb(self) -> Self::GetMSB;
+
+    /// Get the Least Significant bit as a type.
+    type GetLSB: Bit;
+    #[allow(missing_docs)]
+    fn get_lsb(self) -> Self::GetLSB;
+
+    /// Successor of `Self`, equal to `Self + 1`
+    type Successor: Unsigned;
+    #[allow(missing_docs)]
+    fn successor(self) -> Self::Successor;
+
+    /// Add `Self` with `Rhs`.
+    type Add<Rhs: Unsigned>: Unsigned;
+    #[allow(missing_docs)]
+    fn add<Rhs: Unsigned>(self, rhs: Rhs) -> Self::Add<Rhs>;
+
+    /// Add `Self` with `Rhs`, with an additional carry bit.
+    type AddCarry<Rhs: Unsigned, Carry: Bit>: Unsigned;
+    #[allow(missing_docs)]
+    fn add_carry<Rhs: Unsigned, Carry: Bit>(self, rhs: Rhs) -> Self::AddCarry<Rhs, Carry>;
+    /// Add `Self` with `Rhs`, where `Rhs` is in the form `UInt<Ur, Br>`.
+    type AddUInt<Ur: Unsigned, Br: Bit>: Unsigned;
+    #[allow(missing_docs)]
+    fn add_uint<Ur: Unsigned, Br: Bit>(self, ur: Ur) -> Self::AddUInt<Ur, Br>;
 }
 
 /// The **marker trait** for compile time signed integers.

--- a/src/marker_traits.rs
+++ b/src/marker_traits.rs
@@ -27,6 +27,9 @@ pub trait Zero: Sealed {}
 
 /// A **Marker trait** for the types `Greater`, `Equal`, and `Less`.
 pub trait Ord: Sealed {
+    /// Instantiates a singleton representing this ordering.
+    fn new() -> Self;
+
     #[allow(missing_docs)]
     fn to_ordering() -> ::core::cmp::Ordering;
 }
@@ -37,6 +40,30 @@ pub trait Bit: Sealed + Copy + Default + 'static {
     const U8: u8;
     #[allow(missing_docs)]
     const BOOL: bool;
+
+    /// Negation of the current bit.
+    type Not: Bit;
+
+    /// Conjunction of the current bit with `Rhs`.
+    type BitAnd<Rhs: Bit>: Bit;
+
+    /// Disjunction of the current bit with `Rhs`.
+    type BitOr<Rhs: Bit>: Bit;
+
+    /// Exclusive or of the current bit with `Rhs`.
+    type BitXor<Rhs: Bit>: Bit;
+
+    /// Minimum between `Self` and `Rhs`.
+    type Min<Rhs: Bit>: Bit;
+
+    /// Maximum between `Self` and `Rhs`.
+    type Max<Rhs: Bit>: Bit;
+
+    /// Comparison between `Self` and `Rhs`.
+    type Cmp<Rhs: Bit>: Ord;
+
+    /// Returns `A` if `Self` is `B1`, `B` otherwise. `A`, `B` and the output must implement `Cmp`.
+    type IfOrd<A: Ord, B: Ord>: Ord;
 
     /// Instantiates a singleton representing this bit.
     fn new() -> Self;

--- a/src/marker_traits.rs
+++ b/src/marker_traits.rs
@@ -32,6 +32,14 @@ pub trait Ord: Sealed {
 
     #[allow(missing_docs)]
     fn to_ordering() -> ::core::cmp::Ordering;
+
+    /// Returns `B1` if `Self` is `Less`, `B0` otherwise.
+    type IsLess: Bit;
+
+    /// Returns `Rhs` if `Self` is `Equal`, `Self` otherwise.
+    type Then<Rhs: Ord>: Ord;
+    #[allow(missing_docs)]
+    fn then<Rhs: Ord>() -> Self::Then<Rhs>;
 }
 
 /// The **marker trait** for compile time bits.
@@ -61,14 +69,23 @@ pub trait Bit: Sealed + Copy + Default + 'static {
 
     /// Comparison between `Self` and `Rhs`.
     type Cmp<Rhs: Bit>: Ord;
+    #[allow(missing_docs)]
+    fn compare<Rhs: Bit>(rhs: Rhs) -> Self::Cmp<Rhs>;
 
-    /// Returns `A` if `Self` is `B1`, `B` otherwise. `A`, `B` and the output must implement `Cmp`.
+    /// Returns `A` if `Self` is `B1`, `B` otherwise. `A`, `B` and the output must implement `Ord`.
     type IfOrd<A: Ord, B: Ord>: Ord;
+    #[allow(missing_docs)]
+    fn if_ord<A: Ord, B: Ord>(a: A, b: B) -> Self::IfOrd<A, B>;
 
     /// Returns `A` if `Self` is `B1`, `B` otherwise. `A`, `B` and the output must implement `Unsigned`.
     type IfUnsigned<A: Unsigned, B: Unsigned>: Unsigned;
     #[allow(missing_docs)]
     fn if_unsigned<A: Unsigned, B: Unsigned>(a: A, b: B) -> Self::IfUnsigned<A, B>;
+
+    /// Returns `S << N` if `Self` is B0, `S` otherwise.
+    type SelectShlUnsigned<S: Unsigned, N: Unsigned>: Unsigned;
+    #[allow(missing_docs)]
+    fn select_shl_unsigned<S: Unsigned, N: Unsigned>(s: S, n: N) -> Self::SelectShlUnsigned<S, N>;
 
     /// Instantiates a singleton representing this bit.
     fn new() -> Self;
@@ -145,12 +162,12 @@ pub trait Unsigned: Sealed + Copy + Default + 'static {
     #[allow(missing_docs)]
     fn to_isize() -> isize;
 
-    /// Get the Most Significant bits as a type.
+    /// Get the Most Significant Bits as a type.
     type GetMSB: Unsigned;
     #[allow(missing_docs)]
     fn get_msb(self) -> Self::GetMSB;
 
-    /// Get the Least Significant bit as a type.
+    /// Get the Least Significant Bit as a type.
     type GetLSB: Bit;
     #[allow(missing_docs)]
     fn get_lsb(self) -> Self::GetLSB;
@@ -175,24 +192,80 @@ pub trait Unsigned: Sealed + Copy + Default + 'static {
     #[allow(missing_docs)]
     fn is_zero(self) -> Self::IsZero;
 
+    /// Minimum between `Self` and `Rhs`.
+    type Min<Rhs: Unsigned>: Unsigned;
+    #[allow(missing_docs)]
+    fn min<Rhs: Unsigned>(self, rhs: Rhs) -> Self::Min<Rhs>;
+
+    /// Maximum between `Self` and `Rhs`.
+    type Max<Rhs: Unsigned>: Unsigned;
+    #[allow(missing_docs)]
+    fn max<Rhs: Unsigned>(self, rhs: Rhs) -> Self::Max<Rhs>;
+
+    /// Returns `Self & Rhs`.
+    type BitAnd<Rhs: Unsigned>: Unsigned;
+    #[allow(missing_docs)]
+    fn bitand<Rhs: Unsigned>(self, rhs: Rhs) -> Self::BitAnd<Rhs>;
+
+    /// Returns `Self | Rhs`.
+    type BitOr<Rhs: Unsigned>: Unsigned;
+    #[allow(missing_docs)]
+    fn bitor<Rhs: Unsigned>(self, rhs: Rhs) -> Self::BitOr<Rhs>;
+
+    /// Returns `Self ^ Rhs`.
+    type BitXor<Rhs: Unsigned>: Unsigned;
+    #[allow(missing_docs)]
+    fn bitxor<Rhs: Unsigned>(self, rhs: Rhs) -> Self::BitXor<Rhs>;
+
     /// Add `Self` with `Rhs`.
     type Add<Rhs: Unsigned>: Unsigned;
     #[allow(missing_docs)]
     fn add<Rhs: Unsigned>(self, rhs: Rhs) -> Self::Add<Rhs>;
-
     /// Add `Self` with `Rhs`, with an additional carry bit.
     type AddCarry<Rhs: Unsigned, Carry: Bit>: Unsigned;
     #[allow(missing_docs)]
     fn add_carry<Rhs: Unsigned, Carry: Bit>(self, rhs: Rhs) -> Self::AddCarry<Rhs, Carry>;
-    /// Add `Self` with `Rhs`, where `Rhs` is in the form `UInt<Ur, Br>`.
-    type AddUInt<Ur: Unsigned, Br: Bit>: Unsigned;
-    #[allow(missing_docs)]
-    fn add_uint<Ur: Unsigned, Br: Bit>(self, ur: Ur) -> Self::AddUInt<Ur, Br>;
 
-    /// Shift `Self` right left by `Rhs`.
+    /// Multiply `Self` with `Rhs`.
+    type Mul<Rhs: Unsigned>: Unsigned;
+    #[allow(missing_docs)]
+    fn mul<Rhs: Unsigned>(self, rhs: Rhs) -> Self::Mul<Rhs>;
+
+    /// Shift `Self` right by `Rhs`.
     type Shr<Rhs: Unsigned>: Unsigned;
     #[allow(missing_docs)]
     fn shr<Rhs: Unsigned>(self, rhs: Rhs) -> Self::Shr<Rhs>;
+
+    /// Shift `Self` left by `Rhs`.
+    type Shl<Rhs: Unsigned>: Unsigned;
+    #[allow(missing_docs)]
+    fn shl<Rhs: Unsigned>(self, rhs: Rhs) -> Self::Shl<Rhs>;
+
+    /// Returns `Self * 2 = Self << 1`.
+    type Double: Unsigned;
+    #[allow(missing_docs)]
+    fn double(self) -> Self::Double;
+
+    /// Compare `Self` with `Rhs`.
+    type Cmp<Rhs: Unsigned>: Ord;
+    #[allow(missing_docs)]
+    fn compare<Rhs: Unsigned>(self, rhs: Rhs) -> Self::Cmp<Rhs>;
+}
+
+/// The **marker trait** for converting a type to an unsigned integer at compile time.
+pub trait IntoUnsigned {
+    /// The type converted to an unsigned integer.
+    type IntoUnsigned: Unsigned;
+    #[allow(missing_docs)]
+    fn into_unsigned(self) -> Self::IntoUnsigned;
+}
+impl<U: Unsigned> IntoUnsigned for U {
+    type IntoUnsigned = Self;
+
+    #[inline]
+    fn into_unsigned(self) -> Self::IntoUnsigned {
+        self
+    }
 }
 
 /// The **marker trait** for compile time signed integers.

--- a/src/marker_traits.rs
+++ b/src/marker_traits.rs
@@ -192,6 +192,16 @@ pub trait Unsigned: Sealed + Copy + Default + 'static {
     #[allow(missing_docs)]
     fn is_zero(self) -> Self::IsZero;
 
+    /// Returns `B1` if `Self` is even.
+    type IsEven: Bit;
+    #[allow(missing_docs)]
+    fn is_even(self) -> Self::IsEven;
+
+    /// Returns `B1` if `Self` is odd.
+    type IsOdd: Bit;
+    #[allow(missing_docs)]
+    fn is_odd(self) -> Self::IsOdd;
+
     /// Minimum between `Self` and `Rhs`.
     type Min<Rhs: Unsigned>: Unsigned;
     #[allow(missing_docs)]
@@ -230,6 +240,15 @@ pub trait Unsigned: Sealed + Copy + Default + 'static {
     type Mul<Rhs: Unsigned>: Unsigned;
     #[allow(missing_docs)]
     fn mul<Rhs: Unsigned>(self, rhs: Rhs) -> Self::Mul<Rhs>;
+
+    /// Computes `Self**Rhs`.
+    type Pow<Rhs: Unsigned>: Unsigned;
+    #[allow(missing_docs)]
+    fn powi<Rhs: Unsigned>(self, rhs: Rhs) -> Self::Pow<Rhs>;
+    /// Computes `Lhs**Self`.
+    type PowSelf<Lhs: Unsigned>: Unsigned;
+    #[allow(missing_docs)]
+    fn powi_self<Lhs: Unsigned>(self, lhs: Lhs) -> Self::PowSelf<Lhs>;
 
     /// Shift `Self` right by `Rhs`.
     type Shr<Rhs: Unsigned>: Unsigned;

--- a/src/marker_traits.rs
+++ b/src/marker_traits.rs
@@ -160,6 +160,21 @@ pub trait Unsigned: Sealed + Copy + Default + 'static {
     #[allow(missing_docs)]
     fn successor(self) -> Self::Successor;
 
+    /// Predecessor of `Self`, equal to `Self - 1`
+    type Predecessor: Unsigned;
+    #[allow(missing_docs)]
+    fn predecessor(self) -> Self::Predecessor;
+
+    /// Trim `Self`, removing leading 0 bits.
+    type Trimmed: Unsigned;
+    #[allow(missing_docs)]
+    fn trimmed(self) -> Self::Trimmed;
+
+    /// Returns `B1` if `Self` is zero.
+    type IsZero: Bit;
+    #[allow(missing_docs)]
+    fn is_zero(self) -> Self::IsZero;
+
     /// Add `Self` with `Rhs`.
     type Add<Rhs: Unsigned>: Unsigned;
     #[allow(missing_docs)]
@@ -173,6 +188,11 @@ pub trait Unsigned: Sealed + Copy + Default + 'static {
     type AddUInt<Ur: Unsigned, Br: Bit>: Unsigned;
     #[allow(missing_docs)]
     fn add_uint<Ur: Unsigned, Br: Bit>(self, ur: Ur) -> Self::AddUInt<Ur, Br>;
+
+    /// Shift `Self` right left by `Rhs`.
+    type Shr<Rhs: Unsigned>: Unsigned;
+    #[allow(missing_docs)]
+    fn shr<Rhs: Unsigned>(self, rhs: Rhs) -> Self::Shr<Rhs>;
 }
 
 /// The **marker trait** for compile time signed integers.

--- a/src/operator_aliases.rs
+++ b/src/operator_aliases.rs
@@ -17,10 +17,13 @@
 //! ```
 
 // Aliases!!!
-use crate::type_operators::{
-    Abs, Cmp, FoldAdd, FoldMul, Gcd, Len, Logarithm2, Max, Min, PartialDiv, Pow, SquareRoot,
+use crate::{
+    type_operators::{
+        Abs, Cmp, FoldAdd, FoldMul, Gcd, Len, Logarithm2, Max, Min, PartialDiv, Pow, SquareRoot,
+    },
+    TypeShr,
 };
-use core::ops::{Add, BitAnd, BitOr, BitXor, Div, Mul, Neg, Rem, Shl, Shr, Sub};
+use core::ops::{Add, BitAnd, BitOr, BitXor, Div, Mul, Neg, Rem, Shl, Sub};
 
 /// Alias for the associated type of `BitAnd`: `And<A, B> = <A as BitAnd<B>>::Output`
 pub type And<A, B> = <A as BitAnd<B>>::Output;
@@ -32,7 +35,7 @@ pub type Xor<A, B> = <A as BitXor<B>>::Output;
 /// Alias for the associated type of `Shl`: `Shleft<A, B> = <A as Shl<B>>::Output`
 pub type Shleft<A, B> = <A as Shl<B>>::Output;
 /// Alias for the associated type of `Shr`: `Shright<A, B> = <A as Shr<B>>::Output`
-pub type Shright<A, B> = <A as Shr<B>>::Output;
+pub type Shright<A, B> = <A as TypeShr<B>>::Output;
 
 /// Alias for the associated type of `Add`: `Sum<A, B> = <A as Add<B>>::Output`
 pub type Sum<A, B> = <A as Add<B>>::Output;

--- a/src/operator_aliases.rs
+++ b/src/operator_aliases.rs
@@ -17,13 +17,10 @@
 //! ```
 
 // Aliases!!!
-use crate::{
-    type_operators::{
-        Abs, Cmp, FoldAdd, FoldMul, Gcd, Len, Logarithm2, Max, Min, PartialDiv, Pow, SquareRoot,
-    },
-    TypeShr,
+use crate::type_operators::{
+    Abs, Cmp, FoldAdd, FoldMul, Gcd, Len, Logarithm2, Max, Min, PartialDiv, Pow, SquareRoot,
 };
-use core::ops::{Add, BitAnd, BitOr, BitXor, Div, Mul, Neg, Rem, Shl, Sub};
+use core::ops::{Add, BitAnd, BitOr, BitXor, Div, Mul, Neg, Rem, Shl, Shr, Sub};
 
 /// Alias for the associated type of `BitAnd`: `And<A, B> = <A as BitAnd<B>>::Output`
 pub type And<A, B> = <A as BitAnd<B>>::Output;
@@ -35,7 +32,7 @@ pub type Xor<A, B> = <A as BitXor<B>>::Output;
 /// Alias for the associated type of `Shl`: `Shleft<A, B> = <A as Shl<B>>::Output`
 pub type Shleft<A, B> = <A as Shl<B>>::Output;
 /// Alias for the associated type of `Shr`: `Shright<A, B> = <A as Shr<B>>::Output`
-pub type Shright<A, B> = <A as TypeShr<B>>::Output;
+pub type Shright<A, B> = <A as Shr<B>>::Output;
 
 /// Alias for the associated type of `Add`: `Sum<A, B> = <A as Add<B>>::Output`
 pub type Sum<A, B> = <A as Add<B>>::Output;

--- a/src/private.rs
+++ b/src/private.rs
@@ -126,7 +126,7 @@ pub type ShiftDiffOut<A, Rhs> = <A as ShiftDiff<Rhs>>::Output;
 
 /// Gives `SizeOf(Lhs) - SizeOf(Rhs)`
 pub trait BitDiff<Rhs> {
-    type Output;
+    type Output: Unsigned;
 }
 pub type BitDiffOut<A, Rhs> = <A as BitDiff<Rhs>>::Output;
 

--- a/src/type_operators.rs
+++ b/src/type_operators.rs
@@ -60,6 +60,33 @@ impl<U: Unsigned + NonZero> Abs for NInt<U> {
     type Output = PInt<U>;
 }
 
+/// A **type operator** that provides binary and.
+pub trait TypeBitAnd<Rhs> {
+    /// The result of the binary and.
+    type Output;
+
+    #[doc(hidden)]
+    fn bitand(self, rhs: Rhs) -> Self::Output;
+}
+
+/// A **type operator** that provides binary or.
+pub trait TypeBitOr<Rhs> {
+    /// The result of the binary or.
+    type Output;
+
+    #[doc(hidden)]
+    fn bitor(self, rhs: Rhs) -> Self::Output;
+}
+
+/// A **type operator** that provides binary xor.
+pub trait TypeBitXor<Rhs> {
+    /// The result of the binary xor.
+    type Output;
+
+    #[doc(hidden)]
+    fn bitxor(self, rhs: Rhs) -> Self::Output;
+}
+
 /// A **type operator** that provides addition.
 pub trait TypeAdd<Rhs> {
     /// The result of the addition.
@@ -69,6 +96,15 @@ pub trait TypeAdd<Rhs> {
     fn add(self, rhs: Rhs) -> Self::Output;
 }
 
+/// A **type operator** that provides multiplication.
+pub trait TypeMul<Rhs> {
+    /// The result of the multiplication.
+    type Output;
+
+    #[doc(hidden)]
+    fn mul(self, rhs: Rhs) -> Self::Output;
+}
+
 /// A **type operator** that provides right shift operation.
 pub trait TypeShr<Rhs> {
     /// The result of the right shift.
@@ -76,6 +112,15 @@ pub trait TypeShr<Rhs> {
 
     #[doc(hidden)]
     fn shr(self, rhs: Rhs) -> Self::Output;
+}
+
+/// A **type operator** that provides left shift operation.
+pub trait TypeShl<Rhs> {
+    /// The result of the left shift.
+    type Output;
+
+    #[doc(hidden)]
+    fn shl(self, rhs: Rhs) -> Self::Output;
 }
 
 /// A **type operator** that provides exponentiation by repeated squaring.

--- a/src/type_operators.rs
+++ b/src/type_operators.rs
@@ -60,6 +60,15 @@ impl<U: Unsigned + NonZero> Abs for NInt<U> {
     type Output = PInt<U>;
 }
 
+/// A **type operator** that provides addition.
+pub trait TypeAdd<Rhs> {
+    /// The result of the addition.
+    type Output;
+
+    #[doc(hidden)]
+    fn add(self, rhs: Rhs) -> Self::Output;
+}
+
 /// A **type operator** that provides exponentiation by repeated squaring.
 ///
 /// # Example
@@ -307,6 +316,7 @@ fn pow_test() {
 /// assert_eq!(<P2 as Cmp<N3>>::Output::to_ordering(), Ordering::Greater);
 /// assert_eq!(<P2 as Cmp<P2>>::Output::to_ordering(), Ordering::Equal);
 /// assert_eq!(<P2 as Cmp<P5>>::Output::to_ordering(), Ordering::Less);
+/// ```
 pub trait Cmp<Rhs = Self> {
     /// The result of the comparison. It should only ever be one of `Greater`, `Less`, or `Equal`.
     type Output;

--- a/src/type_operators.rs
+++ b/src/type_operators.rs
@@ -69,6 +69,15 @@ pub trait TypeAdd<Rhs> {
     fn add(self, rhs: Rhs) -> Self::Output;
 }
 
+/// A **type operator** that provides right shift operation.
+pub trait TypeShr<Rhs> {
+    /// The result of the right shift.
+    type Output;
+
+    #[doc(hidden)]
+    fn shr(self, rhs: Rhs) -> Self::Output;
+}
+
 /// A **type operator** that provides exponentiation by repeated squaring.
 ///
 /// # Example

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -36,7 +36,7 @@ use crate::{
         PrivateSubOut, PrivateXor, PrivateXorOut, Trim, TrimOut,
     },
     Add1, Cmp, Double, Equal, Gcd, Gcf, GrEq, Greater, IsGreaterOrEqual, Len, Length, Less, Log2,
-    Logarithm2, Maximum, Minimum, NonZero, Or, Ord, Pow, Prod, Shleft, Shright, Sqrt, Square,
+    Logarithm2, Maximum, Minimum, NonZero, Ord, Pow, Prod, Shleft, Shright, Sqrt, Square,
     SquareRoot, Sub1, Sum, ToInt, Zero,
 };
 use core::ops::{Add, BitAnd, BitOr, BitXor, Mul, Shl, Shr, Sub};
@@ -689,66 +689,18 @@ impl<B: Bit, U: Unsigned> PrivateAnd<UTerm> for UInt<U, B> {
     }
 }
 
-/// `UInt<Ul, B0> & UInt<Ur, B0> = UInt<Ul & Ur, B0>`
-impl<Ul: Unsigned, Ur: Unsigned> PrivateAnd<UInt<Ur, B0>> for UInt<Ul, B0>
+/// `UInt<Ul, Bl> & UInt<Ur, Br> = UInt<Ul & Ur, Bl & Br>`
+impl<Ul: Unsigned, Ur: Unsigned, Bl: Bit, Br: Bit> PrivateAnd<UInt<Ur, Br>> for UInt<Ul, Bl>
 where
     Ul: PrivateAnd<Ur>,
 {
-    type Output = UInt<PrivateAndOut<Ul, Ur>, B0>;
+    type Output = UInt<PrivateAndOut<Ul, Ur>, Bl::BitAnd<Br>>;
 
     #[inline]
-    fn private_and(self, rhs: UInt<Ur, B0>) -> Self::Output {
+    fn private_and(self, rhs: UInt<Ur, Br>) -> Self::Output {
         UInt {
             msb: self.msb.private_and(rhs.msb),
-            lsb: B0,
-        }
-    }
-}
-
-/// `UInt<Ul, B0> & UInt<Ur, B1> = UInt<Ul & Ur, B0>`
-impl<Ul: Unsigned, Ur: Unsigned> PrivateAnd<UInt<Ur, B1>> for UInt<Ul, B0>
-where
-    Ul: PrivateAnd<Ur>,
-{
-    type Output = UInt<PrivateAndOut<Ul, Ur>, B0>;
-
-    #[inline]
-    fn private_and(self, rhs: UInt<Ur, B1>) -> Self::Output {
-        UInt {
-            msb: self.msb.private_and(rhs.msb),
-            lsb: B0,
-        }
-    }
-}
-
-/// `UInt<Ul, B1> & UInt<Ur, B0> = UInt<Ul & Ur, B0>`
-impl<Ul: Unsigned, Ur: Unsigned> PrivateAnd<UInt<Ur, B0>> for UInt<Ul, B1>
-where
-    Ul: PrivateAnd<Ur>,
-{
-    type Output = UInt<PrivateAndOut<Ul, Ur>, B0>;
-
-    #[inline]
-    fn private_and(self, rhs: UInt<Ur, B0>) -> Self::Output {
-        UInt {
-            msb: self.msb.private_and(rhs.msb),
-            lsb: B0,
-        }
-    }
-}
-
-/// `UInt<Ul, B1> & UInt<Ur, B1> = UInt<Ul & Ur, B1>`
-impl<Ul: Unsigned, Ur: Unsigned> PrivateAnd<UInt<Ur, B1>> for UInt<Ul, B1>
-where
-    Ul: PrivateAnd<Ur>,
-{
-    type Output = UInt<PrivateAndOut<Ul, Ur>, B1>;
-
-    #[inline]
-    fn private_and(self, rhs: UInt<Ur, B1>) -> Self::Output {
-        UInt {
-            msb: self.msb.private_and(rhs.msb),
-            lsb: B1,
+            lsb: <Bl::BitAnd<Br> as Bit>::new(),
         }
     }
 }
@@ -774,62 +726,17 @@ impl<B: Bit, U: Unsigned> BitOr<UTerm> for UInt<U, B> {
     }
 }
 
-/// `UInt<Ul, B0> | UInt<Ur, B0> = UInt<Ul | Ur, B0>`
-impl<Ul: Unsigned, Ur: Unsigned> BitOr<UInt<Ur, B0>> for UInt<Ul, B0>
+/// `UInt<Ul, Bl> | UInt<Ur, Br> = UInt<Ul | Ur, Bl | Br>`
+impl<Ul: Unsigned, Ur: Unsigned, Bl: Bit, Br: Bit> BitOr<UInt<Ur, Br>> for UInt<Ul, Bl>
 where
     Ul: BitOr<Ur>,
 {
-    type Output = UInt<<Ul as BitOr<Ur>>::Output, B0>;
+    type Output = UInt<<Ul as BitOr<Ur>>::Output, Bl::BitOr<Br>>;
     #[inline]
-    fn bitor(self, rhs: UInt<Ur, B0>) -> Self::Output {
+    fn bitor(self, rhs: UInt<Ur, Br>) -> Self::Output {
         UInt {
             msb: self.msb.bitor(rhs.msb),
-            lsb: B0,
-        }
-    }
-}
-
-/// `UInt<Ul, B0> | UInt<Ur, B1> = UInt<Ul | Ur, B1>`
-impl<Ul: Unsigned, Ur: Unsigned> BitOr<UInt<Ur, B1>> for UInt<Ul, B0>
-where
-    Ul: BitOr<Ur>,
-{
-    type Output = UInt<Or<Ul, Ur>, B1>;
-    #[inline]
-    fn bitor(self, rhs: UInt<Ur, B1>) -> Self::Output {
-        UInt {
-            msb: self.msb.bitor(rhs.msb),
-            lsb: self.lsb.bitor(rhs.lsb),
-        }
-    }
-}
-
-/// `UInt<Ul, B1> | UInt<Ur, B0> = UInt<Ul | Ur, B1>`
-impl<Ul: Unsigned, Ur: Unsigned> BitOr<UInt<Ur, B0>> for UInt<Ul, B1>
-where
-    Ul: BitOr<Ur>,
-{
-    type Output = UInt<Or<Ul, Ur>, B1>;
-    #[inline]
-    fn bitor(self, rhs: UInt<Ur, B0>) -> Self::Output {
-        UInt {
-            msb: self.msb.bitor(rhs.msb),
-            lsb: self.lsb.bitor(rhs.lsb),
-        }
-    }
-}
-
-/// `UInt<Ul, B1> | UInt<Ur, B1> = UInt<Ul | Ur, B1>`
-impl<Ul: Unsigned, Ur: Unsigned> BitOr<UInt<Ur, B1>> for UInt<Ul, B1>
-where
-    Ul: BitOr<Ur>,
-{
-    type Output = UInt<Or<Ul, Ur>, B1>;
-    #[inline]
-    fn bitor(self, rhs: UInt<Ur, B1>) -> Self::Output {
-        UInt {
-            msb: self.msb.bitor(rhs.msb),
-            lsb: self.lsb.bitor(rhs.lsb),
+            lsb: <Bl::BitOr<Br> as Bit>::new(),
         }
     }
 }
@@ -880,66 +787,18 @@ impl<B: Bit, U: Unsigned> PrivateXor<UTerm> for UInt<U, B> {
     }
 }
 
-/// `UInt<Ul, B0> ^ UInt<Ur, B0> = UInt<Ul ^ Ur, B0>`
-impl<Ul: Unsigned, Ur: Unsigned> PrivateXor<UInt<Ur, B0>> for UInt<Ul, B0>
+/// `UInt<Ul, Bl> ^ UInt<Ur, Br> = UInt<Ul ^ Ur, Bl ^ Br>`
+impl<Ul: Unsigned, Ur: Unsigned, Bl: Bit, Br: Bit> PrivateXor<UInt<Ur, Br>> for UInt<Ul, Bl>
 where
     Ul: PrivateXor<Ur>,
 {
-    type Output = UInt<PrivateXorOut<Ul, Ur>, B0>;
+    type Output = UInt<PrivateXorOut<Ul, Ur>, Bl::BitXor<Br>>;
 
     #[inline]
-    fn private_xor(self, rhs: UInt<Ur, B0>) -> Self::Output {
+    fn private_xor(self, rhs: UInt<Ur, Br>) -> Self::Output {
         UInt {
             msb: self.msb.private_xor(rhs.msb),
-            lsb: B0,
-        }
-    }
-}
-
-/// `UInt<Ul, B0> ^ UInt<Ur, B1> = UInt<Ul ^ Ur, B1>`
-impl<Ul: Unsigned, Ur: Unsigned> PrivateXor<UInt<Ur, B1>> for UInt<Ul, B0>
-where
-    Ul: PrivateXor<Ur>,
-{
-    type Output = UInt<PrivateXorOut<Ul, Ur>, B1>;
-
-    #[inline]
-    fn private_xor(self, rhs: UInt<Ur, B1>) -> Self::Output {
-        UInt {
-            msb: self.msb.private_xor(rhs.msb),
-            lsb: B1,
-        }
-    }
-}
-
-/// `UInt<Ul, B1> ^ UInt<Ur, B0> = UInt<Ul ^ Ur, B1>`
-impl<Ul: Unsigned, Ur: Unsigned> PrivateXor<UInt<Ur, B0>> for UInt<Ul, B1>
-where
-    Ul: PrivateXor<Ur>,
-{
-    type Output = UInt<PrivateXorOut<Ul, Ur>, B1>;
-
-    #[inline]
-    fn private_xor(self, rhs: UInt<Ur, B0>) -> Self::Output {
-        UInt {
-            msb: self.msb.private_xor(rhs.msb),
-            lsb: B1,
-        }
-    }
-}
-
-/// `UInt<Ul, B1> ^ UInt<Ur, B1> = UInt<Ul ^ Ur, B0>`
-impl<Ul: Unsigned, Ur: Unsigned> PrivateXor<UInt<Ur, B1>> for UInt<Ul, B1>
-where
-    Ul: PrivateXor<Ur>,
-{
-    type Output = UInt<PrivateXorOut<Ul, Ur>, B0>;
-
-    #[inline]
-    fn private_xor(self, rhs: UInt<Ur, B1>) -> Self::Output {
-        UInt {
-            msb: self.msb.private_xor(rhs.msb),
-            lsb: B0,
+            lsb: <Bl::BitXor<Br> as Bit>::new(),
         }
     }
 }
@@ -1207,28 +1066,15 @@ impl<U: Unsigned, B: Bit> Cmp<UInt<U, B>> for UTerm {
     }
 }
 
-/// `UInt<Ul, B0>` cmp with `UInt<Ur, B0>`: `SoFar` is `Equal`
-impl<Ul: Unsigned, Ur: Unsigned> Cmp<UInt<Ur, B0>> for UInt<Ul, B0>
+/// `UInt<Ul, B>` cmp with `UInt<Ur, B>`: `SoFar` is `Equal`
+impl<Ul: Unsigned, Ur: Unsigned, B> Cmp<UInt<Ur, B>> for UInt<Ul, B>
 where
     Ul: PrivateCmp<Ur, Equal>,
 {
     type Output = PrivateCmpOut<Ul, Ur, Equal>;
 
     #[inline]
-    fn compare<IM: InternalMarker>(&self, rhs: &UInt<Ur, B0>) -> Self::Output {
-        self.msb.private_cmp(&rhs.msb, Equal)
-    }
-}
-
-/// `UInt<Ul, B1>` cmp with `UInt<Ur, B1>`: `SoFar` is `Equal`
-impl<Ul: Unsigned, Ur: Unsigned> Cmp<UInt<Ur, B1>> for UInt<Ul, B1>
-where
-    Ul: PrivateCmp<Ur, Equal>,
-{
-    type Output = PrivateCmpOut<Ul, Ur, Equal>;
-
-    #[inline]
-    fn compare<IM: InternalMarker>(&self, rhs: &UInt<Ur, B1>) -> Self::Output {
+    fn compare<IM: InternalMarker>(&self, rhs: &UInt<Ur, B>) -> Self::Output {
         self.msb.private_cmp(&rhs.msb, Equal)
     }
 }
@@ -1259,9 +1105,9 @@ where
     }
 }
 
-/// Comparing non-terimal bits, with both having bit `B0`.
+/// Comparing non-terimal bits, with both having the same bit.
 /// These are `Equal`, so we propagate `SoFar`.
-impl<Ul, Ur, SoFar> PrivateCmp<UInt<Ur, B0>, SoFar> for UInt<Ul, B0>
+impl<Ul, Ur, SoFar, B> PrivateCmp<UInt<Ur, B>, SoFar> for UInt<Ul, B>
 where
     Ul: Unsigned,
     Ur: Unsigned,
@@ -1271,24 +1117,7 @@ where
     type Output = PrivateCmpOut<Ul, Ur, SoFar>;
 
     #[inline]
-    fn private_cmp(&self, rhs: &UInt<Ur, B0>, so_far: SoFar) -> Self::Output {
-        self.msb.private_cmp(&rhs.msb, so_far)
-    }
-}
-
-/// Comparing non-terimal bits, with both having bit `B1`.
-/// These are `Equal`, so we propagate `SoFar`.
-impl<Ul, Ur, SoFar> PrivateCmp<UInt<Ur, B1>, SoFar> for UInt<Ul, B1>
-where
-    Ul: Unsigned,
-    Ur: Unsigned,
-    SoFar: Ord,
-    Ul: PrivateCmp<Ur, SoFar>,
-{
-    type Output = PrivateCmpOut<Ul, Ur, SoFar>;
-
-    #[inline]
-    fn private_cmp(&self, rhs: &UInt<Ur, B1>, so_far: SoFar) -> Self::Output {
+    fn private_cmp(&self, rhs: &UInt<Ur, B>, so_far: SoFar) -> Self::Output {
         self.msb.private_cmp(&rhs.msb, so_far)
     }
 }

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -37,7 +37,7 @@ use crate::{
     },
     Add1, Cmp, Double, Equal, Gcd, Gcf, GrEq, Greater, IsGreaterOrEqual, Len, Length, Less, Log2,
     Logarithm2, Maximum, Minimum, NonZero, Ord, Pow, Prod, Shleft, Shright, Sqrt, Square,
-    SquareRoot, Sub1, Sum, ToInt, Zero,
+    SquareRoot, Sub1, Sum, ToInt, TypeAdd, Zero,
 };
 use core::ops::{Add, BitAnd, BitOr, BitXor, Mul, Shl, Shr, Sub};
 
@@ -127,34 +127,40 @@ impl Unsigned for UTerm {
     }
 
     type GetMSB = UTerm;
+    #[inline]
     fn get_msb(self) -> Self::GetMSB {
         UTerm
     }
 
     type GetLSB = B0;
+    #[inline]
     fn get_lsb(self) -> Self::GetLSB {
         B0
     }
 
     /// `0 + 1 = 1`
     type Successor = UInt<UTerm, B1>;
+    #[inline]
     fn successor(self) -> Self::Successor {
         U1::new()
     }
 
     /// `0 + Rhs = Rhs`
     type Add<Rhs: Unsigned> = Rhs;
+    #[inline]
     fn add<Rhs: Unsigned>(self, rhs: Rhs) -> Self::Add<Rhs> {
         rhs
     }
 
     /// `0 + Rhs + Carry = Rhs + Carry`
     type AddCarry<Rhs: Unsigned, Carry: Bit> = Carry::IfUnsigned<Rhs::Successor, Rhs>;
+    #[inline]
     fn add_carry<Rhs: Unsigned, Carry: Bit>(self, rhs: Rhs) -> Self::AddCarry<Rhs, Carry> {
         Carry::if_unsigned(rhs.successor(), rhs)
     }
     /// `0 + Rhs = Rhs`
     type AddUInt<Ur: Unsigned, Br: Bit> = UInt<Ur, Br>;
+    #[inline]
     fn add_uint<Ur: Unsigned, Br: Bit>(self, ur: Ur) -> Self::AddUInt<Ur, Br> {
         UInt {
             msb: ur,
@@ -266,44 +272,52 @@ impl<U: Unsigned, B: Bit> Unsigned for UInt<U, B> {
     }
 
     type GetMSB = U;
+    #[inline]
     fn get_msb(self) -> Self::GetMSB {
         self.msb
     }
 
     type GetLSB = B;
+    #[inline]
     fn get_lsb(self) -> Self::GetLSB {
         self.lsb
     }
 
     /// `Self + 1`
     type Successor = B::IfUnsigned<UInt<U::Successor, B0>, UInt<U, B1>>;
+    #[inline]
     fn successor(self) -> Self::Successor {
-        todo!()
-        // if B::to_bool() {
-        //     UInt {
-        //         msb: todo!(),
-        //         lsb: todo!(),
-        //     }
-        // } else {
-        // }
+        B::if_unsigned(
+            UInt {
+                msb: self.get_msb().successor(),
+                lsb: B0,
+            },
+            UInt {
+                msb: self.get_msb(),
+                lsb: B1,
+            },
+        )
     }
 
     /// `Self + Rhs = Rhs`
     type Add<Rhs: Unsigned> = Rhs::AddUInt<U, B>;
+    #[inline]
     fn add<Rhs: Unsigned>(self, rhs: Rhs) -> Self::Add<Rhs> {
         rhs.add_uint(self.get_msb())
     }
 
     /// `Self + Rhs + Carry = Self + (if Carry { Rhs + 1 } else { Rhs })`
     type AddCarry<Rhs: Unsigned, Carry: Bit> = Self::Add<Carry::IfUnsigned<Rhs::Successor, Rhs>>;
+    #[inline]
     fn add_carry<Rhs: Unsigned, Carry: Bit>(self, rhs: Rhs) -> Self::AddCarry<Rhs, Carry> {
         <Self as Unsigned>::add(self, Carry::if_unsigned(rhs.successor(), rhs))
     }
     /// `UInt<U, B> + UInt<Ur, Br> = UInt<U + Ur + (B & Br), B ^ Br>`
     type AddUInt<Ur: Unsigned, Br: Bit> = UInt<U::AddCarry<Ur, B::BitAnd<Br>>, B::BitXor<Br>>;
+    #[inline]
     fn add_uint<Ur: Unsigned, Br: Bit>(self, ur: Ur) -> Self::AddUInt<Ur, Br> {
         UInt {
-            msb: U::add_carry::<_, B::BitAnd<Br>>(self.get_msb(), ur),
+            msb: U::add_carry(self.get_msb(), ur),
             lsb: B::BitXor::<Br>::new(),
         }
     }
@@ -501,6 +515,14 @@ impl<U: Unsigned> Add<U> for UTerm {
 }
 
 impl<Rhs: Unsigned, Ul: Unsigned, Bl: Bit> Add<Rhs> for UInt<Ul, Bl> {
+    type Output = <Self as Unsigned>::Add<Rhs>;
+    #[inline]
+    fn add(self, rhs: Rhs) -> Self::Output {
+        <Self as Unsigned>::add(self, rhs)
+    }
+}
+
+impl<Rhs: Unsigned, U: Unsigned> TypeAdd<Rhs> for U {
     type Output = <Self as Unsigned>::Add<Rhs>;
     #[inline]
     fn add(self, rhs: Rhs) -> Self::Output {

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -125,6 +125,42 @@ impl Unsigned for UTerm {
     fn to_isize() -> isize {
         0
     }
+
+    type GetMSB = UTerm;
+    fn get_msb(self) -> Self::GetMSB {
+        UTerm
+    }
+
+    type GetLSB = B0;
+    fn get_lsb(self) -> Self::GetLSB {
+        B0
+    }
+
+    /// `0 + 1 = 1`
+    type Successor = UInt<UTerm, B1>;
+    fn successor(self) -> Self::Successor {
+        U1::new()
+    }
+
+    /// `0 + Rhs = Rhs`
+    type Add<Rhs: Unsigned> = Rhs;
+    fn add<Rhs: Unsigned>(self, rhs: Rhs) -> Self::Add<Rhs> {
+        rhs
+    }
+
+    /// `0 + Rhs + Carry = Rhs + Carry`
+    type AddCarry<Rhs: Unsigned, Carry: Bit> = Carry::IfUnsigned<Rhs::Successor, Rhs>;
+    fn add_carry<Rhs: Unsigned, Carry: Bit>(self, rhs: Rhs) -> Self::AddCarry<Rhs, Carry> {
+        Carry::if_unsigned(rhs.successor(), rhs)
+    }
+    /// `0 + Rhs = Rhs`
+    type AddUInt<Ur: Unsigned, Br: Bit> = UInt<Ur, Br>;
+    fn add_uint<Ur: Unsigned, Br: Bit>(self, ur: Ur) -> Self::AddUInt<Ur, Br> {
+        UInt {
+            msb: ur,
+            lsb: Br::new(),
+        }
+    }
 }
 
 /// `UInt` is defined recursively, where `B` is the least significant bit and `U` is the rest
@@ -227,6 +263,49 @@ impl<U: Unsigned, B: Bit> Unsigned for UInt<U, B> {
     #[inline]
     fn to_isize() -> isize {
         B::to_u8() as isize | U::to_isize() << 1
+    }
+
+    type GetMSB = U;
+    fn get_msb(self) -> Self::GetMSB {
+        self.msb
+    }
+
+    type GetLSB = B;
+    fn get_lsb(self) -> Self::GetLSB {
+        self.lsb
+    }
+
+    /// `Self + 1`
+    type Successor = B::IfUnsigned<UInt<U::Successor, B0>, UInt<U, B1>>;
+    fn successor(self) -> Self::Successor {
+        todo!()
+        // if B::to_bool() {
+        //     UInt {
+        //         msb: todo!(),
+        //         lsb: todo!(),
+        //     }
+        // } else {
+        // }
+    }
+
+    /// `Self + Rhs = Rhs`
+    type Add<Rhs: Unsigned> = Rhs::AddUInt<U, B>;
+    fn add<Rhs: Unsigned>(self, rhs: Rhs) -> Self::Add<Rhs> {
+        rhs.add_uint(self.get_msb())
+    }
+
+    /// `Self + Rhs + Carry = Self + (if Carry { Rhs + 1 } else { Rhs })`
+    type AddCarry<Rhs: Unsigned, Carry: Bit> = Self::Add<Carry::IfUnsigned<Rhs::Successor, Rhs>>;
+    fn add_carry<Rhs: Unsigned, Carry: Bit>(self, rhs: Rhs) -> Self::AddCarry<Rhs, Carry> {
+        <Self as Unsigned>::add(self, Carry::if_unsigned(rhs.successor(), rhs))
+    }
+    /// `UInt<U, B> + UInt<Ur, Br> = UInt<U + Ur + (B & Br), B ^ Br>`
+    type AddUInt<Ur: Unsigned, Br: Bit> = UInt<U::AddCarry<Ur, B::BitAnd<Br>>, B::BitXor<Br>>;
+    fn add_uint<Ur: Unsigned, Br: Bit>(self, ur: Ur) -> Self::AddUInt<Ur, Br> {
+        UInt {
+            msb: U::add_carry::<_, B::BitAnd<Br>>(self.get_msb(), ur),
+            lsb: B::BitXor::<Br>::new(),
+        }
     }
 }
 
@@ -414,80 +493,18 @@ where
 
 /// `UTerm + U = U`
 impl<U: Unsigned> Add<U> for UTerm {
-    type Output = U;
+    type Output = <Self as Unsigned>::Add<U>;
     #[inline]
     fn add(self, rhs: U) -> Self::Output {
-        rhs
+        <Self as Unsigned>::add(self, rhs)
     }
 }
 
-/// `UInt<U, B> + UTerm = UInt<U, B>`
-impl<U: Unsigned, B: Bit> Add<UTerm> for UInt<U, B> {
-    type Output = UInt<U, B>;
+impl<Rhs: Unsigned, Ul: Unsigned, Bl: Bit> Add<Rhs> for UInt<Ul, Bl> {
+    type Output = <Self as Unsigned>::Add<Rhs>;
     #[inline]
-    fn add(self, _: UTerm) -> Self::Output {
-        UInt::new()
-    }
-}
-
-/// `UInt<Ul, B0> + UInt<Ur, B0> = UInt<Ul + Ur, B0>`
-impl<Ul: Unsigned, Ur: Unsigned> Add<UInt<Ur, B0>> for UInt<Ul, B0>
-where
-    Ul: Add<Ur>,
-{
-    type Output = UInt<Sum<Ul, Ur>, B0>;
-    #[inline]
-    fn add(self, rhs: UInt<Ur, B0>) -> Self::Output {
-        UInt {
-            msb: self.msb + rhs.msb,
-            lsb: B0,
-        }
-    }
-}
-
-/// `UInt<Ul, B0> + UInt<Ur, B1> = UInt<Ul + Ur, B1>`
-impl<Ul: Unsigned, Ur: Unsigned> Add<UInt<Ur, B1>> for UInt<Ul, B0>
-where
-    Ul: Add<Ur>,
-{
-    type Output = UInt<Sum<Ul, Ur>, B1>;
-    #[inline]
-    fn add(self, rhs: UInt<Ur, B1>) -> Self::Output {
-        UInt {
-            msb: self.msb + rhs.msb,
-            lsb: B1,
-        }
-    }
-}
-
-/// `UInt<Ul, B1> + UInt<Ur, B0> = UInt<Ul + Ur, B1>`
-impl<Ul: Unsigned, Ur: Unsigned> Add<UInt<Ur, B0>> for UInt<Ul, B1>
-where
-    Ul: Add<Ur>,
-{
-    type Output = UInt<Sum<Ul, Ur>, B1>;
-    #[inline]
-    fn add(self, rhs: UInt<Ur, B0>) -> Self::Output {
-        UInt {
-            msb: self.msb + rhs.msb,
-            lsb: B1,
-        }
-    }
-}
-
-/// `UInt<Ul, B1> + UInt<Ur, B1> = UInt<(Ul + Ur) + B1, B0>`
-impl<Ul: Unsigned, Ur: Unsigned> Add<UInt<Ur, B1>> for UInt<Ul, B1>
-where
-    Ul: Add<Ur>,
-    Sum<Ul, Ur>: Add<B1>,
-{
-    type Output = UInt<Add1<Sum<Ul, Ur>>, B0>;
-    #[inline]
-    fn add(self, rhs: UInt<Ur, B1>) -> Self::Output {
-        UInt {
-            msb: self.msb + rhs.msb + B1,
-            lsb: B0,
-        }
+    fn add(self, rhs: Rhs) -> Self::Output {
+        <Self as Unsigned>::add(self, rhs)
     }
 }
 

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -36,8 +36,8 @@ use crate::{
         PrivateSubOut, PrivateXor, PrivateXorOut, Trim, TrimOut,
     },
     Add1, Cmp, Double, Equal, Gcd, Gcf, GrEq, Greater, IsGreaterOrEqual, Len, Length, Less, Log2,
-    Logarithm2, Maximum, Minimum, NonZero, Ord, Pow, Prod, Shleft, Shright, Sqrt, Square,
-    SquareRoot, Sub1, Sum, ToInt, TypeAdd, Zero,
+    Logarithm2, Maximum, Minimum, NonZero, Ord, Pow, Prod, Shleft, Sqrt, Square, SquareRoot, Sub1,
+    Sum, ToInt, TypeAdd, TypeShr, Zero,
 };
 use core::ops::{Add, BitAnd, BitOr, BitXor, Mul, Shl, Shr, Sub};
 
@@ -145,6 +145,26 @@ impl Unsigned for UTerm {
         U1::new()
     }
 
+    /// `0 - 1`,  SubstractOverflowError
+    type Predecessor = UInt<UTerm, B1>;
+    #[inline]
+    fn predecessor(self) -> Self::Predecessor {
+        U1::new()
+    }
+
+    /// `0` is already trimmed.
+    type Trimmed = UTerm;
+    #[inline]
+    fn trimmed(self) -> Self::Trimmed {
+        UTerm
+    }
+
+    type IsZero = B1;
+    #[inline]
+    fn is_zero(self) -> Self::IsZero {
+        B1
+    }
+
     /// `0 + Rhs = Rhs`
     type Add<Rhs: Unsigned> = Rhs;
     #[inline]
@@ -166,6 +186,12 @@ impl Unsigned for UTerm {
             msb: ur,
             lsb: Br::new(),
         }
+    }
+
+    type Shr<Rhs: Unsigned> = UTerm;
+    #[inline]
+    fn shr<Rhs: Unsigned>(self, _: Rhs) -> Self::Shr<Rhs> {
+        self
     }
 }
 
@@ -299,6 +325,40 @@ impl<U: Unsigned, B: Bit> Unsigned for UInt<U, B> {
         )
     }
 
+    /// `Self - 1`
+    type Predecessor = <B::IfUnsigned<UInt<U, B0>, UInt<U::Predecessor, B1>> as Unsigned>::Trimmed; // Trim the output because of leading 0.
+    #[inline]
+    fn predecessor(self) -> Self::Predecessor {
+        B::if_unsigned(
+            UInt {
+                msb: self.get_msb(),
+                lsb: B0,
+            },
+            UInt {
+                msb: self.get_msb().predecessor(),
+                lsb: B1,
+            },
+        )
+        .trimmed()
+    }
+
+    /// Remove leading 0 of `Self`.
+    type Trimmed = <<U::Trimmed as Unsigned>::IsZero as Bit>::IfUnsigned<
+        B::IfUnsigned<UInt<UTerm, B>, UTerm>,
+        UInt<U::Trimmed, B>,
+    >;
+    #[inline]
+    fn trimmed(self) -> Self::Trimmed {
+        todo!()
+    }
+
+    // Self can't be zero if trimmed.
+    type IsZero = B0;
+    #[inline]
+    fn is_zero(self) -> Self::IsZero {
+        B0
+    }
+
     /// `Self + Rhs = Rhs`
     type Add<Rhs: Unsigned> = Rhs::AddUInt<U, B>;
     #[inline]
@@ -320,6 +380,12 @@ impl<U: Unsigned, B: Bit> Unsigned for UInt<U, B> {
             msb: U::add_carry(self.get_msb(), ur),
             lsb: B::BitXor::<Br>::new(),
         }
+    }
+
+    type Shr<Rhs: Unsigned> = <Rhs::IsZero as Bit>::IfUnsigned<Self, U::Shr<Rhs::Predecessor>>;
+    #[inline]
+    fn shr<Rhs: Unsigned>(self, rhs: Rhs) -> Self::Shr<Rhs> {
+        Rhs::IsZero::if_unsigned(self, self.get_msb().shr(rhs.predecessor()))
     }
 }
 
@@ -345,13 +411,11 @@ impl Len for UTerm {
 impl<U: Unsigned, B: Bit> Len for UInt<U, B>
 where
     U: Len,
-    Length<U>: Add<B1>,
-    Add1<Length<U>>: Unsigned,
 {
-    type Output = Add1<Length<U>>;
+    type Output = <Length<U> as Unsigned>::Successor;
     #[inline]
     fn len(&self) -> Self::Output {
-        self.msb.len() + B1
+        self.msb.len().successor()
     }
 }
 
@@ -971,16 +1035,19 @@ impl<U: Unsigned, B: Bit> Shr<B1> for UInt<U, B> {
 }
 
 /// Shifting right `UInt` by `UInt`: `UInt(U, B) >> Y` = `U >> (Y - 1)`
-impl<U: Unsigned, B: Bit, Ur: Unsigned, Br: Bit> Shr<UInt<Ur, Br>> for UInt<U, B>
-where
-    UInt<Ur, Br>: Sub<B1>,
-    U: Shr<Sub1<UInt<Ur, Br>>>,
-{
-    type Output = Shright<U, Sub1<UInt<Ur, Br>>>;
+impl<U: Unsigned, B: Bit, Ur: Unsigned, Br: Bit> Shr<UInt<Ur, Br>> for UInt<U, B> {
+    type Output = <Self as Unsigned>::Shr<UInt<Ur, Br>>;
     #[inline]
     fn shr(self, rhs: UInt<Ur, Br>) -> Self::Output {
-        #[allow(clippy::suspicious_arithmetic_impl)]
-        self.msb.shr(rhs - B1)
+        <Self as Unsigned>::shr(self, rhs)
+    }
+}
+
+impl<Rhs: Unsigned, U: Unsigned> TypeShr<Rhs> for U {
+    type Output = <Self as Unsigned>::Shr<Rhs>;
+    #[inline]
+    fn shr(self, rhs: Rhs) -> Self::Output {
+        <Self as Unsigned>::shr(self, rhs)
     }
 }
 

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -31,13 +31,12 @@ use crate::{
     bit::{Bit, B0, B1},
     consts::{U0, U1},
     private::{
-        BitDiff, BitDiffOut, Internal, InternalMarker, PrivateLogarithm2, PrivatePow,
-        PrivatePowOut, PrivateSquareRoot, PrivateSub, PrivateSubOut, Trim, TrimOut,
+        BitDiff, BitDiffOut, Internal, InternalMarker, PrivateLogarithm2, PrivateSquareRoot,
+        PrivateSub, PrivateSubOut, Trim, TrimOut,
     },
     Add1, Cmp, Double, Equal, Gcd, Gcf, GrEq, Greater, IntoUnsigned, IsGreaterOrEqual, Len, Length,
-    Less, Log2, Logarithm2, Maximum, Minimum, NonZero, Ord, Pow, Prod, Shleft, Sqrt, Square,
-    SquareRoot, Sub1, Sum, ToInt, TypeAdd, TypeBitAnd, TypeBitOr, TypeBitXor, TypeMul, TypeShl,
-    TypeShr, Zero,
+    Less, Log2, Logarithm2, Maximum, Minimum, NonZero, Ord, Pow, Shleft, Sqrt, Square, SquareRoot,
+    Sub1, Sum, ToInt, TypeAdd, TypeBitAnd, TypeBitOr, TypeBitXor, TypeMul, TypeShl, TypeShr, Zero,
 };
 use core::ops::{Add, BitAnd, BitOr, BitXor, Mul, Shl, Shr, Sub};
 
@@ -146,10 +145,10 @@ impl Unsigned for UTerm {
     }
 
     /// `0 - 1`,  SubstractOverflowError
-    type Predecessor = UInt<UTerm, B1>;
+    type Predecessor = UTerm; // TODO handle errors
     #[inline]
     fn predecessor(self) -> Self::Predecessor {
-        U1::new()
+        unreachable!()
     }
 
     /// `0` is already trimmed.
@@ -163,6 +162,18 @@ impl Unsigned for UTerm {
     #[inline]
     fn is_zero(self) -> Self::IsZero {
         B1
+    }
+
+    type IsEven = B1;
+    #[inline]
+    fn is_even(self) -> Self::IsEven {
+        B1
+    }
+
+    type IsOdd = B0;
+    #[inline]
+    fn is_odd(self) -> Self::IsOdd {
+        B0
     }
 
     /// `min(0, Rhs) = 0`
@@ -219,6 +230,19 @@ impl Unsigned for UTerm {
     #[allow(missing_docs)]
     fn mul<Rhs: Unsigned>(self, _: Rhs) -> Self::Mul<Rhs> {
         UTerm
+    }
+
+    /// `0 ** Rhs = if Rhs == 0 { 1 } else { 0 }`
+    type Pow<Rhs: Unsigned> = <Rhs::IsZero as Bit>::IfUnsigned<U1, U0>;
+    #[inline]
+    fn powi<Rhs: Unsigned>(self, _: Rhs) -> Self::Pow<Rhs> {
+        Rhs::IsZero::if_unsigned(U1::new(), UTerm)
+    }
+    /// `Lhs ** 0 = 1`
+    type PowSelf<Lhs: Unsigned> = U1;
+    #[inline]
+    fn powi_self<Lhs: Unsigned>(self, _: Lhs) -> Self::PowSelf<Lhs> {
+        U1::new()
     }
 
     /// `0 >> Rhs = 0`
@@ -412,6 +436,18 @@ impl<U: Unsigned, B: Bit> Unsigned for UInt<U, B> {
         B0
     }
 
+    type IsEven = B::Not;
+    #[inline]
+    fn is_even(self) -> Self::IsEven {
+        B::Not::new()
+    }
+
+    type IsOdd = B;
+    #[inline]
+    fn is_odd(self) -> Self::IsOdd {
+        B::new()
+    }
+
     type Min<Rhs: Unsigned> = <<Self::Cmp<Rhs> as Ord>::IsLess as Bit>::IfUnsigned<Self, Rhs>;
     #[inline]
     fn min<Rhs: Unsigned>(self, rhs: Rhs) -> Self::Min<Rhs> {
@@ -480,6 +516,26 @@ impl<U: Unsigned, B: Bit> Unsigned for UInt<U, B> {
     #[allow(missing_docs)]
     fn mul<Rhs: Unsigned>(self, rhs: Rhs) -> Self::Mul<Rhs> {
         Unsigned::add(B::if_unsigned(rhs, UTerm), self.get_msb().mul(rhs.double()))
+    }
+
+    type Pow<Rhs: Unsigned> = Rhs::PowSelf<Self>;
+    #[inline]
+    fn powi<Rhs: Unsigned>(self, rhs: Rhs) -> Self::Pow<Rhs> {
+        rhs.powi_self(self)
+    }
+
+    /// Lhs ** Self = if Rhs % 2 = 0 {
+    ///    (Lhs * Lhs) ** (Self / 2))
+    /// } else {
+    ///    ((Lhs * Lhs) ** (Self / 2)) * Lhs
+    /// }
+    type PowSelf<Lhs: Unsigned> = <Self::IsEven as Bit>::IfUnsigned<
+        <Lhs::Mul<Lhs> as Unsigned>::Pow<Self::Shr<U1>>,
+        Lhs::Mul<<Lhs::Mul<Lhs> as Unsigned>::Pow<Self::Shr<U1>>>,
+    >;
+    #[inline]
+    fn powi_self<Lhs: Unsigned>(self, _: Lhs) -> Self::PowSelf<Lhs> {
+        todo!()
     }
 
     /// `UInt<U, B> >> Rhs = if Rhs == 0 { Self } else { U >> (Rhs - 1) }`
@@ -934,65 +990,8 @@ where
 // ---------------------------------------------------------------------------------------
 // Powers of unsigned integers
 
-/// X^N
-impl<X: Unsigned, N: Unsigned> Pow<N> for X
-where
-    X: PrivatePow<U1, N>,
-{
-    type Output = PrivatePowOut<X, U1, N>;
-    #[inline]
-    fn powi(self, n: N) -> Self::Output {
-        self.private_pow(U1::new(), n)
-    }
-}
-
-impl<Y: Unsigned, X: Unsigned> PrivatePow<Y, U0> for X {
-    type Output = Y;
-
-    #[inline]
-    fn private_pow(self, y: Y, _: U0) -> Self::Output {
-        y
-    }
-}
-
-impl<Y: Unsigned, X: Unsigned> PrivatePow<Y, U1> for X
-where
-    X: Mul<Y>,
-{
-    type Output = Prod<X, Y>;
-
-    #[inline]
-    fn private_pow(self, y: Y, _: U1) -> Self::Output {
-        self * y
-    }
-}
-
-/// N is even
-impl<Y: Unsigned, U: Unsigned, B: Bit, X: Unsigned> PrivatePow<Y, UInt<UInt<U, B>, B0>> for X
-where
-    X: Mul,
-    Square<X>: PrivatePow<Y, UInt<U, B>>,
-{
-    type Output = PrivatePowOut<Square<X>, Y, UInt<U, B>>;
-
-    #[inline]
-    fn private_pow(self, y: Y, n: UInt<UInt<U, B>, B0>) -> Self::Output {
-        (self * self).private_pow(y, n.msb)
-    }
-}
-
-/// N is odd
-impl<Y: Unsigned, U: Unsigned, B: Bit, X: Unsigned> PrivatePow<Y, UInt<UInt<U, B>, B1>> for X
-where
-    X: Mul + Mul<Y>,
-    Square<X>: PrivatePow<Prod<X, Y>, UInt<U, B>>,
-{
-    type Output = PrivatePowOut<Square<X>, Prod<X, Y>, UInt<U, B>>;
-
-    #[inline]
-    fn private_pow(self, y: Y, n: UInt<UInt<U, B>, B1>) -> Self::Output {
-        (self * self).private_pow(self * y, n.msb)
-    }
+delegate_unsigned_binary_impls! {
+    Pow, powi,
 }
 
 //------------------------------------------

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -31,13 +31,13 @@ use crate::{
     bit::{Bit, B0, B1},
     consts::{U0, U1},
     private::{
-        BitDiff, BitDiffOut, Internal, InternalMarker, PrivateAnd, PrivateAndOut, PrivateCmp,
-        PrivateCmpOut, PrivateLogarithm2, PrivatePow, PrivatePowOut, PrivateSquareRoot, PrivateSub,
-        PrivateSubOut, PrivateXor, PrivateXorOut, Trim, TrimOut,
+        BitDiff, BitDiffOut, Internal, InternalMarker, PrivateLogarithm2, PrivatePow,
+        PrivatePowOut, PrivateSquareRoot, PrivateSub, PrivateSubOut, Trim, TrimOut,
     },
-    Add1, Cmp, Double, Equal, Gcd, Gcf, GrEq, Greater, IsGreaterOrEqual, Len, Length, Less, Log2,
-    Logarithm2, Maximum, Minimum, NonZero, Ord, Pow, Prod, Shleft, Sqrt, Square, SquareRoot, Sub1,
-    Sum, ToInt, TypeAdd, TypeShr, Zero,
+    Add1, Cmp, Double, Equal, Gcd, Gcf, GrEq, Greater, IntoUnsigned, IsGreaterOrEqual, Len, Length,
+    Less, Log2, Logarithm2, Maximum, Minimum, NonZero, Ord, Pow, Prod, Shleft, Sqrt, Square,
+    SquareRoot, Sub1, Sum, ToInt, TypeAdd, TypeBitAnd, TypeBitOr, TypeBitXor, TypeMul, TypeShl,
+    TypeShr, Zero,
 };
 use core::ops::{Add, BitAnd, BitOr, BitXor, Mul, Shl, Shr, Sub};
 
@@ -165,6 +165,41 @@ impl Unsigned for UTerm {
         B1
     }
 
+    /// `min(0, Rhs) = 0`
+    type Min<Rhs: Unsigned> = UTerm;
+    #[inline]
+    fn min<Rhs: Unsigned>(self, _: Rhs) -> Self::Min<Rhs> {
+        UTerm
+    }
+
+    /// `max(0, Rhs) = Rhs`
+    type Max<Rhs: Unsigned> = Rhs;
+    #[inline]
+    fn max<Rhs: Unsigned>(self, rhs: Rhs) -> Self::Max<Rhs> {
+        rhs
+    }
+
+    /// `0 & Rhs = 0`
+    type BitAnd<Rhs: Unsigned> = UTerm;
+    #[inline]
+    fn bitand<Rhs: Unsigned>(self, _: Rhs) -> Self::BitAnd<Rhs> {
+        UTerm
+    }
+
+    /// `0 | Rhs = Rhs`
+    type BitOr<Rhs: Unsigned> = Rhs;
+    #[inline]
+    fn bitor<Rhs: Unsigned>(self, rhs: Rhs) -> Self::BitOr<Rhs> {
+        rhs
+    }
+
+    /// `0 ^ Rhs = Rhs`
+    type BitXor<Rhs: Unsigned> = Rhs;
+    #[inline]
+    fn bitxor<Rhs: Unsigned>(self, rhs: Rhs) -> Self::BitXor<Rhs> {
+        rhs
+    }
+
     /// `0 + Rhs = Rhs`
     type Add<Rhs: Unsigned> = Rhs;
     #[inline]
@@ -178,20 +213,38 @@ impl Unsigned for UTerm {
     fn add_carry<Rhs: Unsigned, Carry: Bit>(self, rhs: Rhs) -> Self::AddCarry<Rhs, Carry> {
         Carry::if_unsigned(rhs.successor(), rhs)
     }
-    /// `0 + Rhs = Rhs`
-    type AddUInt<Ur: Unsigned, Br: Bit> = UInt<Ur, Br>;
-    #[inline]
-    fn add_uint<Ur: Unsigned, Br: Bit>(self, ur: Ur) -> Self::AddUInt<Ur, Br> {
-        UInt {
-            msb: ur,
-            lsb: Br::new(),
-        }
+
+    /// `0 * Rhs = 0`
+    type Mul<Rhs: Unsigned> = UTerm;
+    #[allow(missing_docs)]
+    fn mul<Rhs: Unsigned>(self, _: Rhs) -> Self::Mul<Rhs> {
+        UTerm
     }
 
+    /// `0 >> Rhs = 0`
     type Shr<Rhs: Unsigned> = UTerm;
     #[inline]
     fn shr<Rhs: Unsigned>(self, _: Rhs) -> Self::Shr<Rhs> {
         self
+    }
+
+    /// `0 << Rhs = 0`
+    type Shl<Rhs: Unsigned> = UTerm;
+    #[inline]
+    fn shl<Rhs: Unsigned>(self, _: Rhs) -> Self::Shl<Rhs> {
+        self
+    }
+
+    type Double = UTerm;
+    #[inline]
+    fn double(self) -> Self::Double {
+        self
+    }
+
+    type Cmp<Rhs: Unsigned> = <Rhs::IsZero as Bit>::IfOrd<Equal, Less>;
+    #[inline]
+    fn compare<Rhs: Unsigned>(self, _: Rhs) -> Self::Cmp<Rhs> {
+        Rhs::IsZero::if_ord(Equal, Less)
     }
 }
 
@@ -326,7 +379,7 @@ impl<U: Unsigned, B: Bit> Unsigned for UInt<U, B> {
     }
 
     /// `Self - 1`
-    type Predecessor = <B::IfUnsigned<UInt<U, B0>, UInt<U::Predecessor, B1>> as Unsigned>::Trimmed; // Trim the output because of leading 0.
+    type Predecessor = <B::IfUnsigned<UInt<U, B0>, UInt<U::Predecessor, B1>> as Unsigned>::Trimmed; // Trim the output because of potential leadings 0.
     #[inline]
     fn predecessor(self) -> Self::Predecessor {
         B::if_unsigned(
@@ -359,33 +412,103 @@ impl<U: Unsigned, B: Bit> Unsigned for UInt<U, B> {
         B0
     }
 
-    /// `Self + Rhs = Rhs`
-    type Add<Rhs: Unsigned> = Rhs::AddUInt<U, B>;
+    type Min<Rhs: Unsigned> = <<Self::Cmp<Rhs> as Ord>::IsLess as Bit>::IfUnsigned<Self, Rhs>;
     #[inline]
-    fn add<Rhs: Unsigned>(self, rhs: Rhs) -> Self::Add<Rhs> {
-        rhs.add_uint(self.get_msb())
+    fn min<Rhs: Unsigned>(self, rhs: Rhs) -> Self::Min<Rhs> {
+        <Self::Cmp<Rhs> as Ord>::IsLess::if_unsigned(self, rhs)
     }
 
+    type Max<Rhs: Unsigned> = <<Self::Cmp<Rhs> as Ord>::IsLess as Bit>::IfUnsigned<Rhs, Self>;
+    #[inline]
+    fn max<Rhs: Unsigned>(self, rhs: Rhs) -> Self::Max<Rhs> {
+        <Self::Cmp<Rhs> as Ord>::IsLess::if_unsigned(rhs, self)
+    }
+
+    /// `UInt<U, B> & UInt<Ur, Br> = UInt<U & Ur, B & Br>`
+    type BitAnd<Rhs: Unsigned> =
+        <UInt<U::BitAnd<Rhs::GetMSB>, B::BitAnd<Rhs::GetLSB>> as Unsigned>::Trimmed; // Trim the output because of potential leadings 0.
+    #[inline]
+    fn bitand<Rhs: Unsigned>(self, rhs: Rhs) -> Self::BitAnd<Rhs> {
+        UInt {
+            msb: self.get_msb().bitand(rhs.get_msb()),
+            lsb: B::BitAnd::<Rhs::GetLSB>::new(),
+        }
+        .trimmed()
+    }
+
+    /// `UInt<U, B> | UInt<Ur, Br> = UInt<U | Ur, B | Br>`
+    type BitOr<Rhs: Unsigned> = UInt<U::BitOr<Rhs::GetMSB>, B::BitOr<Rhs::GetLSB>>;
+    #[inline]
+    fn bitor<Rhs: Unsigned>(self, rhs: Rhs) -> Self::BitOr<Rhs> {
+        UInt {
+            msb: self.get_msb().bitor(rhs.get_msb()),
+            lsb: B::BitOr::<Rhs::GetLSB>::new(),
+        }
+    }
+
+    /// `UInt<U, B> ^ UInt<Ur, Br> = UInt<U ^ Ur, B ^ Br>`
+    type BitXor<Rhs: Unsigned> =
+        <UInt<U::BitXor<Rhs::GetMSB>, B::BitXor<Rhs::GetLSB>> as Unsigned>::Trimmed; // Trim the output because of potential leadings 0.
+    #[inline]
+    fn bitxor<Rhs: Unsigned>(self, rhs: Rhs) -> Self::BitXor<Rhs> {
+        UInt {
+            msb: self.get_msb().bitxor(rhs.get_msb()),
+            lsb: B::BitXor::<Rhs::GetLSB>::new(),
+        }
+        .trimmed()
+    }
+
+    /// `UInt<U, B> + UInt<Ur, Br> = UInt<U + Ur + (B & Br), B ^ Br>`
+    type Add<Rhs: Unsigned> =
+        UInt<U::AddCarry<Rhs::GetMSB, B::BitAnd<Rhs::GetLSB>>, B::BitXor<Rhs::GetLSB>>;
+    #[inline]
+    fn add<Rhs: Unsigned>(self, rhs: Rhs) -> Self::Add<Rhs> {
+        UInt {
+            msb: U::add_carry(self.get_msb(), rhs.get_msb()),
+            lsb: B::BitXor::<Rhs::GetLSB>::new(),
+        }
+    }
     /// `Self + Rhs + Carry = Self + (if Carry { Rhs + 1 } else { Rhs })`
     type AddCarry<Rhs: Unsigned, Carry: Bit> = Self::Add<Carry::IfUnsigned<Rhs::Successor, Rhs>>;
     #[inline]
     fn add_carry<Rhs: Unsigned, Carry: Bit>(self, rhs: Rhs) -> Self::AddCarry<Rhs, Carry> {
-        <Self as Unsigned>::add(self, Carry::if_unsigned(rhs.successor(), rhs))
-    }
-    /// `UInt<U, B> + UInt<Ur, Br> = UInt<U + Ur + (B & Br), B ^ Br>`
-    type AddUInt<Ur: Unsigned, Br: Bit> = UInt<U::AddCarry<Ur, B::BitAnd<Br>>, B::BitXor<Br>>;
-    #[inline]
-    fn add_uint<Ur: Unsigned, Br: Bit>(self, ur: Ur) -> Self::AddUInt<Ur, Br> {
-        UInt {
-            msb: U::add_carry(self.get_msb(), ur),
-            lsb: B::BitXor::<Br>::new(),
-        }
+        Unsigned::add(self, Carry::if_unsigned(rhs.successor(), rhs))
     }
 
+    /// `UInt<U, B> * Rhs = if B { Rhs } else { 0 } + U * (Rhs << 1)`
+    type Mul<Rhs: Unsigned> = <B::IfUnsigned<Rhs, UTerm> as Unsigned>::Add<U::Mul<Rhs::Double>>;
+    #[allow(missing_docs)]
+    fn mul<Rhs: Unsigned>(self, rhs: Rhs) -> Self::Mul<Rhs> {
+        Unsigned::add(B::if_unsigned(rhs, UTerm), self.get_msb().mul(rhs.double()))
+    }
+
+    /// `UInt<U, B> >> Rhs = if Rhs == 0 { Self } else { U >> (Rhs - 1) }`
     type Shr<Rhs: Unsigned> = <Rhs::IsZero as Bit>::IfUnsigned<Self, U::Shr<Rhs::Predecessor>>;
     #[inline]
     fn shr<Rhs: Unsigned>(self, rhs: Rhs) -> Self::Shr<Rhs> {
         Rhs::IsZero::if_unsigned(self, self.get_msb().shr(rhs.predecessor()))
+    }
+
+    /// `Self << Rhs = if Rhs == 0 { Self } else { UInt<Self, B0> << (Rhs - 1) }`
+    /// The logic is implemented on the `Bit` trait to avoid overflow when the compiler checks types.
+    type Shl<Rhs: Unsigned> = <Rhs::IsZero as Bit>::SelectShlUnsigned<Self, Rhs>;
+    #[inline]
+    fn shl<Rhs: Unsigned>(self, rhs: Rhs) -> Self::Shl<Rhs> {
+        <Rhs::IsZero as Bit>::select_shl_unsigned(self, rhs)
+    }
+
+    /// `Self << 1 = UInt<Self, B0>`
+    type Double = UInt<Self, B0>;
+    #[inline]
+    fn double(self) -> Self::Double {
+        UInt { msb: self, lsb: B0 }
+    }
+
+    /// Compare msb, then if they are equal compare lsb.
+    type Cmp<Rhs: Unsigned> = <U::Cmp<Rhs::GetMSB> as Ord>::Then<B::Cmp<Rhs::GetLSB>>;
+    #[allow(missing_docs)]
+    fn compare<Rhs: Unsigned>(self, _: Rhs) -> Self::Cmp<Rhs> {
+        Self::Cmp::<Rhs>::new()
     }
 }
 
@@ -514,84 +637,60 @@ mod fmt_tests {
     }
 }
 
+macro_rules! delegate_unsigned_binary_impls {
+    // `type` is the rust operation trait name, `custom_type` is the custom trait name associated with the operation,
+    // and fn_name the name of the function in this trait
+    ($($type:ident, $custom_type:ident, $fn_name:ident,)*) => {
+        $(
+            // Implementation for UTerm
+            impl<Rhs: IntoUnsigned> $type<Rhs> for UTerm {
+                // Delegate the implementation
+                type Output = <Self as Unsigned>::$type<Rhs::IntoUnsigned>;
+                #[inline]
+                fn $fn_name(self, rhs: Rhs) -> Self::Output {
+                    <Self as Unsigned>::$fn_name(self, rhs.into_unsigned())
+                }
+            }
+            // Implementation for UInt<U, B>
+            impl<U: Unsigned, B: Bit, Rhs: IntoUnsigned> $type<Rhs> for UInt<U, B> {
+                // Delegate the implementation
+                type Output = <Self as Unsigned>::$type<Rhs::IntoUnsigned>;
+                #[inline]
+                fn $fn_name(self, rhs: Rhs) -> Self::Output {
+                    <Self as Unsigned>::$fn_name(self, rhs.into_unsigned())
+                }
+            }
+            // Implementation of custom trait
+            impl<U: Unsigned, Rhs: IntoUnsigned> $custom_type<Rhs> for U {
+                // Delegate the implementation
+                type Output = <Self as Unsigned>::$type<Rhs::IntoUnsigned>;
+                #[inline]
+                fn $fn_name(self, rhs: Rhs) -> Self::Output {
+                    <Self as Unsigned>::$fn_name(self, rhs.into_unsigned())
+                }
+            }
+        )*
+    };
+    ($($custom_type:ident, $fn_name:ident,)*) => {
+        $(
+            // Implementation of custom trait
+            impl<U: Unsigned, Rhs: IntoUnsigned> $custom_type<Rhs> for U {
+                // Delegate the implementation
+                type Output = <Self as Unsigned>::$custom_type<Rhs::IntoUnsigned>;
+                #[inline]
+                fn $fn_name(self, rhs: Rhs) -> Self::Output {
+                    <Self as Unsigned>::$fn_name(self, rhs.into_unsigned())
+                }
+            }
+        )*
+    };
+}
+
 // ---------------------------------------------------------------------------------------
 // Adding bits to unsigned integers
 
-/// `UTerm + B0 = UTerm`
-impl Add<B0> for UTerm {
-    type Output = UTerm;
-    #[inline]
-    fn add(self, _: B0) -> Self::Output {
-        UTerm
-    }
-}
-
-/// `U + B0 = U`
-impl<U: Unsigned, B: Bit> Add<B0> for UInt<U, B> {
-    type Output = UInt<U, B>;
-    #[inline]
-    fn add(self, _: B0) -> Self::Output {
-        UInt::new()
-    }
-}
-
-/// `UTerm + B1 = UInt<UTerm, B1>`
-impl Add<B1> for UTerm {
-    type Output = UInt<UTerm, B1>;
-    #[inline]
-    fn add(self, _: B1) -> Self::Output {
-        UInt::new()
-    }
-}
-
-/// `UInt<U, B0> + B1 = UInt<U + B1>`
-impl<U: Unsigned> Add<B1> for UInt<U, B0> {
-    type Output = UInt<U, B1>;
-    #[inline]
-    fn add(self, _: B1) -> Self::Output {
-        UInt::new()
-    }
-}
-
-/// `UInt<U, B1> + B1 = UInt<U + B1, B0>`
-impl<U: Unsigned> Add<B1> for UInt<U, B1>
-where
-    U: Add<B1>,
-    Add1<U>: Unsigned,
-{
-    type Output = UInt<Add1<U>, B0>;
-    #[inline]
-    fn add(self, _: B1) -> Self::Output {
-        UInt::new()
-    }
-}
-
-// ---------------------------------------------------------------------------------------
-// Adding unsigned integers
-
-/// `UTerm + U = U`
-impl<U: Unsigned> Add<U> for UTerm {
-    type Output = <Self as Unsigned>::Add<U>;
-    #[inline]
-    fn add(self, rhs: U) -> Self::Output {
-        <Self as Unsigned>::add(self, rhs)
-    }
-}
-
-impl<Rhs: Unsigned, Ul: Unsigned, Bl: Bit> Add<Rhs> for UInt<Ul, Bl> {
-    type Output = <Self as Unsigned>::Add<Rhs>;
-    #[inline]
-    fn add(self, rhs: Rhs) -> Self::Output {
-        <Self as Unsigned>::add(self, rhs)
-    }
-}
-
-impl<Rhs: Unsigned, U: Unsigned> TypeAdd<Rhs> for U {
-    type Output = <Self as Unsigned>::Add<Rhs>;
-    #[inline]
-    fn add(self, rhs: Rhs) -> Self::Output {
-        <Self as Unsigned>::add(self, rhs)
-    }
+delegate_unsigned_binary_impls! {
+    Add, TypeAdd, add,
 }
 
 // ---------------------------------------------------------------------------------------
@@ -749,546 +848,54 @@ where
 // ---------------------------------------------------------------------------------------
 // And unsigned integers
 
-/// 0 & X = 0
-impl<Ur: Unsigned> BitAnd<Ur> for UTerm {
-    type Output = UTerm;
-    #[inline]
-    fn bitand(self, _: Ur) -> Self::Output {
-        UTerm
-    }
-}
-
-/// Anding unsigned integers.
-/// We use our `PrivateAnd` operator and then `Trim` the output.
-impl<Ul: Unsigned, Bl: Bit, Ur: Unsigned> BitAnd<Ur> for UInt<Ul, Bl>
-where
-    UInt<Ul, Bl>: PrivateAnd<Ur>,
-    PrivateAndOut<UInt<Ul, Bl>, Ur>: Trim,
-{
-    type Output = TrimOut<PrivateAndOut<UInt<Ul, Bl>, Ur>>;
-    #[inline]
-    fn bitand(self, rhs: Ur) -> Self::Output {
-        self.private_and(rhs).trim()
-    }
-}
-
-/// `UTerm & X = UTerm`
-impl<U: Unsigned> PrivateAnd<U> for UTerm {
-    type Output = UTerm;
-
-    #[inline]
-    fn private_and(self, _: U) -> Self::Output {
-        UTerm
-    }
-}
-
-/// `X & UTerm = UTerm`
-impl<B: Bit, U: Unsigned> PrivateAnd<UTerm> for UInt<U, B> {
-    type Output = UTerm;
-
-    #[inline]
-    fn private_and(self, _: UTerm) -> Self::Output {
-        UTerm
-    }
-}
-
-/// `UInt<Ul, Bl> & UInt<Ur, Br> = UInt<Ul & Ur, Bl & Br>`
-impl<Ul: Unsigned, Ur: Unsigned, Bl: Bit, Br: Bit> PrivateAnd<UInt<Ur, Br>> for UInt<Ul, Bl>
-where
-    Ul: PrivateAnd<Ur>,
-{
-    type Output = UInt<PrivateAndOut<Ul, Ur>, Bl::BitAnd<Br>>;
-
-    #[inline]
-    fn private_and(self, rhs: UInt<Ur, Br>) -> Self::Output {
-        UInt {
-            msb: self.msb.private_and(rhs.msb),
-            lsb: <Bl::BitAnd<Br> as Bit>::new(),
-        }
-    }
+delegate_unsigned_binary_impls! {
+    BitAnd, TypeBitAnd, bitand,
 }
 
 // ---------------------------------------------------------------------------------------
 // Or unsigned integers
 
-/// `UTerm | X = X`
-impl<U: Unsigned> BitOr<U> for UTerm {
-    type Output = U;
-    #[inline]
-    fn bitor(self, rhs: U) -> Self::Output {
-        rhs
-    }
-}
-
-///  `X | UTerm = X`
-impl<B: Bit, U: Unsigned> BitOr<UTerm> for UInt<U, B> {
-    type Output = Self;
-    #[inline]
-    fn bitor(self, _: UTerm) -> Self::Output {
-        UInt::new()
-    }
-}
-
-/// `UInt<Ul, Bl> | UInt<Ur, Br> = UInt<Ul | Ur, Bl | Br>`
-impl<Ul: Unsigned, Ur: Unsigned, Bl: Bit, Br: Bit> BitOr<UInt<Ur, Br>> for UInt<Ul, Bl>
-where
-    Ul: BitOr<Ur>,
-{
-    type Output = UInt<<Ul as BitOr<Ur>>::Output, Bl::BitOr<Br>>;
-    #[inline]
-    fn bitor(self, rhs: UInt<Ur, Br>) -> Self::Output {
-        UInt {
-            msb: self.msb.bitor(rhs.msb),
-            lsb: <Bl::BitOr<Br> as Bit>::new(),
-        }
-    }
+delegate_unsigned_binary_impls! {
+    BitOr, TypeBitOr, bitor,
 }
 
 // ---------------------------------------------------------------------------------------
 // Xor unsigned integers
 
-/// 0 ^ X = X
-impl<Ur: Unsigned> BitXor<Ur> for UTerm {
-    type Output = Ur;
-    #[inline]
-    fn bitxor(self, rhs: Ur) -> Self::Output {
-        rhs
-    }
-}
-
-/// Xoring unsigned integers.
-/// We use our `PrivateXor` operator and then `Trim` the output.
-impl<Ul: Unsigned, Bl: Bit, Ur: Unsigned> BitXor<Ur> for UInt<Ul, Bl>
-where
-    UInt<Ul, Bl>: PrivateXor<Ur>,
-    PrivateXorOut<UInt<Ul, Bl>, Ur>: Trim,
-{
-    type Output = TrimOut<PrivateXorOut<UInt<Ul, Bl>, Ur>>;
-    #[inline]
-    fn bitxor(self, rhs: Ur) -> Self::Output {
-        self.private_xor(rhs).trim()
-    }
-}
-
-/// `UTerm ^ X = X`
-impl<U: Unsigned> PrivateXor<U> for UTerm {
-    type Output = U;
-
-    #[inline]
-    fn private_xor(self, rhs: U) -> Self::Output {
-        rhs
-    }
-}
-
-/// `X ^ UTerm = X`
-impl<B: Bit, U: Unsigned> PrivateXor<UTerm> for UInt<U, B> {
-    type Output = Self;
-
-    #[inline]
-    fn private_xor(self, _: UTerm) -> Self::Output {
-        self
-    }
-}
-
-/// `UInt<Ul, Bl> ^ UInt<Ur, Br> = UInt<Ul ^ Ur, Bl ^ Br>`
-impl<Ul: Unsigned, Ur: Unsigned, Bl: Bit, Br: Bit> PrivateXor<UInt<Ur, Br>> for UInt<Ul, Bl>
-where
-    Ul: PrivateXor<Ur>,
-{
-    type Output = UInt<PrivateXorOut<Ul, Ur>, Bl::BitXor<Br>>;
-
-    #[inline]
-    fn private_xor(self, rhs: UInt<Ur, Br>) -> Self::Output {
-        UInt {
-            msb: self.msb.private_xor(rhs.msb),
-            lsb: <Bl::BitXor<Br> as Bit>::new(),
-        }
-    }
+delegate_unsigned_binary_impls! {
+    BitXor, TypeBitXor, bitxor,
 }
 
 // ---------------------------------------------------------------------------------------
 // Shl unsigned integers
 
-/// Shifting `UTerm` by a 0 bit: `UTerm << B0 = UTerm`
-impl Shl<B0> for UTerm {
-    type Output = UTerm;
-    #[inline]
-    fn shl(self, _: B0) -> Self::Output {
-        UTerm
-    }
-}
-
-/// Shifting `UTerm` by a 1 bit: `UTerm << B1 = UTerm`
-impl Shl<B1> for UTerm {
-    type Output = UTerm;
-    #[inline]
-    fn shl(self, _: B1) -> Self::Output {
-        UTerm
-    }
-}
-
-/// Shifting left any unsigned by a zero bit: `U << B0 = U`
-impl<U: Unsigned, B: Bit> Shl<B0> for UInt<U, B> {
-    type Output = UInt<U, B>;
-    #[inline]
-    fn shl(self, _: B0) -> Self::Output {
-        UInt::new()
-    }
-}
-
-/// Shifting left a `UInt` by a one bit: `UInt<U, B> << B1 = UInt<UInt<U, B>, B0>`
-impl<U: Unsigned, B: Bit> Shl<B1> for UInt<U, B> {
-    type Output = UInt<UInt<U, B>, B0>;
-    #[inline]
-    fn shl(self, _: B1) -> Self::Output {
-        UInt::new()
-    }
-}
-
-/// Shifting left `UInt` by `UTerm`: `UInt<U, B> << UTerm = UInt<U, B>`
-impl<U: Unsigned, B: Bit> Shl<UTerm> for UInt<U, B> {
-    type Output = UInt<U, B>;
-    #[inline]
-    fn shl(self, _: UTerm) -> Self::Output {
-        UInt::new()
-    }
-}
-
-/// Shifting left `UTerm` by an unsigned integer: `UTerm << U = UTerm`
-impl<U: Unsigned> Shl<U> for UTerm {
-    type Output = UTerm;
-    #[inline]
-    fn shl(self, _: U) -> Self::Output {
-        UTerm
-    }
-}
-
-/// Shifting left `UInt` by `UInt`: `X << Y` = `UInt(X, B0) << (Y - 1)`
-impl<U: Unsigned, B: Bit, Ur: Unsigned, Br: Bit> Shl<UInt<Ur, Br>> for UInt<U, B>
-where
-    UInt<Ur, Br>: Sub<B1>,
-    UInt<UInt<U, B>, B0>: Shl<Sub1<UInt<Ur, Br>>>,
-{
-    type Output = Shleft<UInt<UInt<U, B>, B0>, Sub1<UInt<Ur, Br>>>;
-    #[inline]
-    fn shl(self, rhs: UInt<Ur, Br>) -> Self::Output {
-        #[allow(clippy::suspicious_arithmetic_impl)]
-        (UInt { msb: self, lsb: B0 }).shl(rhs - B1)
-    }
+delegate_unsigned_binary_impls! {
+    Shl, TypeShl, shl,
 }
 
 // ---------------------------------------------------------------------------------------
 // Shr unsigned integers
 
-/// Shifting right a `UTerm` by an unsigned integer: `UTerm >> U = UTerm`
-impl<U: Unsigned> Shr<U> for UTerm {
-    type Output = UTerm;
-    #[inline]
-    fn shr(self, _: U) -> Self::Output {
-        UTerm
-    }
-}
-
-/// Shifting right `UInt` by `UTerm`: `UInt<U, B> >> UTerm = UInt<U, B>`
-impl<U: Unsigned, B: Bit> Shr<UTerm> for UInt<U, B> {
-    type Output = UInt<U, B>;
-    #[inline]
-    fn shr(self, _: UTerm) -> Self::Output {
-        UInt::new()
-    }
-}
-
-/// Shifting right `UTerm` by a 0 bit: `UTerm >> B0 = UTerm`
-impl Shr<B0> for UTerm {
-    type Output = UTerm;
-    #[inline]
-    fn shr(self, _: B0) -> Self::Output {
-        UTerm
-    }
-}
-
-/// Shifting right `UTerm` by a 1 bit: `UTerm >> B1 = UTerm`
-impl Shr<B1> for UTerm {
-    type Output = UTerm;
-    #[inline]
-    fn shr(self, _: B1) -> Self::Output {
-        UTerm
-    }
-}
-
-/// Shifting right any unsigned by a zero bit: `U >> B0 = U`
-impl<U: Unsigned, B: Bit> Shr<B0> for UInt<U, B> {
-    type Output = UInt<U, B>;
-    #[inline]
-    fn shr(self, _: B0) -> Self::Output {
-        UInt::new()
-    }
-}
-
-/// Shifting right a `UInt` by a 1 bit: `UInt<U, B> >> B1 = U`
-impl<U: Unsigned, B: Bit> Shr<B1> for UInt<U, B> {
-    type Output = U;
-    #[inline]
-    fn shr(self, _: B1) -> Self::Output {
-        self.msb
-    }
-}
-
-/// Shifting right `UInt` by `UInt`: `UInt(U, B) >> Y` = `U >> (Y - 1)`
-impl<U: Unsigned, B: Bit, Ur: Unsigned, Br: Bit> Shr<UInt<Ur, Br>> for UInt<U, B> {
-    type Output = <Self as Unsigned>::Shr<UInt<Ur, Br>>;
-    #[inline]
-    fn shr(self, rhs: UInt<Ur, Br>) -> Self::Output {
-        <Self as Unsigned>::shr(self, rhs)
-    }
-}
-
-impl<Rhs: Unsigned, U: Unsigned> TypeShr<Rhs> for U {
-    type Output = <Self as Unsigned>::Shr<Rhs>;
-    #[inline]
-    fn shr(self, rhs: Rhs) -> Self::Output {
-        <Self as Unsigned>::shr(self, rhs)
-    }
+delegate_unsigned_binary_impls! {
+    Shr, TypeShr, shr,
 }
 
 // ---------------------------------------------------------------------------------------
 // Multiply unsigned integers
 
-/// `UInt * B0 = UTerm`
-impl<U: Unsigned, B: Bit> Mul<B0> for UInt<U, B> {
-    type Output = UTerm;
-    #[inline]
-    fn mul(self, _: B0) -> Self::Output {
-        UTerm
-    }
-}
-
-/// `UTerm * B0 = UTerm`
-impl Mul<B0> for UTerm {
-    type Output = UTerm;
-    #[inline]
-    fn mul(self, _: B0) -> Self::Output {
-        UTerm
-    }
-}
-
-/// `UTerm * B1 = UTerm`
-impl Mul<B1> for UTerm {
-    type Output = UTerm;
-    #[inline]
-    fn mul(self, _: B1) -> Self::Output {
-        UTerm
-    }
-}
-
-/// `UInt * B1 = UInt`
-impl<U: Unsigned, B: Bit> Mul<B1> for UInt<U, B> {
-    type Output = UInt<U, B>;
-    #[inline]
-    fn mul(self, _: B1) -> Self::Output {
-        UInt::new()
-    }
-}
-
-/// `UInt<U, B> * UTerm = UTerm`
-impl<U: Unsigned, B: Bit> Mul<UTerm> for UInt<U, B> {
-    type Output = UTerm;
-    #[inline]
-    fn mul(self, _: UTerm) -> Self::Output {
-        UTerm
-    }
-}
-
-/// `UTerm * U = UTerm`
-impl<U: Unsigned> Mul<U> for UTerm {
-    type Output = UTerm;
-    #[inline]
-    fn mul(self, _: U) -> Self::Output {
-        UTerm
-    }
-}
-
-/// `UInt<Ul, B0> * UInt<Ur, B> = UInt<(Ul * UInt<Ur, B>), B0>`
-impl<Ul: Unsigned, B: Bit, Ur: Unsigned> Mul<UInt<Ur, B>> for UInt<Ul, B0>
-where
-    Ul: Mul<UInt<Ur, B>>,
-{
-    type Output = UInt<Prod<Ul, UInt<Ur, B>>, B0>;
-    #[inline]
-    fn mul(self, rhs: UInt<Ur, B>) -> Self::Output {
-        UInt {
-            msb: self.msb * rhs,
-            lsb: B0,
-        }
-    }
-}
-
-/// `UInt<Ul, B1> * UInt<Ur, B> = UInt<(Ul * UInt<Ur, B>), B0> + UInt<Ur, B>`
-impl<Ul: Unsigned, B: Bit, Ur: Unsigned> Mul<UInt<Ur, B>> for UInt<Ul, B1>
-where
-    Ul: Mul<UInt<Ur, B>>,
-    UInt<Prod<Ul, UInt<Ur, B>>, B0>: Add<UInt<Ur, B>>,
-{
-    type Output = Sum<UInt<Prod<Ul, UInt<Ur, B>>, B0>, UInt<Ur, B>>;
-    #[inline]
-    fn mul(self, rhs: UInt<Ur, B>) -> Self::Output {
-        UInt {
-            msb: self.msb * rhs,
-            lsb: B0,
-        } + rhs
-    }
+delegate_unsigned_binary_impls! {
+    Mul, TypeMul, mul,
 }
 
 // ---------------------------------------------------------------------------------------
 // Compare unsigned integers
 
-/// Zero == Zero
-impl Cmp<UTerm> for UTerm {
-    type Output = Equal;
-
+impl<U: Unsigned, Rhs: IntoUnsigned> Cmp<Rhs> for U {
+    // Delegate the implementation
+    type Output = <Self as Unsigned>::Cmp<Rhs::IntoUnsigned>;
     #[inline]
-    fn compare<IM: InternalMarker>(&self, _: &UTerm) -> Self::Output {
-        Equal
-    }
-}
-
-/// Nonzero > Zero
-impl<U: Unsigned, B: Bit> Cmp<UTerm> for UInt<U, B> {
-    type Output = Greater;
-
-    #[inline]
-    fn compare<IM: InternalMarker>(&self, _: &UTerm) -> Self::Output {
-        Greater
-    }
-}
-
-/// Zero < Nonzero
-impl<U: Unsigned, B: Bit> Cmp<UInt<U, B>> for UTerm {
-    type Output = Less;
-
-    #[inline]
-    fn compare<IM: InternalMarker>(&self, _: &UInt<U, B>) -> Self::Output {
-        Less
-    }
-}
-
-/// `UInt<Ul, B>` cmp with `UInt<Ur, B>`: `SoFar` is `Equal`
-impl<Ul: Unsigned, Ur: Unsigned, B> Cmp<UInt<Ur, B>> for UInt<Ul, B>
-where
-    Ul: PrivateCmp<Ur, Equal>,
-{
-    type Output = PrivateCmpOut<Ul, Ur, Equal>;
-
-    #[inline]
-    fn compare<IM: InternalMarker>(&self, rhs: &UInt<Ur, B>) -> Self::Output {
-        self.msb.private_cmp(&rhs.msb, Equal)
-    }
-}
-
-/// `UInt<Ul, B0>` cmp with `UInt<Ur, B1>`: `SoFar` is `Less`
-impl<Ul: Unsigned, Ur: Unsigned> Cmp<UInt<Ur, B1>> for UInt<Ul, B0>
-where
-    Ul: PrivateCmp<Ur, Less>,
-{
-    type Output = PrivateCmpOut<Ul, Ur, Less>;
-
-    #[inline]
-    fn compare<IM: InternalMarker>(&self, rhs: &UInt<Ur, B1>) -> Self::Output {
-        self.msb.private_cmp(&rhs.msb, Less)
-    }
-}
-
-/// `UInt<Ul, B1>` cmp with `UInt<Ur, B0>`: `SoFar` is `Greater`
-impl<Ul: Unsigned, Ur: Unsigned> Cmp<UInt<Ur, B0>> for UInt<Ul, B1>
-where
-    Ul: PrivateCmp<Ur, Greater>,
-{
-    type Output = PrivateCmpOut<Ul, Ur, Greater>;
-
-    #[inline]
-    fn compare<IM: InternalMarker>(&self, rhs: &UInt<Ur, B0>) -> Self::Output {
-        self.msb.private_cmp(&rhs.msb, Greater)
-    }
-}
-
-/// Comparing non-terimal bits, with both having the same bit.
-/// These are `Equal`, so we propagate `SoFar`.
-impl<Ul, Ur, SoFar, B> PrivateCmp<UInt<Ur, B>, SoFar> for UInt<Ul, B>
-where
-    Ul: Unsigned,
-    Ur: Unsigned,
-    SoFar: Ord,
-    Ul: PrivateCmp<Ur, SoFar>,
-{
-    type Output = PrivateCmpOut<Ul, Ur, SoFar>;
-
-    #[inline]
-    fn private_cmp(&self, rhs: &UInt<Ur, B>, so_far: SoFar) -> Self::Output {
-        self.msb.private_cmp(&rhs.msb, so_far)
-    }
-}
-
-/// Comparing non-terimal bits, with `Lhs` having bit `B0` and `Rhs` having bit `B1`.
-/// `SoFar`, Lhs is `Less`.
-impl<Ul, Ur, SoFar> PrivateCmp<UInt<Ur, B1>, SoFar> for UInt<Ul, B0>
-where
-    Ul: Unsigned,
-    Ur: Unsigned,
-    SoFar: Ord,
-    Ul: PrivateCmp<Ur, Less>,
-{
-    type Output = PrivateCmpOut<Ul, Ur, Less>;
-
-    #[inline]
-    fn private_cmp(&self, rhs: &UInt<Ur, B1>, _: SoFar) -> Self::Output {
-        self.msb.private_cmp(&rhs.msb, Less)
-    }
-}
-
-/// Comparing non-terimal bits, with `Lhs` having bit `B1` and `Rhs` having bit `B0`.
-/// `SoFar`, Lhs is `Greater`.
-impl<Ul, Ur, SoFar> PrivateCmp<UInt<Ur, B0>, SoFar> for UInt<Ul, B1>
-where
-    Ul: Unsigned,
-    Ur: Unsigned,
-    SoFar: Ord,
-    Ul: PrivateCmp<Ur, Greater>,
-{
-    type Output = PrivateCmpOut<Ul, Ur, Greater>;
-
-    #[inline]
-    fn private_cmp(&self, rhs: &UInt<Ur, B0>, _: SoFar) -> Self::Output {
-        self.msb.private_cmp(&rhs.msb, Greater)
-    }
-}
-
-/// Got to the end of just the `Lhs`. It's `Less`.
-impl<U: Unsigned, B: Bit, SoFar: Ord> PrivateCmp<UInt<U, B>, SoFar> for UTerm {
-    type Output = Less;
-
-    #[inline]
-    fn private_cmp(&self, _: &UInt<U, B>, _: SoFar) -> Self::Output {
-        Less
-    }
-}
-
-/// Got to the end of just the `Rhs`. `Lhs` is `Greater`.
-impl<U: Unsigned, B: Bit, SoFar: Ord> PrivateCmp<UTerm, SoFar> for UInt<U, B> {
-    type Output = Greater;
-
-    #[inline]
-    fn private_cmp(&self, _: &UTerm, _: SoFar) -> Self::Output {
-        Greater
-    }
-}
-
-/// Got to the end of both! Return `SoFar`
-impl<SoFar: Ord> PrivateCmp<UTerm, SoFar> for UTerm {
-    type Output = SoFar;
-
-    #[inline]
-    fn private_cmp(&self, _: &UTerm, so_far: SoFar) -> Self::Output {
-        so_far
+    fn compare<Im: InternalMarker>(&self, _: &Rhs) -> Self::Output {
+        <Self as Unsigned>::Cmp::<Rhs::IntoUnsigned>::new()
     }
 }
 
@@ -2102,147 +1709,19 @@ where
 }
 
 // -----------------------------------------
-// PrivateMin
-use crate::private::{PrivateMin, PrivateMinOut};
-
-impl<U, B, Ur> PrivateMin<Ur, Equal> for UInt<U, B>
-where
-    Ur: Unsigned,
-    U: Unsigned,
-    B: Bit,
-{
-    type Output = UInt<U, B>;
-    #[inline]
-    fn private_min(self, _: Ur) -> Self::Output {
-        self
-    }
-}
-
-impl<U, B, Ur> PrivateMin<Ur, Less> for UInt<U, B>
-where
-    Ur: Unsigned,
-    U: Unsigned,
-    B: Bit,
-{
-    type Output = UInt<U, B>;
-    #[inline]
-    fn private_min(self, _: Ur) -> Self::Output {
-        self
-    }
-}
-
-impl<U, B, Ur> PrivateMin<Ur, Greater> for UInt<U, B>
-where
-    Ur: Unsigned,
-    U: Unsigned,
-    B: Bit,
-{
-    type Output = Ur;
-    #[inline]
-    fn private_min(self, rhs: Ur) -> Self::Output {
-        rhs
-    }
-}
-
-// -----------------------------------------
 // Min
 use crate::Min;
 
-impl<U> Min<U> for UTerm
-where
-    U: Unsigned,
-{
-    type Output = UTerm;
-    #[inline]
-    fn min(self, _: U) -> Self::Output {
-        self
-    }
-}
-
-impl<U, B, Ur> Min<Ur> for UInt<U, B>
-where
-    U: Unsigned,
-    B: Bit,
-    Ur: Unsigned,
-    UInt<U, B>: Cmp<Ur> + PrivateMin<Ur, Compare<UInt<U, B>, Ur>>,
-{
-    type Output = PrivateMinOut<UInt<U, B>, Ur, Compare<UInt<U, B>, Ur>>;
-    #[inline]
-    fn min(self, rhs: Ur) -> Self::Output {
-        self.private_min(rhs)
-    }
-}
-
-// -----------------------------------------
-// PrivateMax
-use crate::private::{PrivateMax, PrivateMaxOut};
-
-impl<U, B, Ur> PrivateMax<Ur, Equal> for UInt<U, B>
-where
-    Ur: Unsigned,
-    U: Unsigned,
-    B: Bit,
-{
-    type Output = UInt<U, B>;
-    #[inline]
-    fn private_max(self, _: Ur) -> Self::Output {
-        self
-    }
-}
-
-impl<U, B, Ur> PrivateMax<Ur, Less> for UInt<U, B>
-where
-    Ur: Unsigned,
-    U: Unsigned,
-    B: Bit,
-{
-    type Output = Ur;
-    #[inline]
-    fn private_max(self, rhs: Ur) -> Self::Output {
-        rhs
-    }
-}
-
-impl<U, B, Ur> PrivateMax<Ur, Greater> for UInt<U, B>
-where
-    Ur: Unsigned,
-    U: Unsigned,
-    B: Bit,
-{
-    type Output = UInt<U, B>;
-    #[inline]
-    fn private_max(self, _: Ur) -> Self::Output {
-        self
-    }
+delegate_unsigned_binary_impls! {
+    Min, min,
 }
 
 // -----------------------------------------
 // Max
 use crate::Max;
 
-impl<U> Max<U> for UTerm
-where
-    U: Unsigned,
-{
-    type Output = U;
-    #[inline]
-    fn max(self, rhs: U) -> Self::Output {
-        rhs
-    }
-}
-
-impl<U, B, Ur> Max<Ur> for UInt<U, B>
-where
-    U: Unsigned,
-    B: Bit,
-    Ur: Unsigned,
-    UInt<U, B>: Cmp<Ur> + PrivateMax<Ur, Compare<UInt<U, B>, Ur>>,
-{
-    type Output = PrivateMaxOut<UInt<U, B>, Ur, Compare<UInt<U, B>, Ur>>;
-    #[inline]
-    fn max(self, rhs: Ur) -> Self::Output {
-        self.private_max(rhs)
-    }
+delegate_unsigned_binary_impls! {
+    Max, max,
 }
 
 // -----------------------------------------
@@ -2358,7 +1837,7 @@ where
 // -----------------------------------------
 // ToInt
 
-impl ToInt<i8> for UTerm {
+impl<U: Unsigned> ToInt<i8> for U {
     #[inline]
     fn to_int() -> i8 {
         Self::I8
@@ -2366,7 +1845,7 @@ impl ToInt<i8> for UTerm {
     const INT: i8 = Self::I8;
 }
 
-impl ToInt<i16> for UTerm {
+impl<U: Unsigned> ToInt<i16> for U {
     #[inline]
     fn to_int() -> i16 {
         Self::I16
@@ -2374,7 +1853,7 @@ impl ToInt<i16> for UTerm {
     const INT: i16 = Self::I16;
 }
 
-impl ToInt<i32> for UTerm {
+impl<U: Unsigned> ToInt<i32> for U {
     #[inline]
     fn to_int() -> i32 {
         Self::I32
@@ -2382,7 +1861,7 @@ impl ToInt<i32> for UTerm {
     const INT: i32 = Self::I32;
 }
 
-impl ToInt<i64> for UTerm {
+impl<U: Unsigned> ToInt<i64> for U {
     #[inline]
     fn to_int() -> i64 {
         Self::I64
@@ -2390,7 +1869,7 @@ impl ToInt<i64> for UTerm {
     const INT: i64 = Self::I64;
 }
 
-impl ToInt<isize> for UTerm {
+impl<U: Unsigned> ToInt<isize> for U {
     #[inline]
     fn to_int() -> isize {
         Self::ISIZE
@@ -2399,7 +1878,7 @@ impl ToInt<isize> for UTerm {
 }
 
 #[cfg(feature = "i128")]
-impl ToInt<i128> for UTerm {
+impl<U: Unsigned> ToInt<i128> for U {
     #[inline]
     fn to_int() -> i128 {
         Self::I128
@@ -2407,7 +1886,7 @@ impl ToInt<i128> for UTerm {
     const INT: i128 = Self::I128;
 }
 
-impl ToInt<u8> for UTerm {
+impl<U: Unsigned> ToInt<u8> for U {
     #[inline]
     fn to_int() -> u8 {
         Self::U8
@@ -2415,7 +1894,7 @@ impl ToInt<u8> for UTerm {
     const INT: u8 = Self::U8;
 }
 
-impl ToInt<u16> for UTerm {
+impl<U: Unsigned> ToInt<u16> for U {
     #[inline]
     fn to_int() -> u16 {
         Self::U16
@@ -2423,7 +1902,7 @@ impl ToInt<u16> for UTerm {
     const INT: u16 = Self::U16;
 }
 
-impl ToInt<u32> for UTerm {
+impl<U: Unsigned> ToInt<u32> for U {
     #[inline]
     fn to_int() -> u32 {
         Self::U32
@@ -2431,7 +1910,7 @@ impl ToInt<u32> for UTerm {
     const INT: u32 = Self::U32;
 }
 
-impl ToInt<u64> for UTerm {
+impl<U: Unsigned> ToInt<u64> for U {
     #[inline]
     fn to_int() -> u64 {
         Self::U64
@@ -2439,7 +1918,7 @@ impl ToInt<u64> for UTerm {
     const INT: u64 = Self::U64;
 }
 
-impl ToInt<usize> for UTerm {
+impl<U: Unsigned> ToInt<usize> for U {
     #[inline]
     fn to_int() -> usize {
         Self::USIZE
@@ -2448,153 +1927,7 @@ impl ToInt<usize> for UTerm {
 }
 
 #[cfg(feature = "i128")]
-impl ToInt<u128> for UTerm {
-    #[inline]
-    fn to_int() -> u128 {
-        Self::U128
-    }
-    const INT: u128 = Self::U128;
-}
-
-impl<U, B> ToInt<i8> for UInt<U, B>
-where
-    U: Unsigned,
-    B: Bit,
-{
-    #[inline]
-    fn to_int() -> i8 {
-        Self::I8
-    }
-    const INT: i8 = Self::I8;
-}
-
-impl<U, B> ToInt<i16> for UInt<U, B>
-where
-    U: Unsigned,
-    B: Bit,
-{
-    #[inline]
-    fn to_int() -> i16 {
-        Self::I16
-    }
-    const INT: i16 = Self::I16;
-}
-
-impl<U, B> ToInt<i32> for UInt<U, B>
-where
-    U: Unsigned,
-    B: Bit,
-{
-    #[inline]
-    fn to_int() -> i32 {
-        Self::I32
-    }
-    const INT: i32 = Self::I32;
-}
-
-impl<U, B> ToInt<i64> for UInt<U, B>
-where
-    U: Unsigned,
-    B: Bit,
-{
-    #[inline]
-    fn to_int() -> i64 {
-        Self::I64
-    }
-    const INT: i64 = Self::I64;
-}
-
-impl<U, B> ToInt<isize> for UInt<U, B>
-where
-    U: Unsigned,
-    B: Bit,
-{
-    #[inline]
-    fn to_int() -> isize {
-        Self::ISIZE
-    }
-    const INT: isize = Self::ISIZE;
-}
-
-#[cfg(feature = "i128")]
-impl<U, B> ToInt<i128> for UInt<U, B>
-where
-    U: Unsigned,
-    B: Bit,
-{
-    #[inline]
-    fn to_int() -> i128 {
-        Self::I128
-    }
-    const INT: i128 = Self::I128;
-}
-
-impl<U, B> ToInt<u8> for UInt<U, B>
-where
-    U: Unsigned,
-    B: Bit,
-{
-    #[inline]
-    fn to_int() -> u8 {
-        Self::U8
-    }
-    const INT: u8 = Self::U8;
-}
-
-impl<U, B> ToInt<u16> for UInt<U, B>
-where
-    U: Unsigned,
-    B: Bit,
-{
-    #[inline]
-    fn to_int() -> u16 {
-        Self::U16
-    }
-    const INT: u16 = Self::U16;
-}
-
-impl<U, B> ToInt<u32> for UInt<U, B>
-where
-    U: Unsigned,
-    B: Bit,
-{
-    #[inline]
-    fn to_int() -> u32 {
-        Self::U32
-    }
-    const INT: u32 = Self::U32;
-}
-
-impl<U, B> ToInt<u64> for UInt<U, B>
-where
-    U: Unsigned,
-    B: Bit,
-{
-    #[inline]
-    fn to_int() -> u64 {
-        Self::U64
-    }
-    const INT: u64 = Self::U64;
-}
-
-impl<U, B> ToInt<usize> for UInt<U, B>
-where
-    U: Unsigned,
-    B: Bit,
-{
-    #[inline]
-    fn to_int() -> usize {
-        Self::USIZE
-    }
-    const INT: usize = Self::USIZE;
-}
-
-#[cfg(feature = "i128")]
-impl<U, B> ToInt<u128> for UInt<U, B>
-where
-    U: Unsigned,
-    B: Bit,
-{
+impl<U: Unsigned> ToInt<u128> for U {
     #[inline]
     fn to_int() -> u128 {
         Self::U128


### PR DESCRIPTION
This PR tries to implement the solution shown in #191.

Currently, bitwise operations on the `Bit` trait works.

However, I'm facing some issues when trying to implement the addition of two unsigned numbers : to reduce the amount of needed traits, it will be necessary to implement the `Add` trait for every types implementing the `Unsigned` trait.
It's currently impossible because typenum uses the trait from `core::ops`, so something like this :
```rust
impl<Rhs: Unsigned, U: Unsigned> Add<Rhs> for U {
   ...
}
```
Produces the following error :
```txt
error[E0210]: type parameter `U` must be used as the type parameter for some local type (e.g., `MyStruct<U>`)
   --> src/uint.rs:510:21
    |
510 | impl<Rhs: Unsigned, U: Unsigned> Add<Rhs> for U {
    |                     ^ type parameter `U` must be used as the type parameter for some local type
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter

For more information about this error, try `rustc --explain E0210`.
error: could not compile `typenum` (lib) due to 2 previous errors
```

I think that using a custom trait (e.g. `TypeAdd`, like `type_operators::Pow` or `type_operators::Abs`) defined in the crate is needed.

We can always implement the trait `core::ops::Add` too, but the aliases will probably alias the `TypeAdd` trait, so it's a breaking change I think.